### PR TITLE
Code formatting and pom simplifying

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2017 SKB Kontur
+Copyright (c) 2018 SKB Kontur
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/extern-sdk-examples/pom.xml
+++ b/extern-sdk-examples/pom.xml
@@ -1,11 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-      <groupId>ru.skbkontur.sdk</groupId>
-      <artifactId>extern</artifactId>
-      <version>1.1-SNAPSHOT</version>
+        <groupId>ru.skbkontur.sdk</groupId>
+        <artifactId>extern</artifactId>
+        <version>1.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>extern-sdk-examples</artifactId>
@@ -15,7 +16,7 @@
     <dependencies>
         <dependency>
             <groupId>${project.groupId}</groupId>
-            <artifactId>extern-sdk</artifactId>
+            <artifactId>extern-java-sdk</artifactId>
             <version>${project.version}</version>
         </dependency>
     </dependencies>
@@ -24,7 +25,7 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
     </properties>
-    
+
     <build>
         <plugins>
             <plugin>

--- a/extern-sdk-examples/pom.xml
+++ b/extern-sdk-examples/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>ru.skbkontur.sdk</groupId>
         <artifactId>extern</artifactId>
-        <version>1.1-SNAPSHOT</version>
+        <version>1.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>extern-sdk-examples</artifactId>
@@ -22,32 +22,8 @@
     </dependencies>
 
     <properties>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>${java.version}</maven.compiler.source>
+        <maven.compiler.target>${java.version}</maven.compiler.target>
     </properties>
 
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-dependency-plugin</artifactId>
-                <version>3.0.2</version>
-                <executions>
-                    <execution>
-                        <id>copy-dependencies</id>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>copy-dependencies</goal>
-                        </goals>
-                        <configuration>
-                            <outputDirectory>lib</outputDirectory>
-                            <overWriteReleases>false</overWriteReleases>
-                            <overWriteSnapshots>false</overWriteSnapshots>
-                            <overWriteIfNewer>true</overWriteIfNewer>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
 </project>

--- a/extern-sdk-examples/src/main/java/ru/skbkontur/sdk/extern/examples/SendDocument.java
+++ b/extern-sdk-examples/src/main/java/ru/skbkontur/sdk/extern/examples/SendDocument.java
@@ -1,7 +1,7 @@
 /*
- * The MIT License
+ * MIT License
  *
- * Copyright 2018 SKB Kontur
+ * Copyright (c) 2018 SKB Kontur
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -10,32 +10,20 @@
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
  *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
  *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
  * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
  * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  */
+
 package ru.skbkontur.sdk.extern.examples;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.text.MessageFormat;
-import java.util.List;
-import java.util.Properties;
-import java.util.UUID;
-import java.util.concurrent.ExecutionException;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import ru.argosgrp.cryptoservice.CryptoException;
 import ru.argosgrp.cryptoservice.utils.IOUtil;
 import ru.skbkontur.sdk.extern.ExternEngine;
@@ -48,11 +36,24 @@ import ru.skbkontur.sdk.extern.providers.auth.AuthenticationProviderByPass;
 import ru.skbkontur.sdk.extern.providers.crypt.mscapi.CryptoProviderMSCapi;
 import ru.skbkontur.sdk.extern.service.transport.adaptors.QueryContext;
 
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.text.MessageFormat;
+import java.util.List;
+import java.util.Properties;
+import java.util.UUID;
+import java.util.concurrent.ExecutionException;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+
 /**
  * @author Sukhorukov A.D.
- *
+ * <p>
  * Отправка документа, при этом отправитель и организация, за которую производится отправка документа, является одной и той-же организацией
- *
+ * <p>
  * <pre>
  * {@code
  * Для запуска примера необходимо в командной строке передать путь к файлу:
@@ -91,120 +92,118 @@ import ru.skbkontur.sdk.extern.service.transport.adaptors.QueryContext;
  * document.path = X:\\path documents\\NO_SRCHIS_0087_0087_XXXXXXXXXXXXXXXXXXX_20180126_XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX.xml;
  * }
  * </pre>
- *
  */
 public class SendDocument {
 
-	private static ExternEngine engine;
+    private static ExternEngine engine;
 
-	public static void main(String[] args) throws IOException, CryptoException, InterruptedException, ExecutionException {
-		// необходимо передать путь
-		if (args.length == 0) {
-			System.out.println("There is no path to the properter file in the command line.");
-			return;
-		}
-		// файл с параметрами должен существовать
-		File parameterFile = new File(args[0]);
-		if (!parameterFile.exists() || !parameterFile.isFile()) {
-			System.out.println("Parameter file not found: " + args[0]);
-			return;
-		}
+    public static void main(String[] args) throws IOException, CryptoException, InterruptedException, ExecutionException {
+        // необходимо передать путь
+        if (args.length == 0) {
+            System.out.println("There is no path to the properter file in the command line.");
+            return;
+        }
+        // файл с параметрами должен существовать
+        File parameterFile = new File(args[0]);
+        if (!parameterFile.exists() || !parameterFile.isFile()) {
+            System.out.println("Parameter file not found: " + args[0]);
+            return;
+        }
 
-		// создаем экземляр движка для работы с API Экстерна
-		engine = new ExternEngine();
-		// загружаем параметры для отправки документа на портал Экстерна
-		Properties parameters = new Properties();
-		try (InputStream is = new FileInputStream(parameterFile)) {
-			parameters.load(is);
-		}
+        // создаем экземляр движка для работы с API Экстерна
+        engine = new ExternEngine();
+        // загружаем параметры для отправки документа на портал Экстерна
+        Properties parameters = new Properties();
+        try (InputStream is = new FileInputStream(parameterFile)) {
+            parameters.load(is);
+        }
 
-		// КОНФИГУРИРОВАНИЕ ДВИЖКА
-		// устанавливаем URI для Экстерн API
-		engine.setServiceBaseUriProvider(() -> parameters.getProperty("service.base.uri"));
-		// устанавливаем идентификатор аккаунта
-		engine.setAccountProvider(() -> UUID.fromString(parameters.getProperty("account.id")));
-		// устанавливаем идентификатор внешнего сервиса
-		engine.setApiKeyProvider(() -> parameters.getProperty("api.key"));
-		// устанавливаем провайдер для аутентификации по логину и паролю
-		engine.setAuthenticationProvider(
-			new AuthenticationProviderByPass(
-				() -> parameters.getProperty("auth.base.uri"),
-				new LoginAndPasswordProvider() {
-				@Override
-				public String getLogin() {
-					return parameters.getProperty("auth.login");
-				}
+        // КОНФИГУРИРОВАНИЕ ДВИЖКА
+        // устанавливаем URI для Экстерн API
+        engine.setServiceBaseUriProvider(() -> parameters.getProperty("service.base.uri"));
+        // устанавливаем идентификатор аккаунта
+        engine.setAccountProvider(() -> UUID.fromString(parameters.getProperty("account.id")));
+        // устанавливаем идентификатор внешнего сервиса
+        engine.setApiKeyProvider(() -> parameters.getProperty("api.key"));
+        // устанавливаем провайдер для аутентификации по логину и паролю
+        engine.setAuthenticationProvider(
+                new AuthenticationProviderByPass(
+                        () -> parameters.getProperty("auth.base.uri"),
+                        new LoginAndPasswordProvider() {
+                            @Override
+                            public String getLogin() {
+                                return parameters.getProperty("auth.login");
+                            }
 
-				@Override
-				public String getPass() {
-					return parameters.getProperty("auth.pass");
-				}
-			},
-				engine.getApiKeyProvider()
-			)
-		);
+                            @Override
+                            public String getPass() {
+                                return parameters.getProperty("auth.pass");
+                            }
+                        },
+                        engine.getApiKeyProvider()
+                )
+        );
 
-		// данную инициализацию делать необязательно,
-		// если используется свой криптопровайдер
-		engine.setCryptoProvider(
-			new CryptoProviderMSCapi()
-		);
+        // данную инициализацию делать необязательно,
+        // если используется свой криптопровайдер
+        engine.setCryptoProvider(
+                new CryptoProviderMSCapi()
+        );
 
-		engine.configureServices();
+        engine.configureServices();
 
-		// отправитель
-		Sender sender = new Sender();
-		// ИНН отправителя
-		sender.setInn(parameters.getProperty("sender.inn"));
-		// КПП отправителя
-		sender.setKpp(parameters.getProperty("sender.kpp"));
-		// IP адресс отправителя
-		sender.setIpaddress(parameters.getProperty("sender.ip"));
-		// отпечаток сертификат отправителя
-		sender.setThumbprint(parameters.getProperty("sender.thumbprint"));
-		// получатель
-		FnsRecipient recipient = new FnsRecipient();
-		// ИНН отправителя
-		recipient.setIfnsCode(parameters.getProperty("ifns.code"));
-		// подотчетная организация
-		Organization organization = new Organization(parameters.getProperty("company.inn"), parameters.getProperty("company.kpp"));
+        // отправитель
+        Sender sender = new Sender();
+        // ИНН отправителя
+        sender.setInn(parameters.getProperty("sender.inn"));
+        // КПП отправителя
+        sender.setKpp(parameters.getProperty("sender.kpp"));
+        // IP адресс отправителя
+        sender.setIpaddress(parameters.getProperty("sender.ip"));
+        // отпечаток сертификат отправителя
+        sender.setThumbprint(parameters.getProperty("sender.thumbprint"));
+        // получатель
+        FnsRecipient recipient = new FnsRecipient();
+        // ИНН отправителя
+        recipient.setIfnsCode(parameters.getProperty("ifns.code"));
+        // подотчетная организация
+        Organization organization = new Organization(parameters.getProperty("company.inn"), parameters.getProperty("company.kpp"));
 
-		// путь к документу, который будем отправлять
-		String docPath = parameters.getProperty("document.path");
-		String[] docPaths = docPath == null ? null : docPath.split(";");
-		if (docPaths != null) {
-			ru.skbkontur.sdk.extern.service.File[] files =
-				Stream
-					.of(docPaths)
-					.map(p -> new File(p))
-					.map(f -> new ru.skbkontur.sdk.extern.service.File(f.getName(), readFileContent(f))) // 
-					.collect(Collectors.toList())
-					.toArray(new ru.skbkontur.sdk.extern.service.File[docPaths.length]);
-			
-			// отправляем документы
-			QueryContext<List<Docflow>> sendCxt = engine.getBusinessDriver().sendDocument(files, sender, recipient, organization);
-			// проверяем результат отправки
-			if (sendCxt.isFail()) {
-				// ошибка отправки документа
-				// регистрируем ошибку в лог файл
-				System.out.println("Error sending document.\n" + sendCxt.getServiceError().toString());
-						
-				return;
-			}
-					
-			// документ был отправлен
-			// в результате получаем список документооборотов (ДО)
-			// иногда один документ может вызвать несколько ДО
-			System.out.println(MessageFormat.format("The documents [{0}] was sent.", Stream.of(files).map(f->f.getFileName()).reduce((x,y)->x+"\r\n"+y)));
-		}
-	}
-	
-	private static byte[] readFileContent(File file) throws RuntimeException {
-		try {
-			return IOUtil.readFileContent(file);
-		}
-		catch (IOException x) {
-			throw new RuntimeException(x);
-		}
-	}
+        // путь к документу, который будем отправлять
+        String docPath = parameters.getProperty("document.path");
+        String[] docPaths = docPath == null ? null : docPath.split(";");
+        if (docPaths != null) {
+            ru.skbkontur.sdk.extern.service.File[] files =
+                    Stream
+                            .of(docPaths)
+                            .map(p -> new File(p))
+                            .map(f -> new ru.skbkontur.sdk.extern.service.File(f.getName(), readFileContent(f))) //
+                            .collect(Collectors.toList())
+                            .toArray(new ru.skbkontur.sdk.extern.service.File[docPaths.length]);
+
+            // отправляем документы
+            QueryContext<List<Docflow>> sendCxt = engine.getBusinessDriver().sendDocument(files, sender, recipient, organization);
+            // проверяем результат отправки
+            if (sendCxt.isFail()) {
+                // ошибка отправки документа
+                // регистрируем ошибку в лог файл
+                System.out.println("Error sending document.\n" + sendCxt.getServiceError().toString());
+
+                return;
+            }
+
+            // документ был отправлен
+            // в результате получаем список документооборотов (ДО)
+            // иногда один документ может вызвать несколько ДО
+            System.out.println(MessageFormat.format("The documents [{0}] was sent.", Stream.of(files).map(f -> f.getFileName()).reduce((x, y) -> x + "\r\n" + y)));
+        }
+    }
+
+    private static byte[] readFileContent(File file) throws RuntimeException {
+        try {
+            return IOUtil.readFileContent(file);
+        } catch (IOException x) {
+            throw new RuntimeException(x);
+        }
+    }
 }

--- a/extern-sdk-swagger/pom.xml
+++ b/extern-sdk-swagger/pom.xml
@@ -1,11 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-      <groupId>ru.skbkontur.sdk</groupId>
-      <artifactId>extern</artifactId>
-      <version>1.1-SNAPSHOT</version>
+        <groupId>ru.skbkontur.sdk</groupId>
+        <artifactId>extern</artifactId>
+        <version>1.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>extern-swagger</artifactId>
@@ -46,29 +47,30 @@
     </properties>
     <build>
         <plugins>
-<plugin>
-    <groupId>io.swagger</groupId>
-    <artifactId>swagger-codegen-maven-plugin</artifactId>
-    <version>2.2.3</version>
-    <executions>
-        <execution>
-            <goals>
-                <goal>generate</goal>
-            </goals>
-            <configuration>
-                <inputSpec>src/main/resources/swagger.json</inputSpec>
-                <language>java</language>
-                <configOptions>
-                   <sourceFolder>src/main/java</sourceFolder>
-                   <modelPackage>ru.skbkontur.sdk.extern.service.transport.swagger.model</modelPackage>
-                   <apiPackage>ru.skbkontur.sdk.extern.service.transport.swagger.api</apiPackage>
-                   <invokerPackage>ru.skbkontur.sdk.extern.service.transport.swagger.invoker</invokerPackage>
-		   <hideGenerationTimestamp>true</hideGenerationTimestamp>
-                </configOptions>
-            </configuration>
-        </execution>
-    </executions>
-</plugin>        
-	</plugins>
+            <plugin>
+                <groupId>io.swagger</groupId>
+                <artifactId>swagger-codegen-maven-plugin</artifactId>
+                <version>2.2.3</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>generate</goal>
+                        </goals>
+                        <configuration>
+                            <inputSpec>src/main/resources/swagger.json</inputSpec>
+                            <language>java</language>
+                            <configOptions>
+                                <sourceFolder>src/main/java</sourceFolder>
+                                <modelPackage>ru.skbkontur.sdk.extern.service.transport.swagger.model</modelPackage>
+                                <apiPackage>ru.skbkontur.sdk.extern.service.transport.swagger.api</apiPackage>
+                                <invokerPackage>ru.skbkontur.sdk.extern.service.transport.swagger.invoker
+                                </invokerPackage>
+                                <hideGenerationTimestamp>true</hideGenerationTimestamp>
+                            </configOptions>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
     </build>
 </project>

--- a/extern-sdk-swagger/pom.xml
+++ b/extern-sdk-swagger/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>ru.skbkontur.sdk</groupId>
         <artifactId>extern</artifactId>
-        <version>1.1-SNAPSHOT</version>
+        <version>1.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>extern-swagger</artifactId>
@@ -42,8 +42,8 @@
     </dependencies>
 
     <properties>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>${java.version}</maven.compiler.source>
+        <maven.compiler.target>${java.version}</maven.compiler.target>
     </properties>
     <build>
         <plugins>
@@ -73,4 +73,5 @@
             </plugin>
         </plugins>
     </build>
+
 </project>

--- a/extern-sdk/pom.xml
+++ b/extern-sdk/pom.xml
@@ -8,183 +8,38 @@
         <version>1.1-SNAPSHOT</version>
     </parent>
 
-    <artifactId>extern-sdk</artifactId>
+    <artifactId>extern-java-sdk</artifactId>
 
     <packaging>jar</packaging>
 
     <build>
         <plugins>
-            <plugin>
-                <groupId>org.jacoco</groupId>
-                <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.7.9</version>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>prepare-agent</goal>
-                        </goals>
-                    </execution>
-                    <execution>
-                        <id>report</id>
-                        <phase>prepare-package</phase>
-                        <goals>
-                            <goal>report</goal>
-                        </goals>
-                    </execution>
-                </executions>
-                <configuration>
-                    <excludes>
-
-                    </excludes>
-                </configuration>
-            </plugin>
-
-            <plugin>
-                <artifactId>maven-dependency-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>copy-dependencies</goal>
-                        </goals>
-                        <configuration>
-                            <outputDirectory>${project.build.directory}/lib</outputDirectory>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-
-            <!-- attach test jar -->
+            <!-- edit manifest  -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
                 <version>2.2</version>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>jar</goal>
-                            <goal>test-jar</goal>
-                        </goals>
-                    </execution>
-                </executions>
+
                 <configuration>
                     <archive>
                         <manifestEntries>
                             <Implementation-Version>${project.version}</Implementation-Version>
-                            <Implementation-Title>${artifactId}</Implementation-Title>
+                            <Implementation-Title>${project.artifactId}</Implementation-Title>
                         </manifestEntries>
                     </archive>
                 </configuration>
+
             </plugin>
 
             <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>build-helper-maven-plugin</artifactId>
-                <version>1.10</version>
-                <executions>
-                    <execution>
-                        <id>add_sources</id>
-                        <phase>generate-sources</phase>
-                        <goals>
-                            <goal>add-source</goal>
-                        </goals>
-                        <configuration>
-                            <sources>
-                                <source>src/main/java</source>
-                            </sources>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>add_test_sources</id>
-                        <phase>generate-test-sources</phase>
-                        <goals>
-                            <goal>add-test-source</goal>
-                        </goals>
-                        <configuration>
-                            <sources>
-                                <source>src/test/java</source>
-                            </sources>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.10.4</version>
-                <executions>
-                    <execution>
-                        <id>attach-javadocs</id>
-                        <goals>
-                            <goal>jar</goal>
-                        </goals>
-                    </execution>
-                </executions>
+                <artifactId>maven-project-info-reports-plugin</artifactId>
+                <version>2.9</version>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-source-plugin</artifactId>
-                <version>2.2.1</version>
-                <executions>
-                    <execution>
-                        <id>attach-sources</id>
-                        <goals>
-                            <goal>jar-no-fork</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-shade-plugin</artifactId>
-                <version>2.4.3</version>
-                <configuration>
-                    <filters>
-                        <filter>
-                            <artifact>*:*</artifact>
-                            <excludes>
-                                <exclude>META-INF/*.SF</exclude>
-                                <exclude>META-INF/*.DSA</exclude>
-                                <exclude>META-INF/*.RSA</exclude>
-                            </excludes>
-                        </filter>
-                    </filters>
-                </configuration>
-                <executions>
-                    <execution>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>shade</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
+
+
         </plugins>
     </build>
-
-    <profiles>
-        <profile>
-            <id>sign-artifacts</id>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-gpg-plugin</artifactId>
-                        <version>1.5</version>
-                        <executions>
-                            <execution>
-                                <id>sign-artifacts</id>
-                                <phase>verify</phase>
-                                <goals>
-                                    <goal>sign</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
 
     <repositories>
         <repository>
@@ -193,7 +48,9 @@
             <url>file://${project.basedir}/repo</url>
         </repository>
     </repositories>
+
     <dependencies>
+        <!--local repository dependencies-->
         <dependency>
             <groupId>ru.argosgrp.cryptoservice</groupId>
             <artifactId>asn1</artifactId>
@@ -219,6 +76,8 @@
             <artifactId>cs-util</artifactId>
             <version>${cryptoservice.version}</version>
         </dependency>
+
+        <!--central dependencies-->
         <dependency>
             <groupId>io.swagger</groupId>
             <artifactId>swagger-annotations</artifactId>
@@ -244,6 +103,7 @@
             <artifactId>joda-time</artifactId>
             <version>${jodatime-version}</version>
         </dependency>
+
         <!-- test dependencies -->
         <dependency>
             <groupId>junit</groupId>
@@ -263,121 +123,36 @@
             <version>15.0</version>
         </dependency>
     </dependencies>
-    <!--properties>
-      <java.version>1.7</java.version>
-      <maven.compiler.source>${java.version}</maven.compiler.source>
-      <maven.compiler.target>${java.version}</maven.compiler.target>
-      <swagger-core-version>1.5.15</swagger-core-version>
-      <okhttp-version>2.7.5</okhttp-version>
-      <gson-version>2.8.1</gson-version>
-      <jodatime-version>2.9.9</jodatime-version>
-      <maven-plugin-version>1.0.0</maven-plugin-version>
-      <junit-version>4.12</junit-version>
-      <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    </properties-->
+
+    <profiles>
+        <profile>
+            <id>javadoc</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <version>2.10.4</version>
+                        <executions>
+                            <execution>
+                                <id>attach-javadocs</id>
+                                <goals>
+                                    <goal>jar</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
     <reporting>
         <plugins>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-project-info-reports-plugin</artifactId>
-                <version>2.9</version>
-                <reportSets>
-                    <reportSet>
-                        <reports>
-                            <report>index</report>
-                            <!--<report>dependencies</report>-->
-                            <!--<report>project-team</report>-->
-                            <!--<report>mailing-list</report>-->
-                            <report>cim</report>
-                            <!--<report>issue-tracking</report>-->
-                            <!--<report>license</report>-->
-                            <report>scm</report>
-                        </reports>
-                    </reportSet>
-                </reportSets>
-
-            </plugin>
-            <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>findbugs-maven-plugin</artifactId>
-                <version>3.0.5</version>
-                <configuration>
-                    <plugins>
-                        <plugin>
-                            <groupId>com.mebigfatguy.fb-contrib</groupId>
-                            <artifactId>fb-contrib</artifactId>
-                            <version>7.0.5</version>
-                        </plugin>
-                        <plugin>
-                            <groupId>com.h3xstream.findsecbugs</groupId>
-                            <artifactId>findsecbugs-plugin</artifactId>
-                            <version>1.7.1</version>
-                        </plugin>
-                    </plugins>
-                    <xmlOutput>true</xmlOutput>
-                    <!-- Optional directory to put findbugs xdoc xml report -->
-                    <xmlOutputDirectory>target/site</xmlOutputDirectory>
-                    <excludeFilterFile>findbugs-exclude.xml</excludeFilterFile>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.jacoco</groupId>
-                <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.7.9</version>
-                <reportSets>
-                    <reportSet>
-                        <reports>
-                            <!-- select non-aggregate reports -->
-                            <report>report</report>
-                        </reports>
-                    </reportSet>
-                </reportSets>
-                <configuration>
-                    <excludes>
-
-                    </excludes>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-pmd-plugin</artifactId>
-                <version>3.8</version>
-                <configuration>
-                    <linkXref>true</linkXref>
-                    <sourceEncoding>utf-8</sourceEncoding>
-                    <minimumTokens>100</minimumTokens>
-                    <targetJdk>${java-version}</targetJdk>
-                    <excludes>
-
-                    </excludes>
-                    <excludeRoots>
-                        <excludeRoot>target/generated-sources/stubs</excludeRoot>
-                    </excludeRoots>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>taglist-maven-plugin</artifactId>
-                <version>2.4</version>
-                <configuration>
-                    <tagListOptions>
-                        <tagClasses>
-                            <tagClass>
-                                <displayName>Todo Work</displayName>
-                                <tags>
-                                    <tag>
-                                        <matchString>todo</matchString>
-                                        <matchType>ignoreCase</matchType>
-                                    </tag>
-                                    <tag>
-                                        <matchString>FIXME</matchString>
-                                        <matchType>exact</matchType>
-                                    </tag>
-                                </tags>
-                            </tagClass>
-                        </tagClasses>
-                    </tagListOptions>
-                </configuration>
+                <version>3.0.1</version>
             </plugin>
         </plugins>
     </reporting>

--- a/extern-sdk/pom.xml
+++ b/extern-sdk/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>ru.skbkontur.sdk</groupId>
         <artifactId>extern</artifactId>
-        <version>1.1-SNAPSHOT</version>
+        <version>1.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>extern-java-sdk</artifactId>
@@ -18,8 +18,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>2.2</version>
-
                 <configuration>
                     <archive>
                         <manifestEntries>
@@ -28,16 +26,7 @@
                         </manifestEntries>
                     </archive>
                 </configuration>
-
             </plugin>
-
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-project-info-reports-plugin</artifactId>
-                <version>2.9</version>
-            </plugin>
-
-
         </plugins>
     </build>
 
@@ -50,7 +39,7 @@
     </repositories>
 
     <dependencies>
-        <!--local repository dependencies-->
+        <!-- cryptoservice local dependencies -->
         <dependency>
             <groupId>ru.argosgrp.cryptoservice</groupId>
             <artifactId>asn1</artifactId>
@@ -77,7 +66,7 @@
             <version>${cryptoservice.version}</version>
         </dependency>
 
-        <!--central dependencies-->
+        <!-- swagger dependencies -->
         <dependency>
             <groupId>io.swagger</groupId>
             <artifactId>swagger-annotations</artifactId>
@@ -104,55 +93,14 @@
             <version>${jodatime-version}</version>
         </dependency>
 
-        <!-- test dependencies -->
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>${junit-version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-core</artifactId>
-            <version>1.3</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jetbrains</groupId>
-            <artifactId>annotations</artifactId>
-            <version>15.0</version>
-        </dependency>
     </dependencies>
-
-    <profiles>
-        <profile>
-            <id>javadoc</id>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-javadoc-plugin</artifactId>
-                        <version>2.10.4</version>
-                        <executions>
-                            <execution>
-                                <id>attach-javadocs</id>
-                                <goals>
-                                    <goal>jar</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
 
     <reporting>
         <plugins>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>findbugs-maven-plugin</artifactId>
-                <version>3.0.1</version>
+                <version>${findbugs-maven-plugin.version}</version>
             </plugin>
         </plugins>
     </reporting>

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/Configuration.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/Configuration.java
@@ -1,8 +1,27 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * MIT License
+ *
+ * Copyright (c) 2018 SKB Kontur
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  */
+
 package ru.skbkontur.sdk.extern;
 
 import com.google.gson.Gson;

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/Configuration.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/Configuration.java
@@ -7,6 +7,13 @@ package ru.skbkontur.sdk.extern;
 
 import com.google.gson.Gson;
 import com.google.gson.annotations.SerializedName;
+import com.google.gson.stream.JsonReader;
+import ru.skbkontur.sdk.extern.providers.AccountProvider;
+import ru.skbkontur.sdk.extern.providers.ApiKeyProvider;
+import ru.skbkontur.sdk.extern.providers.LoginAndPasswordProvider;
+import ru.skbkontur.sdk.extern.providers.ServiceBaseUriProvider;
+import ru.skbkontur.sdk.extern.providers.UriProvider;
+import ru.skbkontur.sdk.extern.providers.auth.Credential;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -14,171 +21,177 @@ import java.io.InputStreamReader;
 import java.net.URL;
 import java.util.UUID;
 
-import com.google.gson.stream.JsonReader;
-import ru.skbkontur.sdk.extern.providers.AccountProvider;
-import ru.skbkontur.sdk.extern.providers.ApiKeyProvider;
-import ru.skbkontur.sdk.extern.providers.ServiceBaseUriProvider;
-import ru.skbkontur.sdk.extern.providers.UriProvider;
-import ru.skbkontur.sdk.extern.providers.LoginAndPasswordProvider;
-import ru.skbkontur.sdk.extern.providers.auth.Credential;
-import ru.skbkontur.sdk.extern.service.SDKException;
 
 /**
- *
  * @author AlexS
  */
 public class Configuration implements AccountProvider, ApiKeyProvider, LoginAndPasswordProvider, UriProvider, ServiceBaseUriProvider {
-	public static final String DEFAULT_AUTH_PREFIX = "auth.sid ";
-	
-  @SerializedName("accountId")	private UUID accountId;
-	@SerializedName("apiKey") private String apiKey;
-	@SerializedName("authPrefix") private String authPrefix;
-	@SerializedName("credential") private Credential credential;
-	@SerializedName("serviceUserId") private String serviceUserId;
-	@SerializedName("login") private String login;
-	@SerializedName("pass") private String pass;
-	@SerializedName("serviceBaseUri") private String serviceBaseUri;
-	@SerializedName("authBaseUri") private String authBaseUri;
-	@SerializedName("thumbprint") private String thumbprint; // a thumbprint of a signature certificate for CryptoPro
-	@SerializedName("thumbprintCloud") private String thumbprintCloud; // a thumbprint of a signature certificate for CloudCrypto
-	@SerializedName("thumbprintRsa") private String thumbprintRsa; // a thumbprint of a signature certificate with RSA algorithm
-	@SerializedName("jksPass") private String jksPass; // a password of JKS
-	@SerializedName("rsaKeyPass") private String rsaKeyPass; // a password of a RSA key
 
-	public Configuration() {
-		authPrefix = DEFAULT_AUTH_PREFIX;
-	}
-	
-	@Override
-	public UUID accountId() {
-		return accountId;
-	}
+    public static final String DEFAULT_AUTH_PREFIX = "auth.sid ";
 
-	public void setAccountId(UUID accountId) {
-		this.accountId = accountId;
-	}
+    @SerializedName("accountId")
+    private UUID accountId;
+    @SerializedName("apiKey")
+    private String apiKey;
+    @SerializedName("authPrefix")
+    private String authPrefix;
+    @SerializedName("credential")
+    private Credential credential;
+    @SerializedName("serviceUserId")
+    private String serviceUserId;
+    @SerializedName("login")
+    private String login;
+    @SerializedName("pass")
+    private String pass;
+    @SerializedName("serviceBaseUri")
+    private String serviceBaseUri;
+    @SerializedName("authBaseUri")
+    private String authBaseUri;
+    @SerializedName("thumbprint")
+    private String thumbprint; // a thumbprint of a signature certificate for CryptoPro
+    @SerializedName("thumbprintCloud")
+    private String thumbprintCloud; // a thumbprint of a signature certificate for CloudCrypto
+    @SerializedName("thumbprintRsa")
+    private String thumbprintRsa; // a thumbprint of a signature certificate with RSA algorithm
+    @SerializedName("jksPass")
+    private String jksPass; // a password of JKS
+    @SerializedName("rsaKeyPass")
+    private String rsaKeyPass; // a password of a RSA key
 
-	public void setAccountId(String accountId) {
-		this.accountId = UUID.fromString(accountId);
-	}
+    public Configuration() {
+        authPrefix = DEFAULT_AUTH_PREFIX;
+    }
 
-	@Override
-	public String getApiKey() {
-		return apiKey;
-	}
+    public static Configuration load(URL resourceUrl) throws IOException {
+        try (InputStream is = resourceUrl.openStream()) {
+            if (is == null) {
+                throw new IOException(resourceUrl.toExternalForm() + " is not found");
+            }
 
-	public void setApiKey(String apiKey) {
-		this.apiKey = apiKey;
-	}
+            return new Gson().fromJson(new JsonReader(new InputStreamReader(is)), Configuration.class);
+        }
+    }
 
-	public String getAuthPrefix() {
-		return authPrefix;
-	}
+    @Override
+    public UUID accountId() {
+        return accountId;
+    }
 
-	public void setAuthPrefix(String authPrefix) {
-		this.authPrefix = authPrefix;
-	}
+    public void setAccountId(UUID accountId) {
+        this.accountId = accountId;
+    }
 
-	@Override
-	public String getLogin() {
-		return login;
-	}
+    public void setAccountId(String accountId) {
+        this.accountId = UUID.fromString(accountId);
+    }
 
-	public void setLogin(String login) {
-		this.login = login;
-	}
+    @Override
+    public String getApiKey() {
+        return apiKey;
+    }
 
-	@Override
-	public String getPass() {
-		return pass;
-	}
+    public void setApiKey(String apiKey) {
+        this.apiKey = apiKey;
+    }
 
-	public void setPass(String pass) {
-		this.pass = pass;
-	}
+    public String getAuthPrefix() {
+        return authPrefix;
+    }
 
-	@Override
-	public String getServiceBaseUri() {
-		return serviceBaseUri;
-	}
+    public void setAuthPrefix(String authPrefix) {
+        this.authPrefix = authPrefix;
+    }
 
-	public void setServiceBaseUri(String serviceBaseUri) {
-		this.serviceBaseUri = serviceBaseUri;
-	}
+    @Override
+    public String getLogin() {
+        return login;
+    }
 
-	@Override
-	public String getUri() {
-		return authBaseUri;
-	}
+    public void setLogin(String login) {
+        this.login = login;
+    }
 
-	public void setAuthBaseUri(String authBaseUri) {
-		this.authBaseUri = authBaseUri;
-	}
+    @Override
+    public String getPass() {
+        return pass;
+    }
 
-	public String getThumbprint() {
-		return thumbprint;
-	}
+    public void setPass(String pass) {
+        this.pass = pass;
+    }
 
-	public void setThumbprint(String thumbprint) {
-		this.thumbprint = thumbprint;
-	}
+    @Override
+    public String getServiceBaseUri() {
+        return serviceBaseUri;
+    }
 
-	public String getThumbprintCloud() {
-		return thumbprintCloud;
-	}
+    public void setServiceBaseUri(String serviceBaseUri) {
+        this.serviceBaseUri = serviceBaseUri;
+    }
 
-	public void setThumbprintCloud(String thumbprintCloud) {
-		this.thumbprintCloud = thumbprintCloud;
-	}
+    @Override
+    public String getUri() {
+        return authBaseUri;
+    }
 
-	public String getThumbprintRsa() {
-		return thumbprintRsa;
-	}
+    public void setAuthBaseUri(String authBaseUri) {
+        this.authBaseUri = authBaseUri;
+    }
 
-	public void setThumbprintRsa(String thumbprintRsa) {
-		this.thumbprintRsa = thumbprintRsa;
-	}
+    public String getThumbprint() {
+        return thumbprint;
+    }
 
-	public String getJksPass() {
-		return jksPass;
-	}
+    public void setThumbprint(String thumbprint) {
+        this.thumbprint = thumbprint;
+    }
 
-	public void setJksPass(String jksPass) {
-		this.jksPass = jksPass;
-	}
+    public String getThumbprintCloud() {
+        return thumbprintCloud;
+    }
 
-	public String getRsaKeyPass() {
-		return rsaKeyPass;
-	}
+    public void setThumbprintCloud(String thumbprintCloud) {
+        this.thumbprintCloud = thumbprintCloud;
+    }
 
-	public void setRsaKeyPass(String rsaKeyPass) {
-		this.rsaKeyPass = rsaKeyPass;
-	}
+    public String getThumbprintRsa() {
+        return thumbprintRsa;
+    }
 
-	public Credential getCredential() {
-		return credential;
-	}
+    public void setThumbprintRsa(String thumbprintRsa) {
+        this.thumbprintRsa = thumbprintRsa;
+    }
 
-	public void setCredential(Credential credential) {
-		this.credential = credential;
-	}
+    public String getJksPass() {
+        return jksPass;
+    }
 
-	public String getServiceUserId() {
-		return serviceUserId;
-	}
+    public void setJksPass(String jksPass) {
+        this.jksPass = jksPass;
+    }
 
-	public void setServiceUserId(String serviceUserId) {
-		this.serviceUserId = serviceUserId;
-	}
+    public String getRsaKeyPass() {
+        return rsaKeyPass;
+    }
 
-	public static Configuration load(URL resourceUrl) throws IOException {
-		try (InputStream is = resourceUrl.openStream()) {
-			if (is == null) {
-				throw new IOException(resourceUrl.toExternalForm() + " is not found");
-			}
+    public void setRsaKeyPass(String rsaKeyPass) {
+        this.rsaKeyPass = rsaKeyPass;
+    }
 
-			return new Gson().fromJson(new JsonReader(new InputStreamReader(is)), Configuration.class);
-		}
-	}
+    public Credential getCredential() {
+        return credential;
+    }
+
+    public void setCredential(Credential credential) {
+        this.credential = credential;
+    }
+
+    public String getServiceUserId() {
+        return serviceUserId;
+    }
+
+    public void setServiceUserId(String serviceUserId) {
+        this.serviceUserId = serviceUserId;
+    }
 
 }

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/Environment.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/Environment.java
@@ -1,8 +1,27 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * MIT License
+ *
+ * Copyright (c) 2018 SKB Kontur
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  */
+
 package ru.skbkontur.sdk.extern;
 
 import com.google.gson.Gson;

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/Environment.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/Environment.java
@@ -7,17 +7,18 @@ package ru.skbkontur.sdk.extern;
 
 import com.google.gson.Gson;
 
+
 /**
- *
  * @author AlexS
  */
 public class Environment {
-	public final Gson gson = new Gson();
 
-	public Configuration configuration;
-	public String accessToken;
-	
-	public Environment() {
-		configuration = new Configuration();
-	}
+    public final Gson gson = new Gson();
+
+    public Configuration configuration;
+    public String accessToken;
+
+    public Environment() {
+        configuration = new Configuration();
+    }
 }

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/ExternEngine.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/ExternEngine.java
@@ -1,8 +1,27 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * MIT License
+ *
+ * Copyright (c) 2018 SKB Kontur
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  */
+
 package ru.skbkontur.sdk.extern;
 
 import ru.skbkontur.sdk.extern.event.AuthenticationEvent;

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/ExternEngine.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/ExternEngine.java
@@ -5,9 +5,6 @@
  */
 package ru.skbkontur.sdk.extern;
 
-import ru.skbkontur.sdk.extern.service.SDKException;
-import java.io.IOException;
-import static ru.skbkontur.sdk.extern.Messages.C_CRYPTO_ERROR_NO_CRYPTO_PROVIDER;
 import ru.skbkontur.sdk.extern.event.AuthenticationEvent;
 import ru.skbkontur.sdk.extern.event.AuthenticationListener;
 import ru.skbkontur.sdk.extern.providers.AccountProvider;
@@ -22,6 +19,7 @@ import ru.skbkontur.sdk.extern.service.BusinessDriver;
 import ru.skbkontur.sdk.extern.service.CertificateService;
 import ru.skbkontur.sdk.extern.service.DocflowService;
 import ru.skbkontur.sdk.extern.service.DraftService;
+import ru.skbkontur.sdk.extern.service.SDKException;
 import ru.skbkontur.sdk.extern.service.impl.AccountServiceImpl;
 import ru.skbkontur.sdk.extern.service.impl.BaseService;
 import ru.skbkontur.sdk.extern.service.impl.CertificateServiceImpl;
@@ -33,244 +31,241 @@ import ru.skbkontur.sdk.extern.service.transport.adaptors.DocflowsAdaptor;
 import ru.skbkontur.sdk.extern.service.transport.adaptors.DraftsAdaptor;
 import ru.skbkontur.sdk.extern.service.transport.adaptors.QueryContext;
 
+import java.io.IOException;
 import java.net.URL;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.Objects;
 import java.util.Optional;
-import java.util.stream.Stream;
 
+import static ru.skbkontur.sdk.extern.Messages.C_CRYPTO_ERROR_NO_CRYPTO_PROVIDER;
 import static ru.skbkontur.sdk.extern.service.transport.adaptors.QueryContext.SESSION_ID;
 
+
 /**
- *
  * @author AlexS
  */
 public class ExternEngine implements AuthenticationListener {
 
-	private final Environment env;
+    private final Environment env;
 
-	private AccountService accountService;
+    private AccountService accountService;
 
-	private DraftService draftService;
+    private DraftService draftService;
 
-	private DocflowService docflowService;
+    private DocflowService docflowService;
 
-	private CertificateService certificateService;
+    private CertificateService certificateService;
 
-	private ServiceBaseUriProvider serviceBaseUriProvider;
+    private ServiceBaseUriProvider serviceBaseUriProvider;
 
-	private EngineAuthenticationProvider authenticationProvider;
+    private EngineAuthenticationProvider authenticationProvider;
 
-	private AccountProvider accountProvider;
+    private AccountProvider accountProvider;
 
-	private ApiKeyProvider apiKeyProvider;
+    private ApiKeyProvider apiKeyProvider;
 
-	private CryptoProvider cryptoProvider;
+    private CryptoProvider cryptoProvider;
 
-	private String sessionId;
-	
-	private BusinessDriver businessDriver;
+    private String sessionId;
 
-	public ExternEngine() throws SDKException {
-		this(new Configuration());
-	}
+    private BusinessDriver businessDriver;
 
-	public ExternEngine(Configuration configuration) throws SDKException {
-		env = new Environment();
-		env.configuration = configuration;
-		this.sessionId = null;
-		this.businessDriver = new BusinessDriver(this);
-		configureProviders();
-	}
+    public ExternEngine() throws SDKException {
+        this(new Configuration());
+    }
 
-	/**
-	 * loads config data from the resource file
-	 * @param  configUrl url to configuration
-	 * @throws IOException see {@link Configuration#load(URL)}
-	 */
-	public ExternEngine(URL configUrl) throws IOException {
-		this(Configuration.load(configUrl));
-	}
+    public ExternEngine(Configuration configuration) throws SDKException {
+        env = new Environment();
+        env.configuration = configuration;
+        this.sessionId = null;
+        this.businessDriver = new BusinessDriver(this);
+        configureProviders();
+    }
 
-	public Configuration getConfiguration() {
-		return env.configuration;
-	}
+    /**
+     * loads config data from the resource file
+     *
+     * @param configUrl url to configuration
+     * @throws IOException see {@link Configuration#load(URL)}
+     */
+    public ExternEngine(URL configUrl) throws IOException {
+        this(Configuration.load(configUrl));
+    }
 
-	public Environment getEnvironment() {
-		return env;
-	}
+    public Configuration getConfiguration() {
+        return env.configuration;
+    }
 
-	public AccountService getAccountService() {
-		return accountService;
-	}
+    public Environment getEnvironment() {
+        return env;
+    }
 
-	public void setAccountService(AccountService accountService) {
-		this.accountService = accountService;
-	}
+    public AccountService getAccountService() {
+        return accountService;
+    }
 
-	public DraftService getDraftService() {
-		return draftService;
-	}
+    public void setAccountService(AccountService accountService) {
+        this.accountService = accountService;
+    }
 
-	public void setDraftService(DraftService draftService) {
-		this.draftService = draftService;
-	}
+    public DraftService getDraftService() {
+        return draftService;
+    }
 
-	public DocflowService getDocflowService() {
-		return docflowService;
-	}
+    public void setDraftService(DraftService draftService) {
+        this.draftService = draftService;
+    }
 
-	public void setDocflowService(DocflowService docflowService) {
-		this.docflowService = docflowService;
-	}
+    public DocflowService getDocflowService() {
+        return docflowService;
+    }
 
-	public CertificateService getCertificateService() {
-		return certificateService;
-	}
+    public void setDocflowService(DocflowService docflowService) {
+        this.docflowService = docflowService;
+    }
 
-	public void setServiceBaseUriProvider(ServiceBaseUriProvider serviceBaseUriProvider) {
-		this.serviceBaseUriProvider = serviceBaseUriProvider;
-	}
+    public CertificateService getCertificateService() {
+        return certificateService;
+    }
 
-	public AuthenticationProvider getAuthenticationProvider() {
-		return ((EngineAuthenticationProvider) authenticationProvider).getOriginAuthenticationProvider();
-	}
+    public void setServiceBaseUriProvider(ServiceBaseUriProvider serviceBaseUriProvider) {
+        this.serviceBaseUriProvider = serviceBaseUriProvider;
+    }
 
-	public void setAuthenticationProvider(AuthenticationProvider authenticationProvider) {
-		if (authenticationProvider != null) {
-			authenticationProvider.addAuthenticationListener(this);
-			this.authenticationProvider = new EngineAuthenticationProvider(authenticationProvider);
-		}
-		else if (this.authenticationProvider != null) {
-			AuthenticationProvider originAuthenticationProvider = this.authenticationProvider.getOriginAuthenticationProvider();
-			originAuthenticationProvider.removeAuthenticationListener(this);
-		}
-	}
+    public AuthenticationProvider getAuthenticationProvider() {
+        return authenticationProvider.getOriginAuthenticationProvider();
+    }
 
-	public AccountProvider getAccountProvider() {
-		return accountProvider;
-	}
+    public void setAuthenticationProvider(AuthenticationProvider authenticationProvider) {
+        if (authenticationProvider != null) {
+            authenticationProvider.addAuthenticationListener(this);
+            this.authenticationProvider = new EngineAuthenticationProvider(authenticationProvider);
+        } else if (this.authenticationProvider != null) {
+            AuthenticationProvider originAuthenticationProvider = this.authenticationProvider.getOriginAuthenticationProvider();
+            originAuthenticationProvider.removeAuthenticationListener(this);
+        }
+    }
 
-	public void setAccountProvider(AccountProvider accountProvider) {
-		this.accountProvider = accountProvider;
-	}
+    public AccountProvider getAccountProvider() {
+        return accountProvider;
+    }
 
-	public ApiKeyProvider getApiKeyProvider() {
-		return apiKeyProvider;
-	}
+    public void setAccountProvider(AccountProvider accountProvider) {
+        this.accountProvider = accountProvider;
+    }
 
-	public void setApiKeyProvider(ApiKeyProvider apiKeyProvider) {
-		this.apiKeyProvider = apiKeyProvider;
-	}
+    public ApiKeyProvider getApiKeyProvider() {
+        return apiKeyProvider;
+    }
 
-	public CryptoProvider getCryptoProvider() throws SDKException {
-		if (cryptoProvider == null) {
-			throw new SDKException(Messages.get(C_CRYPTO_ERROR_NO_CRYPTO_PROVIDER));
-		}
-		return cryptoProvider;
-	}
+    public void setApiKeyProvider(ApiKeyProvider apiKeyProvider) {
+        this.apiKeyProvider = apiKeyProvider;
+    }
 
-	public CryptoProvider setCryptoProvider(CryptoProvider cryptoProvider) {
-		CryptoProvider current = this.cryptoProvider;
-		this.cryptoProvider = cryptoProvider;
-		return current;
-	}
+    public CryptoProvider getCryptoProvider() throws SDKException {
+        if (cryptoProvider == null) {
+            throw new SDKException(Messages.get(C_CRYPTO_ERROR_NO_CRYPTO_PROVIDER));
+        }
+        return cryptoProvider;
+    }
 
-	public void configureServices() throws SDKException {
-		AccountServiceImpl accSrv = new AccountServiceImpl();
-		configureService(accSrv);
-		accSrv.setApi(new AccountsAdaptor());
-		this.accountService = accSrv;
+    public CryptoProvider setCryptoProvider(CryptoProvider cryptoProvider) {
+        CryptoProvider current = this.cryptoProvider;
+        this.cryptoProvider = cryptoProvider;
+        return current;
+    }
 
-		DraftServiceImpl draftSrv = new DraftServiceImpl();
-		configureService(draftSrv);
-		draftSrv.setApi(new DraftsAdaptor());
-		this.draftService = draftSrv;
+    public void configureServices() throws SDKException {
+        AccountServiceImpl accSrv = new AccountServiceImpl();
+        configureService(accSrv);
+        accSrv.setApi(new AccountsAdaptor());
+        this.accountService = accSrv;
 
-		DocflowServiceImpl docflowSrv = new DocflowServiceImpl();
-		configureService(docflowSrv);
-		docflowSrv.setApi(new DocflowsAdaptor());
-		this.docflowService = docflowSrv;
+        DraftServiceImpl draftSrv = new DraftServiceImpl();
+        configureService(draftSrv);
+        draftSrv.setApi(new DraftsAdaptor());
+        this.draftService = draftSrv;
 
-		CertificateServiceImpl certificateSrvice = new CertificateServiceImpl();
-		configureService(certificateSrvice);
-		certificateSrvice.setApi(new CertificatesAdaptor());
-		this.certificateService = certificateSrvice;
-	}
+        DocflowServiceImpl docflowSrv = new DocflowServiceImpl();
+        configureService(docflowSrv);
+        docflowSrv.setApi(new DocflowsAdaptor());
+        this.docflowService = docflowSrv;
 
-	private void configureService(BaseService baseService) {
-		baseService.setServiceBaseUriProvider(this.serviceBaseUriProvider);
-		baseService.setAuthenticationProvider(this.authenticationProvider);
-		baseService.setAccountProvider(this.accountProvider);
-		baseService.setApiKeyProvider(this.apiKeyProvider);
-		baseService.setCryptoProvider(this.cryptoProvider);
-	}
+        CertificateServiceImpl certificateSrvice = new CertificateServiceImpl();
+        configureService(certificateSrvice);
+        certificateSrvice.setApi(new CertificatesAdaptor());
+        this.certificateService = certificateSrvice;
+    }
 
-	@Override
-	public synchronized void authenticate(AuthenticationEvent authEvent) {
-		sessionId = authEvent.getAuthCxt().isSuccess() ? authEvent.getAuthCxt().get() : null;
-	}
+    private void configureService(BaseService baseService) {
+        baseService.setServiceBaseUriProvider(this.serviceBaseUriProvider);
+        baseService.setAuthenticationProvider(this.authenticationProvider);
+        baseService.setAccountProvider(this.accountProvider);
+        baseService.setApiKeyProvider(this.apiKeyProvider);
+        baseService.setCryptoProvider(this.cryptoProvider);
+    }
 
-	class EngineAuthenticationProvider implements AuthenticationProvider {
+    @Override
+    public synchronized void authenticate(AuthenticationEvent authEvent) {
+        sessionId = authEvent.getAuthCxt().isSuccess() ? authEvent.getAuthCxt().get() : null;
+    }
 
-		private final AuthenticationProvider authenticationProvider;
+    private void configureProviders() {
+        Configuration c = env.configuration;
+        if (c != null) {
 
-		private EngineAuthenticationProvider(AuthenticationProvider authenticationProvider) {
-			this.authenticationProvider = authenticationProvider;
-		}
+            Optional.ofNullable(c.accountId()).ifPresent(value -> setAccountProvider(c));
+            Optional.ofNullable(c.getApiKey()).ifPresent(value -> setApiKeyProvider(c));
+            Optional.ofNullable(c.getServiceBaseUri()).ifPresent(value -> setServiceBaseUriProvider(c));
 
-		public AuthenticationProvider getOriginAuthenticationProvider() {
-			return authenticationProvider;
-		}
+            if (c.getUri() != null && c.getLogin() != null && c.getPass() != null && c.getApiKey() != null) {
+                setAuthenticationProvider(new AuthenticationProviderByPass(c, c, c));
+            }
+        }
+    }
 
-		@Override
-		public QueryContext<String> sessionId() {
-			if (sessionId == null) {
-				return authenticationProvider.sessionId();
-			}
-			else {
-				return new QueryContext<String>().setResult(sessionId, SESSION_ID);
-			}
-		}
+    public BusinessDriver getBusinessDriver() {
+        return businessDriver;
+    }
 
-		@Override
-		public String authPrefix() {
-			return authenticationProvider.authPrefix();
-		}
 
-		@Override
-		public void addAuthenticationListener(AuthenticationListener authListener) {
-			authenticationProvider.addAuthenticationListener(authListener);
-		}
+    class EngineAuthenticationProvider implements AuthenticationProvider {
 
-		@Override
-		public void removeAuthenticationListener(AuthenticationListener authListener) {
-			authenticationProvider.removeAuthenticationListener(authListener);
-		}
+        private final AuthenticationProvider authenticationProvider;
 
-		@Override
-		public void raiseUnauthenticated(ServiceError x) {
-			authenticationProvider.raiseUnauthenticated(x);
-		}
-	}
+        private EngineAuthenticationProvider(AuthenticationProvider authenticationProvider) {
+            this.authenticationProvider = authenticationProvider;
+        }
 
-	private void configureProviders() {
-		Configuration c = env.configuration;
-		if (c != null) {
+        public AuthenticationProvider getOriginAuthenticationProvider() {
+            return authenticationProvider;
+        }
 
-			Optional.ofNullable(c.accountId()).ifPresent(value -> setAccountProvider(c));
-			Optional.ofNullable(c.getApiKey()).ifPresent(value -> setApiKeyProvider(c));
-			Optional.ofNullable(c.getServiceBaseUri()).ifPresent(value -> setServiceBaseUriProvider(c));
+        @Override
+        public QueryContext<String> sessionId() {
+            if (sessionId == null) {
+                return authenticationProvider.sessionId();
+            } else {
+                return new QueryContext<String>().setResult(sessionId, SESSION_ID);
+            }
+        }
 
-			if (c.getUri() != null && c.getLogin() != null && c.getPass() != null && c.getApiKey() != null) {
-				setAuthenticationProvider(new AuthenticationProviderByPass(c, c, c));
-			}
-		}
-	}
-	
-	public BusinessDriver getBusinessDriver() {
-		return businessDriver;
-	}
+        @Override
+        public String authPrefix() {
+            return authenticationProvider.authPrefix();
+        }
+
+        @Override
+        public void addAuthenticationListener(AuthenticationListener authListener) {
+            authenticationProvider.addAuthenticationListener(authListener);
+        }
+
+        @Override
+        public void removeAuthenticationListener(AuthenticationListener authListener) {
+            authenticationProvider.removeAuthenticationListener(authListener);
+        }
+
+        @Override
+        public void raiseUnauthenticated(ServiceError x) {
+            authenticationProvider.raiseUnauthenticated(x);
+        }
+    }
 }

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/Messages.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/Messages.java
@@ -27,37 +27,37 @@ import java.text.MessageFormat;
 import java.util.Locale;
 import java.util.ResourceBundle;
 
+
 /**
- *
  * @author AlexS
  */
 public class Messages {
-	public static final String UNKNOWN = "UNKNOWN";
-	public static final String S_AUTHORIZATION_BY_LOGIN = "S_AUTHORIZATION_BY_LOGIN";
-	public static final String S_SERVER_ERROR = "S_SERVER_ERROR";
-	public static final String S_ENTITY_NOT_FOUND = "S_ENTITY_NOT_FOUND";
-	public static final String C_CONFIG_NOT_FOUND = "C_CONFIG_NOT_FOUND";
-	public static final String C_CONFIG_LOAD = "C_CONFIG_LOAD";
-	public static final String C_CRYPTO_ERROR = "C_CRYPTO_ERROR";
-	public static final String C_CRYPTO_ERROR_NO_CRYPTO_PROVIDER = "C_CRYPTO_ERROR_NO_CRYPTO_PROVIDER";
-	public static final String C_CRYPTO_ERROR_INIT = "C_CRYPTO_ERROR_INIT";
-	public static final String C_CRYPTO_ERROR_KEY_NOT_FOUND = "C_CRYPTO_ERROR_KEY_NOT_FOUND";
-	public static final String C_RESOURCE_NOT_FOUND = "C_RESOURCE_NOT_FOUND";
-	public static final String C_NO_SIGNATURE = "C_NO_SIGNATURE";
-	public static final String C_NO_DECRYPT = "C_NO_DECRYPT";
 
-	private static final ResourceBundle MESSAGES = ResourceBundle.getBundle("Messages", Locale.getDefault());
-	
-	public static String get(String key) {
-		try {
-			return MESSAGES.getString(key);
-		}
-		catch (RuntimeException x) {
-			return MessageFormat.format("Resourse key [{0}] not found.", key);
-		}
-	}
-	
-	public static String get(String key, Object ... p) {
-		return MessageFormat.format(get(key), p);
-	}
+    public static final String UNKNOWN = "UNKNOWN";
+    public static final String S_AUTHORIZATION_BY_LOGIN = "S_AUTHORIZATION_BY_LOGIN";
+    public static final String S_SERVER_ERROR = "S_SERVER_ERROR";
+    public static final String S_ENTITY_NOT_FOUND = "S_ENTITY_NOT_FOUND";
+    public static final String C_CONFIG_NOT_FOUND = "C_CONFIG_NOT_FOUND";
+    public static final String C_CONFIG_LOAD = "C_CONFIG_LOAD";
+    public static final String C_CRYPTO_ERROR = "C_CRYPTO_ERROR";
+    public static final String C_CRYPTO_ERROR_NO_CRYPTO_PROVIDER = "C_CRYPTO_ERROR_NO_CRYPTO_PROVIDER";
+    public static final String C_CRYPTO_ERROR_INIT = "C_CRYPTO_ERROR_INIT";
+    public static final String C_CRYPTO_ERROR_KEY_NOT_FOUND = "C_CRYPTO_ERROR_KEY_NOT_FOUND";
+    public static final String C_RESOURCE_NOT_FOUND = "C_RESOURCE_NOT_FOUND";
+    public static final String C_NO_SIGNATURE = "C_NO_SIGNATURE";
+    public static final String C_NO_DECRYPT = "C_NO_DECRYPT";
+
+    private static final ResourceBundle MESSAGES = ResourceBundle.getBundle("Messages", Locale.getDefault());
+
+    public static String get(String key) {
+        try {
+            return MESSAGES.getString(key);
+        } catch (RuntimeException x) {
+            return MessageFormat.format("Resourse key [{0}] not found.", key);
+        }
+    }
+
+    public static String get(String key, Object... p) {
+        return MessageFormat.format(get(key), p);
+    }
 }

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/Messages.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/Messages.java
@@ -1,7 +1,7 @@
 /*
- * The MIT License
+ * MIT License
  *
- * Copyright 2018 SKB Kontur
+ * Copyright (c) 2018 SKB Kontur
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -10,17 +10,18 @@
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
  *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
  *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
  * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
  * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  */
+
 package ru.skbkontur.sdk.extern;
 
 import java.text.MessageFormat;

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/event/AuthenticationEvent.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/event/AuthenticationEvent.java
@@ -5,22 +5,24 @@
  */
 package ru.skbkontur.sdk.extern.event;
 
-import java.util.EventObject;
 import ru.skbkontur.sdk.extern.service.transport.adaptors.QueryContext;
 
+import java.util.EventObject;
+
+
 /**
- *
  * @author alexs
  */
 public class AuthenticationEvent extends EventObject {
-	private final QueryContext<String> authCxt;
-	
-	public AuthenticationEvent(Object source, QueryContext<String> authCxt) {
-		super(source);
-		this.authCxt = authCxt;
-	}
-	
-	public QueryContext<String> getAuthCxt() {
-		return authCxt;
-	}
+
+    private final QueryContext<String> authCxt;
+
+    public AuthenticationEvent(Object source, QueryContext<String> authCxt) {
+        super(source);
+        this.authCxt = authCxt;
+    }
+
+    public QueryContext<String> getAuthCxt() {
+        return authCxt;
+    }
 }

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/event/AuthenticationEvent.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/event/AuthenticationEvent.java
@@ -1,8 +1,27 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * MIT License
+ *
+ * Copyright (c) 2018 SKB Kontur
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  */
+
 package ru.skbkontur.sdk.extern.event;
 
 import ru.skbkontur.sdk.extern.service.transport.adaptors.QueryContext;

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/event/AuthenticationListener.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/event/AuthenticationListener.java
@@ -1,8 +1,27 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * MIT License
+ *
+ * Copyright (c) 2018 SKB Kontur
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  */
+
 package ru.skbkontur.sdk.extern.event;
 
 /**

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/event/AuthenticationListener.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/event/AuthenticationListener.java
@@ -6,9 +6,9 @@
 package ru.skbkontur.sdk.extern.event;
 
 /**
- *
  * @author alexs
  */
 public interface AuthenticationListener {
-	void authenticate(AuthenticationEvent authEvent);
+
+    void authenticate(AuthenticationEvent authEvent);
 }

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/model/Account.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/model/Account.java
@@ -1,8 +1,27 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * MIT License
+ *
+ * Copyright (c) 2018 SKB Kontur
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  */
+
 package ru.skbkontur.sdk.extern.model;
 
 import java.util.List;

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/model/Account.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/model/Account.java
@@ -8,58 +8,59 @@ package ru.skbkontur.sdk.extern.model;
 import java.util.List;
 import java.util.UUID;
 
+
 /**
- *
  * @author AlexS
  */
 public class Account {
-  private UUID id = null;
-  private String inn = null;
-  private String kpp = null;
-  private String organizationName = null;
-  private List<Link> links = null;
 
-	public UUID getId() {
-		return id;
-	}
+    private UUID id = null;
+    private String inn = null;
+    private String kpp = null;
+    private String organizationName = null;
+    private List<Link> links = null;
 
-	public void setId(UUID id) {
-		this.id = id;
-	}
+    public UUID getId() {
+        return id;
+    }
 
-	public void setId(String id) {
-		this.id = UUID.fromString(id);
-	}
+    public void setId(String id) {
+        this.id = UUID.fromString(id);
+    }
 
-	public String getInn() {
-		return inn;
-	}
+    public void setId(UUID id) {
+        this.id = id;
+    }
 
-	public void setInn(String inn) {
-		this.inn = inn;
-	}
+    public String getInn() {
+        return inn;
+    }
 
-	public String getKpp() {
-		return kpp;
-	}
+    public void setInn(String inn) {
+        this.inn = inn;
+    }
 
-	public void setKpp(String kpp) {
-		this.kpp = kpp;
-	}
+    public String getKpp() {
+        return kpp;
+    }
 
-	public String getOrganizationName() {
-		return organizationName;
-	}
+    public void setKpp(String kpp) {
+        this.kpp = kpp;
+    }
 
-	public void setOrganizationName(String organizationName) {
-		this.organizationName = organizationName;
-	}
+    public String getOrganizationName() {
+        return organizationName;
+    }
 
-	public List<Link> getLinks() {
-		return links;
-	}
+    public void setOrganizationName(String organizationName) {
+        this.organizationName = organizationName;
+    }
 
-	public void setLinks(List<Link> links) {
-		this.links = links;
-	}
+    public List<Link> getLinks() {
+        return links;
+    }
+
+    public void setLinks(List<Link> links) {
+        this.links = links;
+    }
 }

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/model/AccountList.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/model/AccountList.java
@@ -1,8 +1,27 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * MIT License
+ *
+ * Copyright (c) 2018 SKB Kontur
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  */
+
 package ru.skbkontur.sdk.extern.model;
 
 import java.util.List;

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/model/AccountList.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/model/AccountList.java
@@ -7,48 +7,49 @@ package ru.skbkontur.sdk.extern.model;
 
 import java.util.List;
 
+
 /**
- *
  * @author AlexS
  */
 public class AccountList {
-  private Integer skip = null;
 
-  private Integer take = null;
+    private Integer skip = null;
 
-  private Integer totalCount = null;
+    private Integer take = null;
 
-  private List<Account> accounts = null;
+    private Integer totalCount = null;
 
-	public List<Account> getAccounts() {
-		return accounts;
-	}
+    private List<Account> accounts = null;
 
-	public void setAccounts(List<Account> accounts) {
-		this.accounts = accounts;
-	}
+    public List<Account> getAccounts() {
+        return accounts;
+    }
 
-	public Integer getTotalCount() {
-		return totalCount;
-	}
+    public void setAccounts(List<Account> accounts) {
+        this.accounts = accounts;
+    }
 
-	public void setTotalCount(Integer totalCount) {
-		this.totalCount = totalCount;
-	}
+    public Integer getTotalCount() {
+        return totalCount;
+    }
 
-	public Integer getSkip() {
-		return skip;
-	}
+    public void setTotalCount(Integer totalCount) {
+        this.totalCount = totalCount;
+    }
 
-	public void setSkip(Integer skip) {
-		this.skip = skip;
-	}
+    public Integer getSkip() {
+        return skip;
+    }
 
-	public Integer getTake() {
-		return take;
-	}
+    public void setSkip(Integer skip) {
+        this.skip = skip;
+    }
 
-	public void setTake(Integer take) {
-		this.take = take;
-	}
+    public Integer getTake() {
+        return take;
+    }
+
+    public void setTake(Integer take) {
+        this.take = take;
+    }
 }

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/model/AdditionalClientInfo.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/model/AdditionalClientInfo.java
@@ -6,70 +6,67 @@
 package ru.skbkontur.sdk.extern.model;
 
 /**
- *
  * @author alexs
  */
 public class AdditionalClientInfo {
 
-	public enum SignerTypeEnum {
-    UNKNOWN("unknown"),
-    
-    CHIEF("chief"),
-    
-    REPRESENTATIVE("representative");
+    private SignerTypeEnum signerType = null;
+    private String senderFullName = null;
+    private Taxpayer taxpayer = null;
 
-    private final String value;
-
-    SignerTypeEnum(String value) {
-      this.value = value;
+    public SignerTypeEnum getSignerType() {
+        return signerType;
     }
 
-    public String getValue() {
-      return value;
+    public void setSignerType(SignerTypeEnum signerType) {
+        this.signerType = signerType;
     }
 
-    @Override
-    public String toString() {
-      return String.valueOf(value);
+    public String getSenderFullName() {
+        return senderFullName;
     }
 
-    public static SignerTypeEnum fromValue(String text) {
-      for (SignerTypeEnum b : SignerTypeEnum.values()) {
-        if (String.valueOf(b.value).equals(text)) {
-          return b;
+    public void setSenderFullName(String senderFullName) {
+        this.senderFullName = senderFullName;
+    }
+
+    public Taxpayer getTaxpayer() {
+        return taxpayer;
+    }
+
+    public void setTaxpayer(Taxpayer taxpayer) {
+        this.taxpayer = taxpayer;
+    }
+
+    public enum SignerTypeEnum {
+        UNKNOWN("unknown"),
+
+        CHIEF("chief"),
+
+        REPRESENTATIVE("representative");
+
+        private final String value;
+
+        SignerTypeEnum(String value) {
+            this.value = value;
         }
-      }
-      return null;
+
+        public static SignerTypeEnum fromValue(String text) {
+            for (SignerTypeEnum b : SignerTypeEnum.values()) {
+                if (String.valueOf(b.value).equals(text)) {
+                    return b;
+                }
+            }
+            return null;
+        }
+
+        public String getValue() {
+            return value;
+        }
+
+        @Override
+        public String toString() {
+            return String.valueOf(value);
+        }
     }
-  }
-
-  private SignerTypeEnum signerType = null;
-
-  private String senderFullName = null;
-
-  private Taxpayer taxpayer = null;
-
-	public SignerTypeEnum getSignerType() {
-		return signerType;
-	}
-
-	public void setSignerType(SignerTypeEnum signerType) {
-		this.signerType = signerType;
-	}
-
-	public String getSenderFullName() {
-		return senderFullName;
-	}
-
-	public void setSenderFullName(String  senderFullName) {
-		this.senderFullName = senderFullName;
-	}
-
-	public Taxpayer getTaxpayer() {
-		return taxpayer;
-	}
-
-	public void setTaxpayer(Taxpayer taxpayer) {
-		this.taxpayer = taxpayer;
-	}
 }

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/model/AdditionalClientInfo.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/model/AdditionalClientInfo.java
@@ -1,8 +1,27 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * MIT License
+ *
+ * Copyright (c) 2018 SKB Kontur
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  */
+
 package ru.skbkontur.sdk.extern.model;
 
 /**

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/model/Certificate.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/model/Certificate.java
@@ -6,71 +6,71 @@
 package ru.skbkontur.sdk.extern.model;
 
 /**
- *
  * @author alexs
  */
 public class Certificate {
-  private String fio = null;
-  private String inn = null;
-  private String kpp = null;
-  private Boolean isValid = null;
-  private Boolean isCloud = null;
-  private Boolean isQualified = null;
-  private String content = null;
 
-	public String getFio() {
-		return fio;
-	}
+    private String fio = null;
+    private String inn = null;
+    private String kpp = null;
+    private Boolean isValid = null;
+    private Boolean isCloud = null;
+    private Boolean isQualified = null;
+    private String content = null;
 
-	public void setFio(String fio) {
-		this.fio = fio;
-	}
+    public String getFio() {
+        return fio;
+    }
 
-	public String getInn() {
-		return inn;
-	}
+    public void setFio(String fio) {
+        this.fio = fio;
+    }
 
-	public void setInn(String inn) {
-		this.inn = inn;
-	}
+    public String getInn() {
+        return inn;
+    }
 
-	public String getKpp() {
-		return kpp;
-	}
+    public void setInn(String inn) {
+        this.inn = inn;
+    }
 
-	public void setKpp(String kpp) {
-		this.kpp = kpp;
-	}
+    public String getKpp() {
+        return kpp;
+    }
 
-	public Boolean getIsValid() {
-		return isValid;
-	}
+    public void setKpp(String kpp) {
+        this.kpp = kpp;
+    }
 
-	public void setIsValid(Boolean isValid) {
-		this.isValid = isValid;
-	}
+    public Boolean getIsValid() {
+        return isValid;
+    }
 
-	public Boolean getIsCloud() {
-		return isCloud;
-	}
+    public void setIsValid(Boolean isValid) {
+        this.isValid = isValid;
+    }
 
-	public void setIsCloud(Boolean isCloud) {
-		this.isCloud = isCloud;
-	}
+    public Boolean getIsCloud() {
+        return isCloud;
+    }
 
-	public Boolean getIsQualified() {
-		return isQualified;
-	}
+    public void setIsCloud(Boolean isCloud) {
+        this.isCloud = isCloud;
+    }
 
-	public void setIsQualified(Boolean isQualified) {
-		this.isQualified = isQualified;
-	}
+    public Boolean getIsQualified() {
+        return isQualified;
+    }
 
-	public String getContent() {
-		return content;
-	}
+    public void setIsQualified(Boolean isQualified) {
+        this.isQualified = isQualified;
+    }
 
-	public void setContent(String content) {
-		this.content = content;
-	}
+    public String getContent() {
+        return content;
+    }
+
+    public void setContent(String content) {
+        this.content = content;
+    }
 }

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/model/Certificate.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/model/Certificate.java
@@ -1,8 +1,27 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * MIT License
+ *
+ * Copyright (c) 2018 SKB Kontur
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  */
+
 package ru.skbkontur.sdk.extern.model;
 
 /**

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/model/CertificateList.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/model/CertificateList.java
@@ -1,8 +1,27 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * MIT License
+ *
+ * Copyright (c) 2018 SKB Kontur
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  */
+
 package ru.skbkontur.sdk.extern.model;
 
 import java.util.List;

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/model/CertificateList.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/model/CertificateList.java
@@ -7,47 +7,48 @@ package ru.skbkontur.sdk.extern.model;
 
 import java.util.List;
 
+
 /**
- *
  * @author alexs
  */
 public class CertificateList {
-  private List<Certificate> certificates = null;
-  private Integer totalCount = null;
-  private Integer pageIndex = null;
-  private Integer pageSize = null;
 
-	public List<Certificate> getCertificates() {
-		return certificates;
-	}
+    private List<Certificate> certificates = null;
+    private Integer totalCount = null;
+    private Integer pageIndex = null;
+    private Integer pageSize = null;
 
-	public void setCertificates(List<Certificate> certificates) {
-		this.certificates = certificates;
-	}
+    public List<Certificate> getCertificates() {
+        return certificates;
+    }
 
-	public Integer getTotalCount() {
-		return totalCount;
-	}
+    public void setCertificates(List<Certificate> certificates) {
+        this.certificates = certificates;
+    }
 
-	public void setTotalCount(Integer totalCount) {
-		this.totalCount = totalCount;
-	}
+    public Integer getTotalCount() {
+        return totalCount;
+    }
 
-	public Integer getPageIndex() {
-		return pageIndex;
-	}
+    public void setTotalCount(Integer totalCount) {
+        this.totalCount = totalCount;
+    }
 
-	public void setPageIndex(Integer pageIndex) {
-		this.pageIndex = pageIndex;
-	}
+    public Integer getPageIndex() {
+        return pageIndex;
+    }
 
-	public Integer getPageSize() {
-		return pageSize;
-	}
+    public void setPageIndex(Integer pageIndex) {
+        this.pageIndex = pageIndex;
+    }
 
-	public void setPageSize(Integer pageSize) {
-		this.pageSize = pageSize;
-	}
-	
-	
+    public Integer getPageSize() {
+        return pageSize;
+    }
+
+    public void setPageSize(Integer pageSize) {
+        this.pageSize = pageSize;
+    }
+
+
 }

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/model/CheckError.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/model/CheckError.java
@@ -1,8 +1,27 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * MIT License
+ *
+ * Copyright (c) 2018 SKB Kontur
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  */
+
 package ru.skbkontur.sdk.extern.model;
 
 /**

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/model/CheckError.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/model/CheckError.java
@@ -6,129 +6,122 @@
 package ru.skbkontur.sdk.extern.model;
 
 /**
- *
  * @author AlexS
  */
 public class CheckError {
 
-	private String description = null;
-	private String source = null;
-	private String level = null;
-	private String type = null;
-	private String tags = null;
-	private String id = null;
+    private String description = null;
+    private String source = null;
+    private String level = null;
+    private String type = null;
+    private String tags = null;
+    private String id = null;
 
-	public CheckError description(String description) {
-		this.description = description;
-		return this;
-	}
+    public CheckError description(String description) {
+        this.description = description;
+        return this;
+    }
 
-	/**
-	 * Get description
-	 *
-	 * @return description
-	 *
-	 */
-	public String getDescription() {
-		return description;
-	}
+    /**
+     * Get description
+     *
+     * @return description
+     */
+    public String getDescription() {
+        return description;
+    }
 
-	public void setDescription(String description) {
-		this.description = description;
-	}
+    public void setDescription(String description) {
+        this.description = description;
+    }
 
-	public CheckError source(String source) {
-		this.source = source;
-		return this;
-	}
+    public CheckError source(String source) {
+        this.source = source;
+        return this;
+    }
 
-	/**
-	 * Get source
-	 *
-	 * @return source
-	 *
-	 */
-	public String getSource() {
-		return source;
-	}
+    /**
+     * Get source
+     *
+     * @return source
+     */
+    public String getSource() {
+        return source;
+    }
 
-	public void setSource(String source) {
-		this.source = source;
-	}
+    public void setSource(String source) {
+        this.source = source;
+    }
 
-	public CheckError level(String level) {
-		this.level = level;
-		return this;
-	}
+    public CheckError level(String level) {
+        this.level = level;
+        return this;
+    }
 
-	/**
-	 * Get level
-	 *
-	 * @return level
-	 *
-	 */
-	public String getLevel() {
-		return level;
-	}
+    /**
+     * Get level
+     *
+     * @return level
+     */
+    public String getLevel() {
+        return level;
+    }
 
-	public void setLevel(String level) {
-		this.level = level;
-	}
+    public void setLevel(String level) {
+        this.level = level;
+    }
 
-	public CheckError type(String type) {
-		this.type = type;
-		return this;
-	}
+    public CheckError type(String type) {
+        this.type = type;
+        return this;
+    }
 
-	/**
-	 * Get type
-	 *
-	 * @return type
-	 *
-	 */
-	public String getType() {
-		return type;
-	}
+    /**
+     * Get type
+     *
+     * @return type
+     */
+    public String getType() {
+        return type;
+    }
 
-	public void setType(String type) {
-		this.type = type;
-	}
+    public void setType(String type) {
+        this.type = type;
+    }
 
-	public CheckError tags(String tags) {
-		this.tags = tags;
-		return this;
-	}
+    public CheckError tags(String tags) {
+        this.tags = tags;
+        return this;
+    }
 
-	/**
-	 * Get tags
-	 *
-	 * @return tags
-	 *
-	 */
-	public String getTags() {
-		return tags;
-	}
+    /**
+     * Get tags
+     *
+     * @return tags
+     */
+    public String getTags() {
+        return tags;
+    }
 
-	public void setTags(String tags) {
-		this.tags = tags;
-	}
+    public void setTags(String tags) {
+        this.tags = tags;
+    }
 
-	public CheckError id(String id) {
-		this.id = id;
-		return this;
-	}
+    public CheckError id(String id) {
+        this.id = id;
+        return this;
+    }
 
-	/**
-	 * Get id
-	 *
-	 * @return id
-	 *
-	 */
-	public String getId() {
-		return id;
-	}
+    /**
+     * Get id
+     *
+     * @return id
+     */
+    public String getId() {
+        return id;
+    }
 
-	public void setId(String id) {
-		this.id = id;
-	}
+    public void setId(String id) {
+        this.id = id;
+    }
 }

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/model/CheckResultData.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/model/CheckResultData.java
@@ -9,58 +9,56 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+
 /**
- *
  * @author AlexS
  */
 public class CheckResultData {
 
-	private Map<String, List<CheckError>> documentsErrors = null;
-	private List<CheckError> commonErrors = null;
+    private Map<String, List<CheckError>> documentsErrors = null;
+    private List<CheckError> commonErrors = null;
 
-	public CheckResultData documentsErrors(Map<String, List<CheckError>> documentsErrors) {
-		this.documentsErrors = documentsErrors;
-		return this;
-	}
+    public CheckResultData documentsErrors(Map<String, List<CheckError>> documentsErrors) {
+        this.documentsErrors = documentsErrors;
+        return this;
+    }
 
-	/**
-	 * Get documentsErrors
-	 *
-	 * @return documentsErrors
-	 *
-	 */
-	public Map<String, List<CheckError>> getDocumentsErrors() {
-		return documentsErrors;
-	}
+    /**
+     * Get documentsErrors
+     *
+     * @return documentsErrors
+     */
+    public Map<String, List<CheckError>> getDocumentsErrors() {
+        return documentsErrors;
+    }
 
-	public void setDocumentsErrors(Map<String, List<CheckError>> documentsErrors) {
-		this.documentsErrors = documentsErrors;
-	}
+    public void setDocumentsErrors(Map<String, List<CheckError>> documentsErrors) {
+        this.documentsErrors = documentsErrors;
+    }
 
-	public CheckResultData commonErrors(List<CheckError> commonErrors) {
-		this.commonErrors = commonErrors;
-		return this;
-	}
+    public CheckResultData commonErrors(List<CheckError> commonErrors) {
+        this.commonErrors = commonErrors;
+        return this;
+    }
 
-	public CheckResultData addCommonErrorsItem(CheckError commonErrorsItem) {
-		if (this.commonErrors == null) {
-			this.commonErrors = new ArrayList<>();
-		}
-		this.commonErrors.add(commonErrorsItem);
-		return this;
-	}
+    public CheckResultData addCommonErrorsItem(CheckError commonErrorsItem) {
+        if (this.commonErrors == null) {
+            this.commonErrors = new ArrayList<>();
+        }
+        this.commonErrors.add(commonErrorsItem);
+        return this;
+    }
 
-	/**
-	 * Get commonErrors
-	 *
-	 * @return commonErrors
-	 *
-	 */
-	public List<CheckError> getCommonErrors() {
-		return commonErrors;
-	}
+    /**
+     * Get commonErrors
+     *
+     * @return commonErrors
+     */
+    public List<CheckError> getCommonErrors() {
+        return commonErrors;
+    }
 
-	public void setCommonErrors(List<CheckError> commonErrors) {
-		this.commonErrors = commonErrors;
-	}
+    public void setCommonErrors(List<CheckError> commonErrors) {
+        this.commonErrors = commonErrors;
+    }
 }

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/model/CheckResultData.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/model/CheckResultData.java
@@ -1,8 +1,27 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * MIT License
+ *
+ * Copyright (c) 2018 SKB Kontur
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  */
+
 package ru.skbkontur.sdk.extern.model;
 
 import java.util.ArrayList;

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/model/Content.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/model/Content.java
@@ -1,8 +1,27 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * MIT License
+ *
+ * Copyright (c) 2018 SKB Kontur
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  */
+
 package ru.skbkontur.sdk.extern.model;
 
 /**

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/model/Content.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/model/Content.java
@@ -6,49 +6,46 @@
 package ru.skbkontur.sdk.extern.model;
 
 /**
- *
  * @author AlexS
  */
 public class Content {
 
-	private Link decrypted = null;
-	private Link encrypted = null;
+    private Link decrypted = null;
+    private Link encrypted = null;
 
-	public Content decrypted(Link decrypted) {
-		this.decrypted = decrypted;
-		return this;
-	}
+    public Content decrypted(Link decrypted) {
+        this.decrypted = decrypted;
+        return this;
+    }
 
-	/**
-	 * Get decrypted
-	 *
-	 * @return decrypted
-  *
-	 */
-	public Link getDecrypted() {
-		return decrypted;
-	}
+    /**
+     * Get decrypted
+     *
+     * @return decrypted
+     */
+    public Link getDecrypted() {
+        return decrypted;
+    }
 
-	public void setDecrypted(Link decrypted) {
-		this.decrypted = decrypted;
-	}
+    public void setDecrypted(Link decrypted) {
+        this.decrypted = decrypted;
+    }
 
-	public Content encrypted(Link encrypted) {
-		this.encrypted = encrypted;
-		return this;
-	}
+    public Content encrypted(Link encrypted) {
+        this.encrypted = encrypted;
+        return this;
+    }
 
-	/**
-	 * Get encrypted
-	 *
-	 * @return encrypted
-  *
-	 */
-	public Link getEncrypted() {
-		return encrypted;
-	}
+    /**
+     * Get encrypted
+     *
+     * @return encrypted
+     */
+    public Link getEncrypted() {
+        return encrypted;
+    }
 
-	public void setEncrypted(Link encrypted) {
-		this.encrypted = encrypted;
-	}
+    public void setEncrypted(Link encrypted) {
+        this.encrypted = encrypted;
+    }
 }

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/model/CreateAccountRequest.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/model/CreateAccountRequest.java
@@ -6,35 +6,35 @@
 package ru.skbkontur.sdk.extern.model;
 
 /**
- *
  * @author AlexS
  */
 public class CreateAccountRequest {
-  private String inn = null;
-  private String kpp = null;
-  private String organizationName = null;
 
-	public String getInn() {
-		return inn;
-	}
+    private String inn = null;
+    private String kpp = null;
+    private String organizationName = null;
 
-	public void setInn(String inn) {
-		this.inn = inn;
-	}
+    public String getInn() {
+        return inn;
+    }
 
-	public String getKpp() {
-		return kpp;
-	}
+    public void setInn(String inn) {
+        this.inn = inn;
+    }
 
-	public void setKpp(String kpp) {
-		this.kpp = kpp;
-	}
+    public String getKpp() {
+        return kpp;
+    }
 
-	public String getOrganizationName() {
-		return organizationName;
-	}
+    public void setKpp(String kpp) {
+        this.kpp = kpp;
+    }
 
-	public void setOrganizationName(String organizationName) {
-		this.organizationName = organizationName;
-	}
+    public String getOrganizationName() {
+        return organizationName;
+    }
+
+    public void setOrganizationName(String organizationName) {
+        this.organizationName = organizationName;
+    }
 }

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/model/CreateAccountRequest.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/model/CreateAccountRequest.java
@@ -1,8 +1,27 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * MIT License
+ *
+ * Copyright (c) 2018 SKB Kontur
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  */
+
 package ru.skbkontur.sdk.extern.model;
 
 /**

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/model/Docflow.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/model/Docflow.java
@@ -5,134 +5,127 @@
  */
 package ru.skbkontur.sdk.extern.model;
 
-import java.util.List;
-import java.util.UUID;
 import org.joda.time.DateTime;
 
+import java.util.List;
+import java.util.UUID;
+
+
 /**
- *
  * @author AlexS
  */
 public class Docflow {
 
-	private UUID id = null;
-	private String type = null;
-	private String status = null;
-	private DocflowDescription description = null;
-	private List<Document> documents = null;
-	private List<Link> links = null;
-	private DateTime sendDate = null;
-	private DateTime lastChangeDate = null;
+    private UUID id = null;
+    private String type = null;
+    private String status = null;
+    private DocflowDescription description = null;
+    private List<Document> documents = null;
+    private List<Link> links = null;
+    private DateTime sendDate = null;
+    private DateTime lastChangeDate = null;
 
-	/**
-	 * Get id
-	 *
-	 * @return id
-	 *
-	 */
-	public UUID getId() {
-		return id;
-	}
+    /**
+     * Get id
+     *
+     * @return id
+     */
+    public UUID getId() {
+        return id;
+    }
 
-	public void setId(UUID id) {
-		this.id = id;
-	}
+    public void setId(UUID id) {
+        this.id = id;
+    }
 
-	/**
-	 * Get type
-	 *
-	 * @return type
-	 *
-	 */
-	public String getType() {
-		return type;
-	}
+    /**
+     * Get type
+     *
+     * @return type
+     */
+    public String getType() {
+        return type;
+    }
 
-	public void setType(String type) {
-		this.type = type;
-	}
+    public void setType(String type) {
+        this.type = type;
+    }
 
-	/**
-	 * Get status
-	 *
-	 * @return status
-	 *
-	 */
-	public String getStatus() {
-		return status;
-	}
+    /**
+     * Get status
+     *
+     * @return status
+     */
+    public String getStatus() {
+        return status;
+    }
 
-	public void setStatus(String status) {
-		this.status = status;
-	}
+    public void setStatus(String status) {
+        this.status = status;
+    }
 
-	/**
-	 * Get description
-	 *
-	 * @return description
-	 *
-	 */
-	public DocflowDescription getDescription() {
-		return description;
-	}
+    /**
+     * Get description
+     *
+     * @return description
+     */
+    public DocflowDescription getDescription() {
+        return description;
+    }
 
-	public void setDescription(DocflowDescription description) {
-		this.description = description;
-	}
+    public void setDescription(DocflowDescription description) {
+        this.description = description;
+    }
 
-	/**
-	 * Get documents
-	 *
-	 * @return documents
-	 *
-	 */
-	public List<Document> getDocuments() {
-		return documents;
-	}
+    /**
+     * Get documents
+     *
+     * @return documents
+     */
+    public List<Document> getDocuments() {
+        return documents;
+    }
 
-	public void setDocuments(List<Document> documents) {
-		this.documents = documents;
-	}
+    public void setDocuments(List<Document> documents) {
+        this.documents = documents;
+    }
 
-	/**
-	 * Get links
-	 *
-	 * @return links
-	 *
-	 */
-	public List<Link> getLinks() {
-		return links;
-	}
+    /**
+     * Get links
+     *
+     * @return links
+     */
+    public List<Link> getLinks() {
+        return links;
+    }
 
-	public void setLinks(List<Link> links) {
-		this.links = links;
-	}
+    public void setLinks(List<Link> links) {
+        this.links = links;
+    }
 
-	/**
-	 * Get sendDate
-	 *
-	 * @return sendDate
-	 *
-	 */
-	public DateTime getSendDate() {
-		return sendDate;
-	}
+    /**
+     * Get sendDate
+     *
+     * @return sendDate
+     */
+    public DateTime getSendDate() {
+        return sendDate;
+    }
 
-	public void setSendDate(DateTime sendDate) {
-		this.sendDate = sendDate;
-	}
+    public void setSendDate(DateTime sendDate) {
+        this.sendDate = sendDate;
+    }
 
-	/**
-	 * Get lastChangeDate
-	 *
-	 * @return lastChangeDate
-	 *
-	 */
-	public DateTime getLastChangeDate() {
-		return lastChangeDate;
-	}
+    /**
+     * Get lastChangeDate
+     *
+     * @return lastChangeDate
+     */
+    public DateTime getLastChangeDate() {
+        return lastChangeDate;
+    }
 
-	public void setLastChangeDate(DateTime lastChangeDate) {
-		this.lastChangeDate = lastChangeDate;
-	}
+    public void setLastChangeDate(DateTime lastChangeDate) {
+        this.lastChangeDate = lastChangeDate;
+    }
 }

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/model/Docflow.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/model/Docflow.java
@@ -1,8 +1,27 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * MIT License
+ *
+ * Copyright (c) 2018 SKB Kontur
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  */
+
 package ru.skbkontur.sdk.extern.model;
 
 import org.joda.time.DateTime;

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/model/DocflowDescription.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/model/DocflowDescription.java
@@ -6,9 +6,8 @@
 package ru.skbkontur.sdk.extern.model;
 
 /**
- *
  * @author AlexS
  */
 public class DocflowDescription {
-	
+
 }

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/model/DocflowDescription.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/model/DocflowDescription.java
@@ -1,8 +1,27 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * MIT License
+ *
+ * Copyright (c) 2018 SKB Kontur
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  */
+
 package ru.skbkontur.sdk.extern.model;
 
 /**

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/model/DocflowPage.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/model/DocflowPage.java
@@ -1,8 +1,27 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * MIT License
+ *
+ * Copyright (c) 2018 SKB Kontur
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  */
+
 package ru.skbkontur.sdk.extern.model;
 
 import java.util.List;

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/model/DocflowPage.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/model/DocflowPage.java
@@ -7,46 +7,47 @@ package ru.skbkontur.sdk.extern.model;
 
 import java.util.List;
 
+
 /**
- *
  * @author alexs
  */
 public class DocflowPage {
-  private Long skip = null;
-  private Long take = null;
-  private Long totalCount = null;
-  private List<DocflowPageItem> docflowsPageItem = null;
 
-	public Long getSkip() {
-		return skip;
-	}
+    private Long skip = null;
+    private Long take = null;
+    private Long totalCount = null;
+    private List<DocflowPageItem> docflowsPageItem = null;
 
-	public void setSkip(Long skip) {
-		this.skip = skip;
-	}
+    public Long getSkip() {
+        return skip;
+    }
 
-	public Long getTake() {
-		return take;
-	}
+    public void setSkip(Long skip) {
+        this.skip = skip;
+    }
 
-	public void setTake(Long take) {
-		this.take = take;
-	}
+    public Long getTake() {
+        return take;
+    }
 
-	public Long getTotalCount() {
-		return totalCount;
-	}
+    public void setTake(Long take) {
+        this.take = take;
+    }
 
-	public void setTotalCount(Long totalCount) {
-		this.totalCount = totalCount;
-	}
+    public Long getTotalCount() {
+        return totalCount;
+    }
 
-	public List<DocflowPageItem> getDocflowsPageItem() {
-		return docflowsPageItem;
-	}
+    public void setTotalCount(Long totalCount) {
+        this.totalCount = totalCount;
+    }
 
-	public void setDocflowsPageItem(List<DocflowPageItem> docflowsPageItem) {
-		this.docflowsPageItem = docflowsPageItem;
-	}
+    public List<DocflowPageItem> getDocflowsPageItem() {
+        return docflowsPageItem;
+    }
+
+    public void setDocflowsPageItem(List<DocflowPageItem> docflowsPageItem) {
+        this.docflowsPageItem = docflowsPageItem;
+    }
 
 }

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/model/DocflowPageItem.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/model/DocflowPageItem.java
@@ -5,67 +5,69 @@
  */
 package ru.skbkontur.sdk.extern.model;
 
-import java.util.List;
-import java.util.UUID;
 import org.joda.time.DateTime;
 
+import java.util.List;
+import java.util.UUID;
+
+
 /**
- *
  * @author alexs
  */
 public class DocflowPageItem {
-  private UUID id = null;
-  private String type = null;
-  private String status = null;
-  private List<Link> links = null;
-  private DateTime sendDate = null;
-  private DateTime lastChangeDate = null;
 
-	public UUID getId() {
-		return id;
-	}
+    private UUID id = null;
+    private String type = null;
+    private String status = null;
+    private List<Link> links = null;
+    private DateTime sendDate = null;
+    private DateTime lastChangeDate = null;
 
-	public void setId(UUID id) {
-		this.id = id;
-	}
+    public UUID getId() {
+        return id;
+    }
 
-	public String getType() {
-		return type;
-	}
+    public void setId(UUID id) {
+        this.id = id;
+    }
 
-	public void setType(String type) {
-		this.type = type;
-	}
+    public String getType() {
+        return type;
+    }
 
-	public String getStatus() {
-		return status;
-	}
+    public void setType(String type) {
+        this.type = type;
+    }
 
-	public void setStatus(String status) {
-		this.status = status;
-	}
+    public String getStatus() {
+        return status;
+    }
 
-	public List<Link> getLinks() {
-		return links;
-	}
+    public void setStatus(String status) {
+        this.status = status;
+    }
 
-	public void setLinks(List<Link> links) {
-		this.links = links;
-	}
+    public List<Link> getLinks() {
+        return links;
+    }
 
-	public DateTime getSendDate() {
-		return sendDate;
-	}
+    public void setLinks(List<Link> links) {
+        this.links = links;
+    }
 
-	public void setSendDate(DateTime sendDate) {
-		this.sendDate = sendDate;
-	}
+    public DateTime getSendDate() {
+        return sendDate;
+    }
 
-	public DateTime getLastChangeDate() {
-		return lastChangeDate;
-	}
+    public void setSendDate(DateTime sendDate) {
+        this.sendDate = sendDate;
+    }
 
-	public void setLastChangeDate(DateTime lastChangeDate) {
-		this.lastChangeDate = lastChangeDate;
-	}
+    public DateTime getLastChangeDate() {
+        return lastChangeDate;
+    }
+
+    public void setLastChangeDate(DateTime lastChangeDate) {
+        this.lastChangeDate = lastChangeDate;
+    }
 }

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/model/DocflowPageItem.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/model/DocflowPageItem.java
@@ -1,8 +1,27 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * MIT License
+ *
+ * Copyright (c) 2018 SKB Kontur
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  */
+
 package ru.skbkontur.sdk.extern.model;
 
 import org.joda.time.DateTime;

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/model/Document.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/model/Document.java
@@ -1,8 +1,27 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * MIT License
+ *
+ * Copyright (c) 2018 SKB Kontur
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  */
+
 package ru.skbkontur.sdk.extern.model;
 
 import java.util.List;

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/model/Document.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/model/Document.java
@@ -8,110 +8,105 @@ package ru.skbkontur.sdk.extern.model;
 import java.util.List;
 import java.util.UUID;
 
+
 /**
- *
  * @author AlexS
  */
 public class Document {
 
-	private UUID id = null;
-	private DocumentDescription description = null;
-	private Content content = null;
-	private List<Signature> signatures = null;
-	private List<Link> links = null;
+    private UUID id = null;
+    private DocumentDescription description = null;
+    private Content content = null;
+    private List<Signature> signatures = null;
+    private List<Link> links = null;
 
-	public Document id(UUID id) {
-		this.id = id;
-		return this;
-	}
+    public Document id(UUID id) {
+        this.id = id;
+        return this;
+    }
 
-	/**
-	 * Get id
-	 *
-	 * @return id
-	 *
-	 */
-	public UUID getId() {
-		return id;
-	}
+    /**
+     * Get id
+     *
+     * @return id
+     */
+    public UUID getId() {
+        return id;
+    }
 
-	public void setId(UUID id) {
-		this.id = id;
-	}
+    public void setId(UUID id) {
+        this.id = id;
+    }
 
-	public Document description(DocumentDescription description) {
-		this.description = description;
-		return this;
-	}
+    public Document description(DocumentDescription description) {
+        this.description = description;
+        return this;
+    }
 
-	/**
-	 * Get description
-	 *
-	 * @return description
-	 *
-	 */
-	public DocumentDescription getDescription() {
-		return description;
-	}
+    /**
+     * Get description
+     *
+     * @return description
+     */
+    public DocumentDescription getDescription() {
+        return description;
+    }
 
-	public void setDescription(DocumentDescription description) {
-		this.description = description;
-	}
+    public void setDescription(DocumentDescription description) {
+        this.description = description;
+    }
 
-	public Document content(Content content) {
-		this.content = content;
-		return this;
-	}
+    public Document content(Content content) {
+        this.content = content;
+        return this;
+    }
 
-	/**
-	 * Get content
-	 *
-	 * @return content
-	 *
-	 */
-	public Content getContent() {
-		return content;
-	}
+    /**
+     * Get content
+     *
+     * @return content
+     */
+    public Content getContent() {
+        return content;
+    }
 
-	public void setContent(Content content) {
-		this.content = content;
-	}
+    public void setContent(Content content) {
+        this.content = content;
+    }
 
-	public Document signatures(List<Signature> signatures) {
-		this.signatures = signatures;
-		return this;
-	}
+    public Document signatures(List<Signature> signatures) {
+        this.signatures = signatures;
+        return this;
+    }
 
-	/**
-	 * Get signatures
-	 *
-	 * @return signatures
-	 *
-	 */
-	public List<Signature> getSignatures() {
-		return signatures;
-	}
+    /**
+     * Get signatures
+     *
+     * @return signatures
+     */
+    public List<Signature> getSignatures() {
+        return signatures;
+    }
 
-	public void setSignatures(List<Signature> signatures) {
-		this.signatures = signatures;
-	}
+    public void setSignatures(List<Signature> signatures) {
+        this.signatures = signatures;
+    }
 
-	public Document links(List<Link> links) {
-		this.links = links;
-		return this;
-	}
+    public Document links(List<Link> links) {
+        this.links = links;
+        return this;
+    }
 
-	/**
-	 * Get links
-	 *
-	 * @return links
-	 *
-	 */
-	public List<Link> getLinks() {
-		return links;
-	}
+    /**
+     * Get links
+     *
+     * @return links
+     */
+    public List<Link> getLinks() {
+        return links;
+    }
 
-	public void setLinks(List<Link> links) {
-		this.links = links;
-	}
+    public void setLinks(List<Link> links) {
+        this.links = links;
+    }
 }

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/model/DocumentContents.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/model/DocumentContents.java
@@ -1,8 +1,27 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * MIT License
+ *
+ * Copyright (c) 2018 SKB Kontur
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  */
+
 package ru.skbkontur.sdk.extern.model;
 
 /**

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/model/DocumentContents.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/model/DocumentContents.java
@@ -6,54 +6,50 @@
 package ru.skbkontur.sdk.extern.model;
 
 /**
- *
  * @author AlexS
  */
 public class DocumentContents {
 
-	private String base64Content = null;
-	private String signature = null;
-	private DocumentDescription documentDescription = null;
+    private String base64Content = null;
+    private String signature = null;
+    private DocumentDescription documentDescription = null;
 
-	/**
-	 * Get base64Content
-	 *
-	 * @return base64Content
-	 *
-	 */
-	public String getBase64Content() {
-		return base64Content;
-	}
+    /**
+     * Get base64Content
+     *
+     * @return base64Content
+     */
+    public String getBase64Content() {
+        return base64Content;
+    }
 
-	public void setBase64Content(String base64Content) {
-		this.base64Content = base64Content;
-	}
+    public void setBase64Content(String base64Content) {
+        this.base64Content = base64Content;
+    }
 
-	/**
-	 * Get signature
-	 *
-	 * @return signature
-	 *
-	 */
-	public String getSignature() {
-		return signature;
-	}
+    /**
+     * Get signature
+     *
+     * @return signature
+     */
+    public String getSignature() {
+        return signature;
+    }
 
-	public void setSignature(String signature) {
-		this.signature = signature;
-	}
+    public void setSignature(String signature) {
+        this.signature = signature;
+    }
 
-	/**
-	 * Get meta
-	 *
-	 * @return meta
-	 *
-	 */
-	public DocumentDescription getDocumentDescription() {
-		return documentDescription;
-	}
+    /**
+     * Get meta
+     *
+     * @return meta
+     */
+    public DocumentDescription getDocumentDescription() {
+        return documentDescription;
+    }
 
-	public void setDocumentDescription(DocumentDescription documentDescription) {
-		this.documentDescription = documentDescription;
-	}
+    public void setDocumentDescription(DocumentDescription documentDescription) {
+        this.documentDescription = documentDescription;
+    }
 }

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/model/DocumentDescription.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/model/DocumentDescription.java
@@ -6,69 +6,65 @@
 package ru.skbkontur.sdk.extern.model;
 
 /**
- *
  * @author AlexS
  */
 public class DocumentDescription {
 
-	private String type = null;
-	private String filename = null;
-	private String contentType = null;
+    private String type = null;
+    private String filename = null;
+    private String contentType = null;
 
-	public DocumentDescription type(String type) {
-		this.type = type;
-		return this;
-	}
+    public DocumentDescription type(String type) {
+        this.type = type;
+        return this;
+    }
 
-	/**
-	 * Get type
-	 *
-	 * @return type
-	 *
-	 */
-	public String getType() {
-		return type;
-	}
+    /**
+     * Get type
+     *
+     * @return type
+     */
+    public String getType() {
+        return type;
+    }
 
-	public void setType(String type) {
-		this.type = type;
-	}
+    public void setType(String type) {
+        this.type = type;
+    }
 
-	public DocumentDescription filename(String filename) {
-		this.filename = filename;
-		return this;
-	}
+    public DocumentDescription filename(String filename) {
+        this.filename = filename;
+        return this;
+    }
 
-	/**
-	 * Get filename
-	 *
-	 * @return filename
-	 *
-	 */
-	public String getFilename() {
-		return filename;
-	}
+    /**
+     * Get filename
+     *
+     * @return filename
+     */
+    public String getFilename() {
+        return filename;
+    }
 
-	public void setFilename(String filename) {
-		this.filename = filename;
-	}
+    public void setFilename(String filename) {
+        this.filename = filename;
+    }
 
-	public DocumentDescription contentType(String contentType) {
-		this.contentType = contentType;
-		return this;
-	}
+    public DocumentDescription contentType(String contentType) {
+        this.contentType = contentType;
+        return this;
+    }
 
-	/**
-	 * Get contentType
-	 *
-	 * @return contentType
-	 *
-	 */
-	public String getContentType() {
-		return contentType;
-	}
+    /**
+     * Get contentType
+     *
+     * @return contentType
+     */
+    public String getContentType() {
+        return contentType;
+    }
 
-	public void setContentType(String contentType) {
-		this.contentType = contentType;
-	}
+    public void setContentType(String contentType) {
+        this.contentType = contentType;
+    }
 }

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/model/DocumentDescription.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/model/DocumentDescription.java
@@ -1,8 +1,27 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * MIT License
+ *
+ * Copyright (c) 2018 SKB Kontur
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  */
+
 package ru.skbkontur.sdk.extern.model;
 
 /**

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/model/DocumentToSend.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/model/DocumentToSend.java
@@ -1,8 +1,27 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * MIT License
+ *
+ * Copyright (c) 2018 SKB Kontur
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  */
+
 package ru.skbkontur.sdk.extern.model;
 
 import com.google.gson.annotations.SerializedName;

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/model/DocumentToSend.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/model/DocumentToSend.java
@@ -6,108 +6,104 @@
 package ru.skbkontur.sdk.extern.model;
 
 import com.google.gson.annotations.SerializedName;
+
 import java.util.List;
 import java.util.UUID;
 
+
 /**
- *
  * @author AlexS
  */
 public class DocumentToSend {
 
-	@SerializedName("id")
-	private UUID id = null;
-	@SerializedName("content")
-	private byte[] content = null;
-	@SerializedName("filename")
-	private String filename = null;
-	@SerializedName("signature")
-	private SignatureToSend signature = null;
-	@SerializedName("sender-ip")
-	private String senderIp = null;
-  @SerializedName("links")
-  private List<Link> links = null;
+    @SerializedName("id")
+    private UUID id = null;
+    @SerializedName("content")
+    private byte[] content = null;
+    @SerializedName("filename")
+    private String filename = null;
+    @SerializedName("signature")
+    private SignatureToSend signature = null;
+    @SerializedName("sender-ip")
+    private String senderIp = null;
+    @SerializedName("links")
+    private List<Link> links = null;
 
 
-	/**
-	 * Get id
-	 *
-	 * @return id
-  *
-	 */
-	public UUID getId() {
-		return id;
-	}
+    /**
+     * Get id
+     *
+     * @return id
+     */
+    public UUID getId() {
+        return id;
+    }
 
-	public void setId(UUID id) {
-		this.id = id;
-	}
+    public void setId(String id) {
+        this.id = UUID.fromString(id);
+    }
 
-	public void setId(String id) {
-		this.id = UUID.fromString(id);
-	}
+    public void setId(UUID id) {
+        this.id = id;
+    }
 
-	/**
-	 * Get content
-	 *
-	 * @return content
-  *
-	 */
-	public byte[] getContent() {
-		return content;
-	}
+    /**
+     * Get content
+     *
+     * @return content
+     */
+    public byte[] getContent() {
+        return content;
+    }
 
-	public void setContent(byte[] content) {
-		this.content = content;
-	}
+    public void setContent(byte[] content) {
+        this.content = content;
+    }
 
-	/**
-	 * Get filename
-	 *
-	 * @return filename
-  *
-	 */
-	public String getFilename() {
-		return filename;
-	}
+    /**
+     * Get filename
+     *
+     * @return filename
+     */
+    public String getFilename() {
+        return filename;
+    }
 
-	public void setFilename(String filename) {
-		this.filename = filename;
-	}
+    public void setFilename(String filename) {
+        this.filename = filename;
+    }
 
-	/**
-	 * Get signature
-	 *
-	 * @return signature
-  *
-	 */
-	public SignatureToSend getSignature() {
-		return signature;
-	}
+    /**
+     * Get signature
+     *
+     * @return signature
+     */
+    public SignatureToSend getSignature() {
+        return signature;
+    }
 
-	public void setSignature(SignatureToSend signature) {
-		this.signature = signature;
-	}
+    public void setSignature(SignatureToSend signature) {
+        this.signature = signature;
+    }
 
-	/**
-	 * Get senderIp
-	 *
-	 * @return senderIp
-  *
-	 */
-	public String getSenderIp() {
-		return senderIp;
-	}
+    /**
+     * Get senderIp
+     *
+     * @return senderIp
+     */
+    public String getSenderIp() {
+        return senderIp;
+    }
 
-	public void setSenderIp(String senderIp) {
-		this.senderIp = senderIp;
-	}
+    public void setSenderIp(String senderIp) {
+        this.senderIp = senderIp;
+    }
 
-	public List<Link> getLinks() {
-		return links;
-	}
+    public List<Link> getLinks() {
+        return links;
+    }
 
-	public void setLinks(List<Link> links) {
-		this.links = links;
-	}
+    public void setLinks(List<Link> links) {
+        this.links = links;
+    }
 }

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/model/Draft.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/model/Draft.java
@@ -1,8 +1,27 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * MIT License
+ *
+ * Copyright (c) 2018 SKB Kontur
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  */
+
 package ru.skbkontur.sdk.extern.model;
 
 import java.util.UUID;
@@ -15,6 +34,7 @@ public class Draft {
 
     private UUID id;
     private Status status;
+
     public Draft() {
     }
 

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/model/Draft.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/model/Draft.java
@@ -7,74 +7,73 @@ package ru.skbkontur.sdk.extern.model;
 
 import java.util.UUID;
 
+
 /**
- *
  * @author AlexS
  */
 public class Draft {
-	
-  public enum Status {
-    NEW("new"),
-    
-    CHECKED("checked"),
-    
-    READYTOSEND("readyToSend"),
-    
-    SENT("sent");
 
-    private final String value;
-
-    Status(String value) {
-      this.value = value;
+    private UUID id;
+    private Status status;
+    public Draft() {
     }
 
-    public String getValue() {
-      return value;
+    public Draft(UUID id, Status status) {
+        this.id = id;
+        this.status = status;
     }
 
-    @Override
-    public String toString() {
-      return String.valueOf(value);
+    public UUID getId() {
+        return id;
     }
 
-    public static Status fromValue(String text) {
-      for (Status b : Status.values()) {
-        if (String.valueOf(b.value).equals(text)) {
-          return b;
+    public void setId(UUID id) {
+        this.id = id;
+    }
+
+    public Status getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = Status.fromValue(status);
+    }
+
+    public void setStatus(Status status) {
+        this.status = status;
+    }
+
+    public enum Status {
+        NEW("new"),
+
+        CHECKED("checked"),
+
+        READYTOSEND("readyToSend"),
+
+        SENT("sent");
+
+        private final String value;
+
+        Status(String value) {
+            this.value = value;
         }
-      }
-      return null;
-    }
-	}
-	
-  private UUID       id;
-	private Status status;
-	
-	public Draft() {
-	}
-	
-	public Draft(UUID id, Status status) {
-		this.id = id;
-		this.status = status;
-	}
-	
-	public UUID getId() {
-		return id;
-	}
-	
-	public void setId(UUID id) {
-		this.id = id;
-	}
-	
-	public Status getStatus() {
-		return status;
-	}
-	
-	public void setStatus(Status status) {
-		this.status = status;
-	}
 
-	public void setStatus(String status) {
-		this.status = Status.fromValue(status);
-	}
+        public static Status fromValue(String text) {
+            for (Status b : Status.values()) {
+                if (String.valueOf(b.value).equals(text)) {
+                    return b;
+                }
+            }
+            return null;
+        }
+
+        public String getValue() {
+            return value;
+        }
+
+        @Override
+        public String toString() {
+            return String.valueOf(value);
+        }
+    }
 }

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/model/DraftDocument.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/model/DraftDocument.java
@@ -7,85 +7,80 @@ package ru.skbkontur.sdk.extern.model;
 
 import java.util.UUID;
 
+
 /**
- *
  * @author AlexS
  */
 public class DraftDocument {
 
-	private UUID id = null;
-	private Link decryptedContentLink = null;
-	private Link encryptedContentLink = null;
-	private Link signatureContentLink = null;
-	private DocumentDescription documentDescription = null;
+    private UUID id = null;
+    private Link decryptedContentLink = null;
+    private Link encryptedContentLink = null;
+    private Link signatureContentLink = null;
+    private DocumentDescription documentDescription = null;
 
-	/**
-	 * Get id
-	 *
-	 * @return id
-	 *
-	 */
-	public UUID getId() {
-		return id;
-	}
+    /**
+     * Get id
+     *
+     * @return id
+     */
+    public UUID getId() {
+        return id;
+    }
 
-	public void setId(UUID id) {
-		this.id = id;
-	}
+    public void setId(UUID id) {
+        this.id = id;
+    }
 
-	/**
-	 * Get decryptedContentLink
-	 *
-	 * @return decryptedContentLink
-	 *
-	 */
-	public Link getDecryptedContentLink() {
-		return decryptedContentLink;
-	}
+    /**
+     * Get decryptedContentLink
+     *
+     * @return decryptedContentLink
+     */
+    public Link getDecryptedContentLink() {
+        return decryptedContentLink;
+    }
 
-	public void setDecryptedContentLink(Link decryptedContentLink) {
-		this.decryptedContentLink = decryptedContentLink;
-	}
+    public void setDecryptedContentLink(Link decryptedContentLink) {
+        this.decryptedContentLink = decryptedContentLink;
+    }
 
-	/**
-	 * Get encryptedContentLink
-	 *
-	 * @return encryptedContentLink
-	 *
-	 */
-	public Link getEncryptedContentLink() {
-		return encryptedContentLink;
-	}
+    /**
+     * Get encryptedContentLink
+     *
+     * @return encryptedContentLink
+     */
+    public Link getEncryptedContentLink() {
+        return encryptedContentLink;
+    }
 
-	public void setEncryptedContentLink(Link encryptedContentLink) {
-		this.encryptedContentLink = encryptedContentLink;
-	}
+    public void setEncryptedContentLink(Link encryptedContentLink) {
+        this.encryptedContentLink = encryptedContentLink;
+    }
 
-	/**
-	 * Get signatureContentLink
-	 *
-	 * @return signatureContentLink
-	 *
-	 */
-	public Link getSignatureContentLink() {
-		return signatureContentLink;
-	}
+    /**
+     * Get signatureContentLink
+     *
+     * @return signatureContentLink
+     */
+    public Link getSignatureContentLink() {
+        return signatureContentLink;
+    }
 
-	public void setSignatureContentLink(Link signatureContentLink) {
-		this.signatureContentLink = signatureContentLink;
-	}
+    public void setSignatureContentLink(Link signatureContentLink) {
+        this.signatureContentLink = signatureContentLink;
+    }
 
-	/**
-	 * Get meta
-	 *
-	 * @return meta
-	 *
-	 */
-	public DocumentDescription getDocumentDescription() {
-		return documentDescription;
-	}
+    /**
+     * Get meta
+     *
+     * @return meta
+     */
+    public DocumentDescription getDocumentDescription() {
+        return documentDescription;
+    }
 
-	public void setDocumentDescription(DocumentDescription documentDescription) {
-		this.documentDescription = documentDescription;
-	}
+    public void setDocumentDescription(DocumentDescription documentDescription) {
+        this.documentDescription = documentDescription;
+    }
 }

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/model/DraftDocument.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/model/DraftDocument.java
@@ -1,8 +1,27 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * MIT License
+ *
+ * Copyright (c) 2018 SKB Kontur
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  */
+
 package ru.skbkontur.sdk.extern.model;
 
 import java.util.UUID;

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/model/DraftMeta.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/model/DraftMeta.java
@@ -1,8 +1,27 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * MIT License
+ *
+ * Copyright (c) 2018 SKB Kontur
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  */
+
 package ru.skbkontur.sdk.extern.model;
 
 import com.google.gson.annotations.SerializedName;

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/model/DraftMeta.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/model/DraftMeta.java
@@ -7,48 +7,49 @@ package ru.skbkontur.sdk.extern.model;
 
 import com.google.gson.annotations.SerializedName;
 
+
 /**
- *
  * @author AlexS
  */
 public class DraftMeta {
-	@SerializedName("sender")
-	private Sender sender;
-	@SerializedName("recipient")
-	private Recipient recipient;
-	@SerializedName("payer")
-	private Organization payer;
 
-	public DraftMeta() {
-	}	
-	
-	public DraftMeta(Sender sender, Recipient recipient, Organization payer) {
-		this.sender = sender;
-		this.recipient = recipient;
-		this.payer = payer;
-	}
-	
-	public Sender getSender() {
-		return sender;
-	}
+    @SerializedName("sender")
+    private Sender sender;
+    @SerializedName("recipient")
+    private Recipient recipient;
+    @SerializedName("payer")
+    private Organization payer;
 
-	public void setSender(Sender sender) {
-		this.sender = sender;
-	}
+    public DraftMeta() {
+    }
 
-	public Recipient getRecipient() {
-		return recipient;
-	}
+    public DraftMeta(Sender sender, Recipient recipient, Organization payer) {
+        this.sender = sender;
+        this.recipient = recipient;
+        this.payer = payer;
+    }
 
-	public void setRecipient(Recipient recipient) {
-		this.recipient = recipient;
-	}
+    public Sender getSender() {
+        return sender;
+    }
 
-	public Organization getPayer() {
-		return payer;
-	}
+    public void setSender(Sender sender) {
+        this.sender = sender;
+    }
 
-	public void setPayer(Organization payer) {
-		this.payer = payer;
-	}
+    public Recipient getRecipient() {
+        return recipient;
+    }
+
+    public void setRecipient(Recipient recipient) {
+        this.recipient = recipient;
+    }
+
+    public Organization getPayer() {
+        return payer;
+    }
+
+    public void setPayer(Organization payer) {
+        this.payer = payer;
+    }
 }

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/model/FnsRecipient.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/model/FnsRecipient.java
@@ -6,25 +6,25 @@
 package ru.skbkontur.sdk.extern.model;
 
 /**
- *
  * @author AlexS
  */
 public class FnsRecipient implements Recipient {
-	private String ifnsCode;
 
-	public FnsRecipient() {
-	}
-	
-	public FnsRecipient(String ifnsCode) {
-		this.ifnsCode = ifnsCode;
-	}
-	
-	public String getIfnsCode() {
-		return ifnsCode;
-	}
-	
-	public void setIfnsCode(String ifnsCode) {
-		this.ifnsCode = ifnsCode;
-	}
-	
+    private String ifnsCode;
+
+    public FnsRecipient() {
+    }
+
+    public FnsRecipient(String ifnsCode) {
+        this.ifnsCode = ifnsCode;
+    }
+
+    public String getIfnsCode() {
+        return ifnsCode;
+    }
+
+    public void setIfnsCode(String ifnsCode) {
+        this.ifnsCode = ifnsCode;
+    }
+
 }

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/model/FnsRecipient.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/model/FnsRecipient.java
@@ -1,8 +1,27 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * MIT License
+ *
+ * Copyright (c) 2018 SKB Kontur
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  */
+
 package ru.skbkontur.sdk.extern.model;
 
 /**

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/model/Link.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/model/Link.java
@@ -6,62 +6,62 @@
 package ru.skbkontur.sdk.extern.model;
 
 /**
- *
  * @author AlexS
  */
 public class Link {
-  private String href = null;
-  private String rel = null;
-  private String name = null;
-  private String title = null;
-  private String profile = null;
-  private Boolean templated = null;
 
-	public String getHref() {
-		return href;
-	}
+    private String href = null;
+    private String rel = null;
+    private String name = null;
+    private String title = null;
+    private String profile = null;
+    private Boolean templated = null;
 
-	public void setHref(String href) {
-		this.href = href;
-	}
+    public String getHref() {
+        return href;
+    }
 
-	public String getRel() {
-		return rel;
-	}
+    public void setHref(String href) {
+        this.href = href;
+    }
 
-	public void setRel(String rel) {
-		this.rel = rel;
-	}
+    public String getRel() {
+        return rel;
+    }
 
-	public String getName() {
-		return name;
-	}
+    public void setRel(String rel) {
+        this.rel = rel;
+    }
 
-	public void setName(String name) {
-		this.name = name;
-	}
+    public String getName() {
+        return name;
+    }
 
-	public String getTitle() {
-		return title;
-	}
+    public void setName(String name) {
+        this.name = name;
+    }
 
-	public void setTitle(String title) {
-		this.title = title;
-	}
+    public String getTitle() {
+        return title;
+    }
 
-	public String getProfile() {
-		return profile;
-	}
+    public void setTitle(String title) {
+        this.title = title;
+    }
 
-	public void setProfile(String profile) {
-		this.profile = profile;
-	}
+    public String getProfile() {
+        return profile;
+    }
 
-	public Boolean getTemplated() {
-		return templated;
-	}
+    public void setProfile(String profile) {
+        this.profile = profile;
+    }
 
-	public void setTemplated(Boolean templated) {
-		this.templated = templated;
-	}
+    public Boolean getTemplated() {
+        return templated;
+    }
+
+    public void setTemplated(Boolean templated) {
+        this.templated = templated;
+    }
 }

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/model/Link.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/model/Link.java
@@ -1,8 +1,27 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * MIT License
+ *
+ * Copyright (c) 2018 SKB Kontur
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  */
+
 package ru.skbkontur.sdk.extern.model;
 
 /**

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/model/MerchantTax.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/model/MerchantTax.java
@@ -6,44 +6,44 @@
 package ru.skbkontur.sdk.extern.model;
 
 /**
- *
  * @author alexs
  */
 public class MerchantTax {
-  private String dohod = null;
-  private String ischisl = null;
-  private String torgSborFact = null;
-  private String torgSborUmen = null;
 
-	public String getDohod() {
-		return dohod;
-	}
+    private String dohod = null;
+    private String ischisl = null;
+    private String torgSborFact = null;
+    private String torgSborUmen = null;
 
-	public void setDohod(String dohod) {
-		this.dohod = dohod;
-	}
+    public String getDohod() {
+        return dohod;
+    }
 
-	public String getIschisl() {
-		return ischisl;
-	}
+    public void setDohod(String dohod) {
+        this.dohod = dohod;
+    }
 
-	public void setIschisl(String ischisl) {
-		this.ischisl = ischisl;
-	}
+    public String getIschisl() {
+        return ischisl;
+    }
 
-	public String getTorgSborFact() {
-		return torgSborFact;
-	}
+    public void setIschisl(String ischisl) {
+        this.ischisl = ischisl;
+    }
 
-	public void setTorgSborFact(String torgSborFact) {
-		this.torgSborFact = torgSborFact;
-	}
+    public String getTorgSborFact() {
+        return torgSborFact;
+    }
 
-	public String getTorgSborUmen() {
-		return torgSborUmen;
-	}
+    public void setTorgSborFact(String torgSborFact) {
+        this.torgSborFact = torgSborFact;
+    }
 
-	public void setTorgSborUmen(String torgSborUmen) {
-		this.torgSborUmen = torgSborUmen;
-	}
+    public String getTorgSborUmen() {
+        return torgSborUmen;
+    }
+
+    public void setTorgSborUmen(String torgSborUmen) {
+        this.torgSborUmen = torgSborUmen;
+    }
 }

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/model/MerchantTax.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/model/MerchantTax.java
@@ -1,8 +1,27 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * MIT License
+ *
+ * Copyright (c) 2018 SKB Kontur
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  */
+
 package ru.skbkontur.sdk.extern.model;
 
 /**

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/model/MerchatTax.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/model/MerchatTax.java
@@ -1,8 +1,27 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * MIT License
+ *
+ * Copyright (c) 2018 SKB Kontur
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  */
+
 package ru.skbkontur.sdk.extern.model;
 
 /**

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/model/MerchatTax.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/model/MerchatTax.java
@@ -6,9 +6,8 @@
 package ru.skbkontur.sdk.extern.model;
 
 /**
- *
  * @author alexs
  */
 public class MerchatTax {
-	
+
 }

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/model/Organization.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/model/Organization.java
@@ -6,33 +6,33 @@
 package ru.skbkontur.sdk.extern.model;
 
 /**
- *
  * @author AlexS
  */
 public class Organization {
-	private String inn;
-	private String kpp;
 
-	public Organization(String inn, String kpp) {
-		this.inn = inn;
-		this.kpp = kpp;
-	}
-	
-	public String getInn() {
-		return inn;
-	}
+    private String inn;
+    private String kpp;
 
-	public void setInn(String inn) {
-		this.inn = inn;
-	}
+    public Organization(String inn, String kpp) {
+        this.inn = inn;
+        this.kpp = kpp;
+    }
 
-	public String getKpp() {
-		return kpp;
-	}
+    public String getInn() {
+        return inn;
+    }
 
-	public void setKpp(String kpp) {
-		this.kpp = kpp;
-	}
-	
-	
+    public void setInn(String inn) {
+        this.inn = inn;
+    }
+
+    public String getKpp() {
+        return kpp;
+    }
+
+    public void setKpp(String kpp) {
+        this.kpp = kpp;
+    }
+
+
 }

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/model/Organization.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/model/Organization.java
@@ -1,8 +1,27 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * MIT License
+ *
+ * Copyright (c) 2018 SKB Kontur
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  */
+
 package ru.skbkontur.sdk.extern.model;
 
 /**

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/model/PassportInfo.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/model/PassportInfo.java
@@ -7,49 +7,50 @@ package ru.skbkontur.sdk.extern.model;
 
 import org.joda.time.DateTime;
 
+
 /**
- *
  * @author alexs
  */
 public class PassportInfo {
-  private String code = null;
 
-  private String seriesNumber = null;
+    private String code = null;
 
-  private DateTime issuedDate = null;
+    private String seriesNumber = null;
 
-  private String issuedBy = null;
+    private DateTime issuedDate = null;
 
-	public String getCode() {
-		return code;
-	}
+    private String issuedBy = null;
 
-	public void setCode(String code) {
-		this.code = code;
-	}
+    public String getCode() {
+        return code;
+    }
 
-	public String getSeriesNumber() {
-		return seriesNumber;
-	}
+    public void setCode(String code) {
+        this.code = code;
+    }
 
-	public void setSeriesNumber(String seriesNumber) {
-		this.seriesNumber = seriesNumber;
-	}
+    public String getSeriesNumber() {
+        return seriesNumber;
+    }
 
-	public DateTime getIssuedDate() {
-		return issuedDate;
-	}
+    public void setSeriesNumber(String seriesNumber) {
+        this.seriesNumber = seriesNumber;
+    }
 
-	public void setIssuedDate(DateTime issuedDate) {
-		this.issuedDate = issuedDate;
-	}
+    public DateTime getIssuedDate() {
+        return issuedDate;
+    }
 
-	public String getIssuedBy() {
-		return issuedBy;
-	}
+    public void setIssuedDate(DateTime issuedDate) {
+        this.issuedDate = issuedDate;
+    }
 
-	public void setIssuedBy(String issuedBy) {
-		this.issuedBy = issuedBy;
-	}
+    public String getIssuedBy() {
+        return issuedBy;
+    }
+
+    public void setIssuedBy(String issuedBy) {
+        this.issuedBy = issuedBy;
+    }
 
 }

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/model/PassportInfo.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/model/PassportInfo.java
@@ -1,8 +1,27 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * MIT License
+ *
+ * Copyright (c) 2018 SKB Kontur
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  */
+
 package ru.skbkontur.sdk.extern.model;
 
 import org.joda.time.DateTime;

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/model/PeriodIndicators.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/model/PeriodIndicators.java
@@ -6,89 +6,89 @@
 package ru.skbkontur.sdk.extern.model;
 
 /**
- *
  * @author alexs
  */
 public class PeriodIndicators {
-  protected String oktmo = null;
-  protected String avPu = null;
-  protected String dohod = null;
-  protected String rashod = null;
-  protected String nalBazaUbyt = null;
-  protected String stavka = null;
-  protected String ischisl = null;
-  protected String umenNal = null;
-  protected MerchantTax raschTorgSbor = null;
 
-	public String getOktmo() {
-		return oktmo;
-	}
+    protected String oktmo = null;
+    protected String avPu = null;
+    protected String dohod = null;
+    protected String rashod = null;
+    protected String nalBazaUbyt = null;
+    protected String stavka = null;
+    protected String ischisl = null;
+    protected String umenNal = null;
+    protected MerchantTax raschTorgSbor = null;
 
-	public void setOktmo(String oktmo) {
-		this.oktmo = oktmo;
-	}
+    public String getOktmo() {
+        return oktmo;
+    }
 
-	public String getAvPu() {
-		return avPu;
-	}
+    public void setOktmo(String oktmo) {
+        this.oktmo = oktmo;
+    }
 
-	public void setAvPu(String avPu) {
-		this.avPu = avPu;
-	}
+    public String getAvPu() {
+        return avPu;
+    }
 
-	public String getDohod() {
-		return dohod;
-	}
+    public void setAvPu(String avPu) {
+        this.avPu = avPu;
+    }
 
-	public void setDohod(String dohod) {
-		this.dohod = dohod;
-	}
+    public String getDohod() {
+        return dohod;
+    }
 
-	public String getRashod() {
-		return rashod;
-	}
+    public void setDohod(String dohod) {
+        this.dohod = dohod;
+    }
 
-	public void setRashod(String rashod) {
-		this.rashod = rashod;
-	}
+    public String getRashod() {
+        return rashod;
+    }
 
-	public String getNalBazaUbyt() {
-		return nalBazaUbyt;
-	}
+    public void setRashod(String rashod) {
+        this.rashod = rashod;
+    }
 
-	public void setNalBazaUbyt(String nalBazaUbyt) {
-		this.nalBazaUbyt = nalBazaUbyt;
-	}
+    public String getNalBazaUbyt() {
+        return nalBazaUbyt;
+    }
 
-	public String getStavka() {
-		return stavka;
-	}
+    public void setNalBazaUbyt(String nalBazaUbyt) {
+        this.nalBazaUbyt = nalBazaUbyt;
+    }
 
-	public void setStavka(String stavka) {
-		this.stavka = stavka;
-	}
+    public String getStavka() {
+        return stavka;
+    }
 
-	public String getIschisl() {
-		return ischisl;
-	}
+    public void setStavka(String stavka) {
+        this.stavka = stavka;
+    }
 
-	public void setIschisl(String ischisl) {
-		this.ischisl = ischisl;
-	}
+    public String getIschisl() {
+        return ischisl;
+    }
 
-	public String getUmenNal() {
-		return umenNal;
-	}
+    public void setIschisl(String ischisl) {
+        this.ischisl = ischisl;
+    }
 
-	public void setUmenNal(String umenNal) {
-		this.umenNal = umenNal;
-	}
+    public String getUmenNal() {
+        return umenNal;
+    }
 
-	public MerchantTax getRaschTorgSbor() {
-		return raschTorgSbor;
-	}
+    public void setUmenNal(String umenNal) {
+        this.umenNal = umenNal;
+    }
 
-	public void setRaschTorgSbor(MerchantTax raschTorgSbor) {
-		this.raschTorgSbor = raschTorgSbor;
-	}
+    public MerchantTax getRaschTorgSbor() {
+        return raschTorgSbor;
+    }
+
+    public void setRaschTorgSbor(MerchantTax raschTorgSbor) {
+        this.raschTorgSbor = raschTorgSbor;
+    }
 }

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/model/PeriodIndicators.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/model/PeriodIndicators.java
@@ -1,8 +1,27 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * MIT License
+ *
+ * Copyright (c) 2018 SKB Kontur
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  */
+
 package ru.skbkontur.sdk.extern.model;
 
 /**

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/model/PrepareResult.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/model/PrepareResult.java
@@ -1,8 +1,27 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * MIT License
+ *
+ * Copyright (c) 2018 SKB Kontur
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  */
+
 package ru.skbkontur.sdk.extern.model;
 
 import java.util.List;

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/model/PrepareResult.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/model/PrepareResult.java
@@ -7,72 +7,72 @@ package ru.skbkontur.sdk.extern.model;
 
 import java.util.List;
 
+
 /**
- *
  * @author AlexS
  */
 public class PrepareResult {
-	
-  public enum Status {
-    CHECKPROTOCOLHASERRORS("checkProtocolHasErrors"),
-    
-    CHECKPROTOCOLHASONLYWARNINGS("checkProtocolHasOnlyWarnings"),
-    
-    ENCRYPTIONFAILED("encryptionFailed"),
-    
-    OK("ok");
 
-    private final String value;
+    private CheckResultData checkResult = null;
+    private List<Link> links = null;
+    private Status status = null;
 
-    Status(String value) {
-      this.value = value;
+    public CheckResultData getCheckResult() {
+        return checkResult;
     }
 
-    public String getValue() {
-      return value;
+    public void setCheckResult(CheckResultData checkResult) {
+        this.checkResult = checkResult;
     }
 
-    @Override
-    public String toString() {
-      return String.valueOf(value);
+    public List<Link> getLinks() {
+        return links;
     }
 
-    public static Status fromValue(String text) {
-      for (Status b : Status.values()) {
-        if (String.valueOf(b.value).equals(text)) {
-          return b;
+    public void setLinks(List<Link> links) {
+        this.links = links;
+    }
+
+    public Status getStatus() {
+        return status;
+    }
+
+    public void setStatus(Status status) {
+        this.status = status;
+    }
+
+    public enum Status {
+        CHECKPROTOCOLHASERRORS("checkProtocolHasErrors"),
+
+        CHECKPROTOCOLHASONLYWARNINGS("checkProtocolHasOnlyWarnings"),
+
+        ENCRYPTIONFAILED("encryptionFailed"),
+
+        OK("ok");
+
+        private final String value;
+
+        Status(String value) {
+            this.value = value;
         }
-      }
-      return null;
+
+        public static Status fromValue(String text) {
+            for (Status b : Status.values()) {
+                if (String.valueOf(b.value).equals(text)) {
+                    return b;
+                }
+            }
+            return null;
+        }
+
+        public String getValue() {
+            return value;
+        }
+
+        @Override
+        public String toString() {
+            return String.valueOf(value);
+        }
     }
-	}
-		
-  private CheckResultData checkResult = null;
-  private List<Link> links = null;
-  private Status status = null;
-
-	public CheckResultData getCheckResult() {
-		return checkResult;
-	}
-
-	public void setCheckResult(CheckResultData checkResult) {
-		this.checkResult = checkResult;
-	}
-
-	public List<Link> getLinks() {
-		return links;
-	}
-
-	public void setLinks(List<Link> links) {
-		this.links = links;
-	}
-
-	public Status getStatus() {
-		return status;
-	}
-	
-  public void setStatus(Status status) {
-    this.status = status;
-  }
 
 }

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/model/Recipient.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/model/Recipient.java
@@ -6,9 +6,8 @@
 package ru.skbkontur.sdk.extern.model;
 
 /**
- *
  * @author AlexS
  */
 public interface Recipient {
-	
+
 }

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/model/Recipient.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/model/Recipient.java
@@ -1,8 +1,27 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * MIT License
+ *
+ * Copyright (c) 2018 SKB Kontur
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  */
+
 package ru.skbkontur.sdk.extern.model;
 
 /**

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/model/Representative.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/model/Representative.java
@@ -6,28 +6,28 @@
 package ru.skbkontur.sdk.extern.model;
 
 /**
- *
  * @author alexs
  */
 public class Representative {
-  private String representativeDocument = null;
 
-  private PassportInfo passport = null;
+    private String representativeDocument = null;
 
-	public String getRepresentativeDocument() {
-		return representativeDocument;
-	}
+    private PassportInfo passport = null;
 
-	public void setRepresentativeDocument(String representativeDocument) {
-		this.representativeDocument = representativeDocument;
-	}
+    public String getRepresentativeDocument() {
+        return representativeDocument;
+    }
 
-	public PassportInfo getPassport() {
-		return passport;
-	}
+    public void setRepresentativeDocument(String representativeDocument) {
+        this.representativeDocument = representativeDocument;
+    }
 
-	public void setPassport(PassportInfo passport) {
-		this.passport = passport;
-	}
+    public PassportInfo getPassport() {
+        return passport;
+    }
+
+    public void setPassport(PassportInfo passport) {
+        this.passport = passport;
+    }
 
 }

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/model/Representative.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/model/Representative.java
@@ -1,8 +1,27 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * MIT License
+ *
+ * Copyright (c) 2018 SKB Kontur
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  */
+
 package ru.skbkontur.sdk.extern.model;
 
 /**

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/model/Sender.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/model/Sender.java
@@ -1,8 +1,27 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * MIT License
+ *
+ * Copyright (c) 2018 SKB Kontur
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  */
+
 package ru.skbkontur.sdk.extern.model;
 
 import com.google.gson.annotations.SerializedName;

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/model/Sender.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/model/Sender.java
@@ -7,69 +7,70 @@ package ru.skbkontur.sdk.extern.model;
 
 import com.google.gson.annotations.SerializedName;
 
+
 /**
- *
  * @author AlexS
  */
 public class Sender {
-	@SerializedName("inn")
-	private String inn;
-	@SerializedName("kpp")
-	private String kpp;
-	@SerializedName("certificate")
-	private String certificate;
-	@SerializedName("ipaddress")
-	private String ipaddress;
-	
-	private String thumbprint;
 
-	public Sender() {
-	}
+    @SerializedName("inn")
+    private String inn;
+    @SerializedName("kpp")
+    private String kpp;
+    @SerializedName("certificate")
+    private String certificate;
+    @SerializedName("ipaddress")
+    private String ipaddress;
 
-	public Sender(String inn, String kpp, String certificate, String ipaddress) {
-		this.inn = inn;
-		this.kpp = kpp;
-		this.certificate = certificate;
-		this.ipaddress = ipaddress;
-	}
-	
-	public String getInn() {
-		return inn;
-	}
+    private String thumbprint;
 
-	public void setInn(String inn) {
-		this.inn = inn;
-	}
+    public Sender() {
+    }
 
-	public String getKpp() {
-		return kpp;
-	}
+    public Sender(String inn, String kpp, String certificate, String ipaddress) {
+        this.inn = inn;
+        this.kpp = kpp;
+        this.certificate = certificate;
+        this.ipaddress = ipaddress;
+    }
 
-	public void setKpp(String kpp) {
-		this.kpp = kpp;
-	}
+    public String getInn() {
+        return inn;
+    }
 
-	public String getCertificate() {
-		return certificate;
-	}
+    public void setInn(String inn) {
+        this.inn = inn;
+    }
 
-	public void setCertificate(String certificate) {
-		this.certificate = certificate;
-	}
+    public String getKpp() {
+        return kpp;
+    }
 
-  public String getIpaddress() {
-    return ipaddress;
-  }
+    public void setKpp(String kpp) {
+        this.kpp = kpp;
+    }
 
-  public void setIpaddress(String ipaddress) {
-    this.ipaddress = ipaddress;
-  }
+    public String getCertificate() {
+        return certificate;
+    }
 
-	public String getThumbprint() {
-		return thumbprint;
-	}
+    public void setCertificate(String certificate) {
+        this.certificate = certificate;
+    }
 
-	public void setThumbprint(String thumbprint) {
-		this.thumbprint = thumbprint;
-	}
+    public String getIpaddress() {
+        return ipaddress;
+    }
+
+    public void setIpaddress(String ipaddress) {
+        this.ipaddress = ipaddress;
+    }
+
+    public String getThumbprint() {
+        return thumbprint;
+    }
+
+    public void setThumbprint(String thumbprint) {
+        this.thumbprint = thumbprint;
+    }
 }

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/model/Signature.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/model/Signature.java
@@ -1,8 +1,27 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * MIT License
+ *
+ * Copyright (c) 2018 SKB Kontur
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  */
+
 package ru.skbkontur.sdk.extern.model;
 
 import java.util.List;

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/model/Signature.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/model/Signature.java
@@ -7,72 +7,68 @@ package ru.skbkontur.sdk.extern.model;
 
 import java.util.List;
 import java.util.UUID;
-import ru.skbkontur.sdk.extern.model.Link;
+
 
 /**
- *
  * @author AlexS
  */
 public class Signature {
 
-	private UUID id = null;
-	private Link contentLink = null;
-	private List<Link> links = null;
+    private UUID id = null;
+    private Link contentLink = null;
+    private List<Link> links = null;
 
-	public Signature id(UUID id) {
-		this.id = id;
-		return this;
-	}
+    public Signature id(UUID id) {
+        this.id = id;
+        return this;
+    }
 
-	/**
-	 * Get id
-	 *
-	 * @return id
-	 *
-	 */
-	public UUID getId() {
-		return id;
-	}
+    /**
+     * Get id
+     *
+     * @return id
+     */
+    public UUID getId() {
+        return id;
+    }
 
-	public void setId(UUID id) {
-		this.id = id;
-	}
+    public void setId(UUID id) {
+        this.id = id;
+    }
 
-	public Signature contentLink(Link contentLink) {
-		this.contentLink = contentLink;
-		return this;
-	}
+    public Signature contentLink(Link contentLink) {
+        this.contentLink = contentLink;
+        return this;
+    }
 
-	/**
-	 * Get contentLink
-	 *
-	 * @return contentLink
-	 *
-	 */
-	public Link getContentLink() {
-		return contentLink;
-	}
+    /**
+     * Get contentLink
+     *
+     * @return contentLink
+     */
+    public Link getContentLink() {
+        return contentLink;
+    }
 
-	public void setContentLink(Link contentLink) {
-		this.contentLink = contentLink;
-	}
+    public void setContentLink(Link contentLink) {
+        this.contentLink = contentLink;
+    }
 
-	public Signature links(List<Link> links) {
-		this.links = links;
-		return this;
-	}
+    public Signature links(List<Link> links) {
+        this.links = links;
+        return this;
+    }
 
-	/**
-	 * Get links
-	 *
-	 * @return links
-	 *
-	 */
-	public List<Link> getLinks() {
-		return links;
-	}
+    /**
+     * Get links
+     *
+     * @return links
+     */
+    public List<Link> getLinks() {
+        return links;
+    }
 
-	public void setLinks(List<Link> links) {
-		this.links = links;
-	}
+    public void setLinks(List<Link> links) {
+        this.links = links;
+    }
 }

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/model/SignatureToSend.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/model/SignatureToSend.java
@@ -1,8 +1,27 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * MIT License
+ *
+ * Copyright (c) 2018 SKB Kontur
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  */
+
 package ru.skbkontur.sdk.extern.model;
 
 import com.google.gson.annotations.SerializedName;

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/model/SignatureToSend.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/model/SignatureToSend.java
@@ -6,48 +6,47 @@
 package ru.skbkontur.sdk.extern.model;
 
 import com.google.gson.annotations.SerializedName;
+
 import java.util.UUID;
 
+
 /**
- *
  * @author AlexS
  */
 public class SignatureToSend {
 
-	@SerializedName("id")
-	private UUID id = null;
-	@SerializedName("content-data")
-	private byte[] contentData = null;
+    @SerializedName("id")
+    private UUID id = null;
+    @SerializedName("content-data")
+    private byte[] contentData = null;
 
-	/**
-	 * Get id
-	 *
-	 * @return id
-	 *
-	 */
-	public UUID getId() {
-		return id;
-	}
+    /**
+     * Get id
+     *
+     * @return id
+     */
+    public UUID getId() {
+        return id;
+    }
 
-	public void setId(UUID id) {
-		this.id = id;
-	}
+    public void setId(String id) {
+        this.id = UUID.fromString(id);
+    }
 
-	public void setId(String id) {
-		this.id = UUID.fromString(id);
-	}
+    public void setId(UUID id) {
+        this.id = id;
+    }
 
-	/**
-	 * Get contentData
-	 *
-	 * @return contentData
-	 *
-	 */
-	public byte[] getContentData() {
-		return contentData;
-	}
+    /**
+     * Get contentData
+     *
+     * @return contentData
+     */
+    public byte[] getContentData() {
+        return contentData;
+    }
 
-	public void setContentData(byte[] contentData) {
-		this.contentData = contentData;
-	}
+    public void setContentData(byte[] contentData) {
+        this.contentData = contentData;
+    }
 }

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/model/TaxPeriodIndicators.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/model/TaxPeriodIndicators.java
@@ -6,33 +6,33 @@
 package ru.skbkontur.sdk.extern.model;
 
 /**
- *
  * @author alexs
  */
 public class TaxPeriodIndicators extends PeriodIndicators {
-  private String nalPumin = null;
 
-	public TaxPeriodIndicators(String nalPumin,PeriodIndicators p) {
-		this.nalPumin = nalPumin;
-		this.avPu = p.getAvPu();
-		this.dohod = p.getDohod();
-		this.ischisl = p.getIschisl();
-		this.nalBazaUbyt = p.getNalBazaUbyt();
-		this.oktmo = p.getOktmo();
-		this.raschTorgSbor = p.getRaschTorgSbor();
-		this.rashod = p.getRashod();
-		this.stavka = p.getStavka();
-		this.umenNal = p.getUmenNal();
-	}
+    private String nalPumin = null;
 
-	public TaxPeriodIndicators() {
-	}
+    public TaxPeriodIndicators(String nalPumin, PeriodIndicators p) {
+        this.nalPumin = nalPumin;
+        this.avPu = p.getAvPu();
+        this.dohod = p.getDohod();
+        this.ischisl = p.getIschisl();
+        this.nalBazaUbyt = p.getNalBazaUbyt();
+        this.oktmo = p.getOktmo();
+        this.raschTorgSbor = p.getRaschTorgSbor();
+        this.rashod = p.getRashod();
+        this.stavka = p.getStavka();
+        this.umenNal = p.getUmenNal();
+    }
 
-	public String getNalPumin() {
-		return nalPumin;
-	}
+    public TaxPeriodIndicators() {
+    }
 
-	public void setNalPumin(String nalPumin) {
-		this.nalPumin = nalPumin;
-	}
+    public String getNalPumin() {
+        return nalPumin;
+    }
+
+    public void setNalPumin(String nalPumin) {
+        this.nalPumin = nalPumin;
+    }
 }

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/model/TaxPeriodIndicators.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/model/TaxPeriodIndicators.java
@@ -1,8 +1,27 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * MIT License
+ *
+ * Copyright (c) 2018 SKB Kontur
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  */
+
 package ru.skbkontur.sdk.extern.model;
 
 /**

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/model/Taxpayer.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/model/Taxpayer.java
@@ -6,57 +6,57 @@
 package ru.skbkontur.sdk.extern.model;
 
 /**
- *
  * @author alexs
  */
 public class Taxpayer {
-  private String taxpayerChiefFio = null;
 
-  private Representative representative = null;
+    private String taxpayerChiefFio = null;
 
-  private String taxpayerPhone = null;
+    private Representative representative = null;
 
-  private String taxpayerOkved = null;
+    private String taxpayerPhone = null;
 
-  private String taxpayerFullName = null;
+    private String taxpayerOkved = null;
 
-	public String getTaxpayerChiefFio() {
-		return taxpayerChiefFio;
-	}
+    private String taxpayerFullName = null;
 
-	public void setTaxpayerChiefFio(String taxpayerChiefFio) {
-		this.taxpayerChiefFio = taxpayerChiefFio;
-	}
+    public String getTaxpayerChiefFio() {
+        return taxpayerChiefFio;
+    }
 
-	public Representative getRepresentative() {
-		return representative;
-	}
+    public void setTaxpayerChiefFio(String taxpayerChiefFio) {
+        this.taxpayerChiefFio = taxpayerChiefFio;
+    }
 
-	public void setRepresentative(Representative representative) {
-		this.representative = representative;
-	}
+    public Representative getRepresentative() {
+        return representative;
+    }
 
-	public String getTaxpayerPhone() {
-		return taxpayerPhone;
-	}
+    public void setRepresentative(Representative representative) {
+        this.representative = representative;
+    }
 
-	public void setTaxpayerPhone(String taxpayerPhone) {
-		this.taxpayerPhone = taxpayerPhone;
-	}
+    public String getTaxpayerPhone() {
+        return taxpayerPhone;
+    }
 
-	public String getTaxpayerOkved() {
-		return taxpayerOkved;
-	}
+    public void setTaxpayerPhone(String taxpayerPhone) {
+        this.taxpayerPhone = taxpayerPhone;
+    }
 
-	public void setTaxpayerOkved(String taxpayerOkved) {
-		this.taxpayerOkved = taxpayerOkved;
-	}
+    public String getTaxpayerOkved() {
+        return taxpayerOkved;
+    }
 
-	public String getTaxpayerFullName() {
-		return taxpayerFullName;
-	}
+    public void setTaxpayerOkved(String taxpayerOkved) {
+        this.taxpayerOkved = taxpayerOkved;
+    }
 
-	public void setTaxpayerFullName(String taxpayerFullName) {
-		this.taxpayerFullName = taxpayerFullName;
-	}
+    public String getTaxpayerFullName() {
+        return taxpayerFullName;
+    }
+
+    public void setTaxpayerFullName(String taxpayerFullName) {
+        this.taxpayerFullName = taxpayerFullName;
+    }
 }

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/model/Taxpayer.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/model/Taxpayer.java
@@ -1,8 +1,27 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * MIT License
+ *
+ * Copyright (c) 2018 SKB Kontur
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  */
+
 package ru.skbkontur.sdk.extern.model;
 
 /**

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/model/Urn.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/model/Urn.java
@@ -6,54 +6,50 @@
 package ru.skbkontur.sdk.extern.model;
 
 /**
- *
  * @author AlexS
  */
 public class Urn {
 
-	private String nid = null;
-	private String nss = null;
-	private String value = null;
+    private String nid = null;
+    private String nss = null;
+    private String value = null;
 
-	/**
-	 * Get nid
-	 *
-	 * @return nid
-	 *
-	 */
-	public String getNid() {
-		return nid;
-	}
+    /**
+     * Get nid
+     *
+     * @return nid
+     */
+    public String getNid() {
+        return nid;
+    }
 
-	public void setNid(String nid) {
-		this.nid = nid;
-	}
-	
-	/**
-	 * Get nss
-	 *
-	 * @return nss
-	 *
-	 */
-	public String getNss() {
-		return nss;
-	}
+    public void setNid(String nid) {
+        this.nid = nid;
+    }
 
-	public void setNss(String nss) {
-		this.nss = nss;
-	}
-	
-	/**
-	 * Get value
-	 *
-	 * @return value
-	 *
-	 */
-	public String getValue() {
-		return value;
-	}
+    /**
+     * Get nss
+     *
+     * @return nss
+     */
+    public String getNss() {
+        return nss;
+    }
 
-	public void setValue(String value) {
-		this.value = value;
-	}
+    public void setNss(String nss) {
+        this.nss = nss;
+    }
+
+    /**
+     * Get value
+     *
+     * @return value
+     */
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
 }

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/model/Urn.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/model/Urn.java
@@ -1,8 +1,27 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * MIT License
+ *
+ * Copyright (c) 2018 SKB Kontur
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  */
+
 package ru.skbkontur.sdk.extern.model;
 
 /**

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/model/UsnDataV2.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/model/UsnDataV2.java
@@ -6,90 +6,90 @@
 package ru.skbkontur.sdk.extern.model;
 
 /**
- *
  * @author alexs
  */
 public class UsnDataV2 {
-  private Integer nomKorr = null;
-  private Integer poMestu = null;
-  private Integer prizNp = null;
-  private String ubytPred = null;
-  private String ischislMin = null;
-  private PeriodIndicators zaKv = null;
-  private PeriodIndicators zaPg = null;
-  private PeriodIndicators za9m = null;
-  private TaxPeriodIndicators zaNalPer = null;
 
-	public Integer getNomKorr() {
-		return nomKorr;
-	}
+    private Integer nomKorr = null;
+    private Integer poMestu = null;
+    private Integer prizNp = null;
+    private String ubytPred = null;
+    private String ischislMin = null;
+    private PeriodIndicators zaKv = null;
+    private PeriodIndicators zaPg = null;
+    private PeriodIndicators za9m = null;
+    private TaxPeriodIndicators zaNalPer = null;
 
-	public void setNomKorr(Integer nomKorr) {
-		this.nomKorr = nomKorr;
-	}
+    public Integer getNomKorr() {
+        return nomKorr;
+    }
 
-	public Integer getPoMestu() {
-		return poMestu;
-	}
+    public void setNomKorr(Integer nomKorr) {
+        this.nomKorr = nomKorr;
+    }
 
-	public void setPoMestu(Integer poMestu) {
-		this.poMestu = poMestu;
-	}
+    public Integer getPoMestu() {
+        return poMestu;
+    }
 
-	public Integer getPrizNp() {
-		return prizNp;
-	}
+    public void setPoMestu(Integer poMestu) {
+        this.poMestu = poMestu;
+    }
 
-	public void setPrizNp(Integer prizNp) {
-		this.prizNp = prizNp;
-	}
+    public Integer getPrizNp() {
+        return prizNp;
+    }
 
-	public String getUbytPred() {
-		return ubytPred;
-	}
+    public void setPrizNp(Integer prizNp) {
+        this.prizNp = prizNp;
+    }
 
-	public void setUbytPred(String ubytPred) {
-		this.ubytPred = ubytPred;
-	}
+    public String getUbytPred() {
+        return ubytPred;
+    }
 
-	public String getIschislMin() {
-		return ischislMin;
-	}
+    public void setUbytPred(String ubytPred) {
+        this.ubytPred = ubytPred;
+    }
 
-	public void setIschislMin(String ischislMin) {
-		this.ischislMin = ischislMin;
-	}
+    public String getIschislMin() {
+        return ischislMin;
+    }
 
-	public PeriodIndicators getZaKv() {
-		return zaKv;
-	}
+    public void setIschislMin(String ischislMin) {
+        this.ischislMin = ischislMin;
+    }
 
-	public void setZaKv(PeriodIndicators zaKv) {
-		this.zaKv = zaKv;
-	}
+    public PeriodIndicators getZaKv() {
+        return zaKv;
+    }
 
-	public PeriodIndicators getZaPg() {
-		return zaPg;
-	}
+    public void setZaKv(PeriodIndicators zaKv) {
+        this.zaKv = zaKv;
+    }
 
-	public void setZaPg(PeriodIndicators zaPg) {
-		this.zaPg = zaPg;
-	}
+    public PeriodIndicators getZaPg() {
+        return zaPg;
+    }
 
-	public PeriodIndicators getZa9m() {
-		return za9m;
-	}
+    public void setZaPg(PeriodIndicators zaPg) {
+        this.zaPg = zaPg;
+    }
 
-	public void setZa9m(PeriodIndicators za9m) {
-		this.za9m = za9m;
-	}
+    public PeriodIndicators getZa9m() {
+        return za9m;
+    }
 
-	public TaxPeriodIndicators getZaNalPer() {
-		return zaNalPer;
-	}
+    public void setZa9m(PeriodIndicators za9m) {
+        this.za9m = za9m;
+    }
 
-	public void setZaNalPer(TaxPeriodIndicators zaNalPer) {
-		this.zaNalPer = zaNalPer;
-	}
+    public TaxPeriodIndicators getZaNalPer() {
+        return zaNalPer;
+    }
+
+    public void setZaNalPer(TaxPeriodIndicators zaNalPer) {
+        this.zaNalPer = zaNalPer;
+    }
 
 }

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/model/UsnDataV2.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/model/UsnDataV2.java
@@ -1,8 +1,27 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * MIT License
+ *
+ * Copyright (c) 2018 SKB Kontur
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  */
+
 package ru.skbkontur.sdk.extern.model;
 
 /**

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/model/UsnFormatPeriod.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/model/UsnFormatPeriod.java
@@ -6,62 +6,60 @@
 package ru.skbkontur.sdk.extern.model;
 
 /**
- *
  * @author alexs
  */
 public class UsnFormatPeriod {
 
-	public enum PeriodModifiersEnum {
-    NONE("none"),
-    
-    LIQUIDATIONREORGANIZATION("liquidationReorganization"),
-    
-    TAXREGIMECHANGE("taxRegimeChange"),
-    
-    LASTPERIODFORTAXREGIME("lastPeriodForTaxRegime");
+    private PeriodModifiersEnum periodModifiers = null;
+    private Integer year = null;
 
-    private final String value;
-
-    PeriodModifiersEnum(String value) {
-      this.value = value;
+    public PeriodModifiersEnum getPeriodModifiers() {
+        return periodModifiers;
     }
 
-    public String getValue() {
-      return value;
+    public void setPeriodModifiers(PeriodModifiersEnum periodModifiers) {
+        this.periodModifiers = periodModifiers;
     }
 
-    @Override
-    public String toString() {
-      return String.valueOf(value);
+    public Integer getYear() {
+        return year;
     }
 
-    public static PeriodModifiersEnum fromValue(String text) {
-      for (PeriodModifiersEnum b : PeriodModifiersEnum.values()) {
-        if (String.valueOf(b.value).equals(text)) {
-          return b;
+    public void setYear(Integer year) {
+        this.year = year;
+    }
+
+    public enum PeriodModifiersEnum {
+        NONE("none"),
+
+        LIQUIDATIONREORGANIZATION("liquidationReorganization"),
+
+        TAXREGIMECHANGE("taxRegimeChange"),
+
+        LASTPERIODFORTAXREGIME("lastPeriodForTaxRegime");
+
+        private final String value;
+
+        PeriodModifiersEnum(String value) {
+            this.value = value;
         }
-      }
-      return null;
+
+        public static PeriodModifiersEnum fromValue(String text) {
+            for (PeriodModifiersEnum b : PeriodModifiersEnum.values()) {
+                if (String.valueOf(b.value).equals(text)) {
+                    return b;
+                }
+            }
+            return null;
+        }
+
+        public String getValue() {
+            return value;
+        }
+
+        @Override
+        public String toString() {
+            return String.valueOf(value);
+        }
     }
-  }
-
-  private PeriodModifiersEnum periodModifiers = null;
-	
-  private Integer year = null;
-
-	public PeriodModifiersEnum getPeriodModifiers() {
-		return periodModifiers;
-	}
-
-	public void setPeriodModifiers(PeriodModifiersEnum periodModifiers) {
-		this.periodModifiers = periodModifiers;
-	}
-
-	public Integer getYear() {
-		return year;
-	}
-
-	public void setYear(Integer year) {
-		this.year = year;
-	}
 }

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/model/UsnFormatPeriod.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/model/UsnFormatPeriod.java
@@ -1,8 +1,27 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * MIT License
+ *
+ * Copyright (c) 2018 SKB Kontur
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  */
+
 package ru.skbkontur.sdk.extern.model;
 
 /**

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/model/UsnServiceContractInfo.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/model/UsnServiceContractInfo.java
@@ -1,8 +1,27 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * MIT License
+ *
+ * Copyright (c) 2018 SKB Kontur
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  */
+
 package ru.skbkontur.sdk.extern.model;
 
 /**

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/model/UsnServiceContractInfo.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/model/UsnServiceContractInfo.java
@@ -6,36 +6,36 @@
 package ru.skbkontur.sdk.extern.model;
 
 /**
- *
  * @author alexs
  */
 public class UsnServiceContractInfo {
-  private UsnFormatPeriod period = null;
-  private AdditionalClientInfo additionalOrgInfo = null;
-  private Object data = null;
 
-	public UsnFormatPeriod getPeriod() {
-		return period;
-	}
+    private UsnFormatPeriod period = null;
+    private AdditionalClientInfo additionalOrgInfo = null;
+    private Object data = null;
 
-	public void setPeriod(UsnFormatPeriod period) {
-		this.period = period;
-	}
+    public UsnFormatPeriod getPeriod() {
+        return period;
+    }
 
-	public AdditionalClientInfo getAdditionalOrgInfo() {
-		return additionalOrgInfo;
-	}
+    public void setPeriod(UsnFormatPeriod period) {
+        this.period = period;
+    }
 
-	public void setAdditionalOrgInfo(AdditionalClientInfo additionalOrgInfo) {
-		this.additionalOrgInfo = additionalOrgInfo;
-	}
+    public AdditionalClientInfo getAdditionalOrgInfo() {
+        return additionalOrgInfo;
+    }
 
-	public Object getData() {
-		return data;
-	}
+    public void setAdditionalOrgInfo(AdditionalClientInfo additionalOrgInfo) {
+        this.additionalOrgInfo = additionalOrgInfo;
+    }
 
-	public void setData(Object data) {
-		this.data = data;
-	}
+    public Object getData() {
+        return data;
+    }
+
+    public void setData(Object data) {
+        this.data = data;
+    }
 
 }

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/model/UsnServiceContractInfoV2.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/model/UsnServiceContractInfoV2.java
@@ -6,36 +6,36 @@
 package ru.skbkontur.sdk.extern.model;
 
 /**
- *
  * @author alexs
  */
 public class UsnServiceContractInfoV2 {
-  private UsnFormatPeriod period = null;
-  private AdditionalClientInfo additionalOrgInfo = null;
-  private UsnDataV2 data = null;
 
-	public UsnFormatPeriod getPeriod() {
-		return period;
-	}
+    private UsnFormatPeriod period = null;
+    private AdditionalClientInfo additionalOrgInfo = null;
+    private UsnDataV2 data = null;
 
-	public void setPeriod(UsnFormatPeriod period) {
-		this.period = period;
-	}
+    public UsnFormatPeriod getPeriod() {
+        return period;
+    }
 
-	public AdditionalClientInfo getAdditionalOrgInfo() {
-		return additionalOrgInfo;
-	}
+    public void setPeriod(UsnFormatPeriod period) {
+        this.period = period;
+    }
 
-	public void setAdditionalOrgInfo(AdditionalClientInfo additionalOrgInfo) {
-		this.additionalOrgInfo = additionalOrgInfo;
-	}
+    public AdditionalClientInfo getAdditionalOrgInfo() {
+        return additionalOrgInfo;
+    }
 
-	public UsnDataV2 getData() {
-		return data;
-	}
+    public void setAdditionalOrgInfo(AdditionalClientInfo additionalOrgInfo) {
+        this.additionalOrgInfo = additionalOrgInfo;
+    }
 
-	public void setData(UsnDataV2 data) {
-		this.data = data;
-	}
+    public UsnDataV2 getData() {
+        return data;
+    }
+
+    public void setData(UsnDataV2 data) {
+        this.data = data;
+    }
 
 }

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/model/UsnServiceContractInfoV2.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/model/UsnServiceContractInfoV2.java
@@ -1,8 +1,27 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * MIT License
+ *
+ * Copyright (c) 2018 SKB Kontur
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  */
+
 package ru.skbkontur.sdk.extern.model;
 
 /**

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/providers/AccountProvider.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/providers/AccountProvider.java
@@ -1,8 +1,27 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * MIT License
+ *
+ * Copyright (c) 2018 SKB Kontur
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  */
+
 package ru.skbkontur.sdk.extern.providers;
 
 import java.util.UUID;

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/providers/AccountProvider.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/providers/AccountProvider.java
@@ -7,10 +7,11 @@ package ru.skbkontur.sdk.extern.providers;
 
 import java.util.UUID;
 
+
 /**
- *
  * @author AlexS
  */
 public interface AccountProvider {
-	UUID accountId();
+
+    UUID accountId();
 }

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/providers/ApiKeyProvider.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/providers/ApiKeyProvider.java
@@ -1,8 +1,27 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * MIT License
+ *
+ * Copyright (c) 2018 SKB Kontur
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  */
+
 package ru.skbkontur.sdk.extern.providers;
 
 /**

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/providers/ApiKeyProvider.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/providers/ApiKeyProvider.java
@@ -6,9 +6,9 @@
 package ru.skbkontur.sdk.extern.providers;
 
 /**
- *
  * @author AlexS
  */
 public interface ApiKeyProvider {
-	String getApiKey();
+
+    String getApiKey();
 }

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/providers/AuthenticationProvider.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/providers/AuthenticationProvider.java
@@ -8,19 +8,19 @@ package ru.skbkontur.sdk.extern.providers;
 import ru.skbkontur.sdk.extern.event.AuthenticationListener;
 import ru.skbkontur.sdk.extern.service.transport.adaptors.QueryContext;
 
+
 /**
- *
  * @author AlexS
  */
 public interface AuthenticationProvider {
 
-	QueryContext<String> sessionId();
+    QueryContext<String> sessionId();
 
-	String authPrefix();
-	
-	void addAuthenticationListener(AuthenticationListener authListener);
+    String authPrefix();
 
-	void removeAuthenticationListener(AuthenticationListener authListener);
-	
-	void raiseUnauthenticated(ServiceError x);
+    void addAuthenticationListener(AuthenticationListener authListener);
+
+    void removeAuthenticationListener(AuthenticationListener authListener);
+
+    void raiseUnauthenticated(ServiceError x);
 }

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/providers/AuthenticationProvider.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/providers/AuthenticationProvider.java
@@ -1,8 +1,27 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * MIT License
+ *
+ * Copyright (c) 2018 SKB Kontur
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  */
+
 package ru.skbkontur.sdk.extern.providers;
 
 import ru.skbkontur.sdk.extern.event.AuthenticationListener;

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/providers/CredentialProvider.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/providers/CredentialProvider.java
@@ -1,8 +1,27 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * MIT License
+ *
+ * Copyright (c) 2018 SKB Kontur
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  */
+
 package ru.skbkontur.sdk.extern.providers;
 
 import ru.skbkontur.sdk.extern.providers.auth.Credential;

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/providers/CredentialProvider.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/providers/CredentialProvider.java
@@ -7,10 +7,11 @@ package ru.skbkontur.sdk.extern.providers;
 
 import ru.skbkontur.sdk.extern.providers.auth.Credential;
 
+
 /**
- *
  * @author alexs
  */
 public interface CredentialProvider {
-	Credential getCredential();
+
+    Credential getCredential();
 }

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/providers/CryptoProvider.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/providers/CryptoProvider.java
@@ -5,20 +5,25 @@
  */
 package ru.skbkontur.sdk.extern.providers;
 
-import java.util.concurrent.CompletableFuture;
 import ru.skbkontur.sdk.extern.service.transport.adaptors.QueryContext;
 
+import java.util.concurrent.CompletableFuture;
+
+
 /**
- *
  * @author AlexS
  */
 public interface CryptoProvider {
-	CompletableFuture<QueryContext<byte[]>> signAsync(String thumbprint, byte[] content);
-	QueryContext<byte[]> sign(QueryContext<byte[]> cxt);
-	
-	CompletableFuture<QueryContext<byte[]>> getSignerCertificateAsync(String thumbprint);
-	QueryContext<byte[]> getSignerCertificate(QueryContext<byte[]> cxt);
 
-	CompletableFuture<QueryContext<byte[]>> decryptAsync(String thumbprint, byte[] content);
-	QueryContext<byte[]> decrypt(QueryContext<byte[]> cxt);
+    CompletableFuture<QueryContext<byte[]>> signAsync(String thumbprint, byte[] content);
+
+    QueryContext<byte[]> sign(QueryContext<byte[]> cxt);
+
+    CompletableFuture<QueryContext<byte[]>> getSignerCertificateAsync(String thumbprint);
+
+    QueryContext<byte[]> getSignerCertificate(QueryContext<byte[]> cxt);
+
+    CompletableFuture<QueryContext<byte[]>> decryptAsync(String thumbprint, byte[] content);
+
+    QueryContext<byte[]> decrypt(QueryContext<byte[]> cxt);
 }

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/providers/CryptoProvider.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/providers/CryptoProvider.java
@@ -1,8 +1,27 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * MIT License
+ *
+ * Copyright (c) 2018 SKB Kontur
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  */
+
 package ru.skbkontur.sdk.extern.providers;
 
 import ru.skbkontur.sdk.extern.service.transport.adaptors.QueryContext;

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/providers/LoginAndPasswordProvider.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/providers/LoginAndPasswordProvider.java
@@ -1,10 +1,11 @@
 package ru.skbkontur.sdk.extern.providers;
 
 /**
- *
  * @author AlexS
  */
 public interface LoginAndPasswordProvider {
-	String getLogin();
-	String getPass();
+
+    String getLogin();
+
+    String getPass();
 }

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/providers/LoginAndPasswordProvider.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/providers/LoginAndPasswordProvider.java
@@ -1,3 +1,27 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2018 SKB Kontur
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 package ru.skbkontur.sdk.extern.providers;
 
 /**

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/providers/ServiceBaseUriProvider.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/providers/ServiceBaseUriProvider.java
@@ -6,9 +6,9 @@
 package ru.skbkontur.sdk.extern.providers;
 
 /**
- *
  * @author AlexS
  */
 public interface ServiceBaseUriProvider {
-	String getServiceBaseUri();
+
+    String getServiceBaseUri();
 }

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/providers/ServiceBaseUriProvider.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/providers/ServiceBaseUriProvider.java
@@ -1,8 +1,27 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * MIT License
+ *
+ * Copyright (c) 2018 SKB Kontur
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  */
+
 package ru.skbkontur.sdk.extern.providers;
 
 /**

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/providers/ServiceError.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/providers/ServiceError.java
@@ -6,36 +6,37 @@
 package ru.skbkontur.sdk.extern.providers;
 
 /**
- *
  * @author AlexS
  */
 public interface ServiceError {
-	enum ErrorCode {
-		server(1,"A server side error."), 
-		auth(2,"An authentication error."), 
-		unknownAuth(3,"Unknown authenticator."), 
-		business(4,"Unkonow business error.");
-	
-		private final int value;
-		private final String message;
-		
-		ErrorCode(int value, String message) {
-			this.value = value;
-			this.message = message;
-		}
-		
-		public int value() {
-			return value;
-		}
 
-		public String message() {
-			return message;
-		}
-	};
-	
-	ErrorCode getErrorCode();
-	
-	int getResponseCode();
-	
-	String getMessage();
+    ErrorCode getErrorCode();
+
+
+    int getResponseCode();
+
+    String getMessage();
+
+    enum ErrorCode {
+        server(1, "A server side error."),
+        auth(2, "An authentication error."),
+        unknownAuth(3, "Unknown authenticator."),
+        business(4, "Unkonow business error.");
+
+        private final int value;
+        private final String message;
+
+        ErrorCode(int value, String message) {
+            this.value = value;
+            this.message = message;
+        }
+
+        public int value() {
+            return value;
+        }
+
+        public String message() {
+            return message;
+        }
+    }
 }

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/providers/ServiceError.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/providers/ServiceError.java
@@ -1,8 +1,27 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * MIT License
+ *
+ * Copyright (c) 2018 SKB Kontur
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  */
+
 package ru.skbkontur.sdk.extern.providers;
 
 /**

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/providers/ServiceUserIdProvider.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/providers/ServiceUserIdProvider.java
@@ -1,8 +1,27 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * MIT License
+ *
+ * Copyright (c) 2018 SKB Kontur
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  */
+
 package ru.skbkontur.sdk.extern.providers;
 
 /**

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/providers/ServiceUserIdProvider.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/providers/ServiceUserIdProvider.java
@@ -6,9 +6,9 @@
 package ru.skbkontur.sdk.extern.providers;
 
 /**
- *
  * @author AlexS
  */
 public interface ServiceUserIdProvider {
-	String getServiceUserIdProvider();
+
+    String getServiceUserIdProvider();
 }

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/providers/SignatureKeyProvider.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/providers/SignatureKeyProvider.java
@@ -6,9 +6,9 @@
 package ru.skbkontur.sdk.extern.providers;
 
 /**
- *
  * @author AlexS
  */
 public interface SignatureKeyProvider {
-	String getThumbprint();
+
+    String getThumbprint();
 }

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/providers/SignatureKeyProvider.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/providers/SignatureKeyProvider.java
@@ -1,8 +1,27 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * MIT License
+ *
+ * Copyright (c) 2018 SKB Kontur
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  */
+
 package ru.skbkontur.sdk.extern.providers;
 
 /**

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/providers/UriProvider.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/providers/UriProvider.java
@@ -6,9 +6,9 @@
 package ru.skbkontur.sdk.extern.providers;
 
 /**
- *
  * @author AlexS
  */
 public interface UriProvider {
-	String getUri();
+
+    String getUri();
 }

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/providers/UriProvider.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/providers/UriProvider.java
@@ -1,8 +1,27 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * MIT License
+ *
+ * Copyright (c) 2018 SKB Kontur
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  */
+
 package ru.skbkontur.sdk.extern.providers;
 
 /**

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/providers/auth/AuthenticationProviderAbstract.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/providers/auth/AuthenticationProviderAbstract.java
@@ -1,8 +1,27 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * MIT License
+ *
+ * Copyright (c) 2018 SKB Kontur
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  */
+
 package ru.skbkontur.sdk.extern.providers.auth;
 
 import ru.skbkontur.sdk.extern.event.AuthenticationEvent;

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/providers/auth/AuthenticationProviderAbstract.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/providers/auth/AuthenticationProviderAbstract.java
@@ -5,60 +5,62 @@
  */
 package ru.skbkontur.sdk.extern.providers.auth;
 
-import java.util.ArrayList;
-import java.util.List;
 import ru.skbkontur.sdk.extern.event.AuthenticationEvent;
 import ru.skbkontur.sdk.extern.event.AuthenticationListener;
 import ru.skbkontur.sdk.extern.providers.AuthenticationProvider;
 import ru.skbkontur.sdk.extern.providers.ServiceError;
 import ru.skbkontur.sdk.extern.service.transport.adaptors.QueryContext;
 
+import java.util.ArrayList;
+import java.util.List;
+
+
 /**
- *
  * @author alexs
  */
 public abstract class AuthenticationProviderAbstract implements AuthenticationProvider {
-	protected static final String DEFAULT_AUTH_PREFIX = "auth.sid ";
-	
-	private final List<AuthenticationListener> authListeners;
 
-	protected AuthenticationProviderAbstract() {
-		this.authListeners = new ArrayList<>();
-	}
-	
-	@Override
-	public void addAuthenticationListener(AuthenticationListener authenticationListener) {
-		synchronized (authListeners) {
-			authListeners.add(authenticationListener);
-		}
-	}
-	
-	@Override
-	public void removeAuthenticationListener(AuthenticationListener authenticationListener) {
-		synchronized (authListeners) {
-			authListeners.add(authenticationListener);
-		}
-	}
-	
-	private List<AuthenticationListener> getAuthenticationListener() {
-		List<AuthenticationListener> cloned = new ArrayList<>();
-		synchronized (authListeners) {
-			authListeners.forEach(a->cloned.add(a));
-		}
-		return cloned;
-	}
-	
-	@Override
-	public void raiseUnauthenticated(ServiceError x) {
-		QueryContext<String> authCxt = new QueryContext();
-		authCxt.setServiceError(x);
-		fireAuthenticationEvent(authCxt);
-	}
-	
-	protected void fireAuthenticationEvent(QueryContext<String> authCxt) {
-		List<AuthenticationListener> clonedAuthListeners = getAuthenticationListener();
-		if (clonedAuthListeners != null) {
-			clonedAuthListeners.stream().forEach(l->l.authenticate(new AuthenticationEvent(AuthenticationProviderAbstract.this, authCxt)));
-		}
-	}
+    protected static final String DEFAULT_AUTH_PREFIX = "auth.sid ";
+
+    private final List<AuthenticationListener> authListeners;
+
+    protected AuthenticationProviderAbstract() {
+        this.authListeners = new ArrayList<>();
+    }
+
+    @Override
+    public void addAuthenticationListener(AuthenticationListener authenticationListener) {
+        synchronized (authListeners) {
+            authListeners.add(authenticationListener);
+        }
+    }
+
+    @Override
+    public void removeAuthenticationListener(AuthenticationListener authenticationListener) {
+        synchronized (authListeners) {
+            authListeners.add(authenticationListener);
+        }
+    }
+
+    private List<AuthenticationListener> getAuthenticationListener() {
+        List<AuthenticationListener> cloned = new ArrayList<>();
+        synchronized (authListeners) {
+            authListeners.forEach(a -> cloned.add(a));
+        }
+        return cloned;
+    }
+
+    @Override
+    public void raiseUnauthenticated(ServiceError x) {
+        QueryContext<String> authCxt = new QueryContext();
+        authCxt.setServiceError(x);
+        fireAuthenticationEvent(authCxt);
+    }
+
+    protected void fireAuthenticationEvent(QueryContext<String> authCxt) {
+        List<AuthenticationListener> clonedAuthListeners = getAuthenticationListener();
+        if (clonedAuthListeners != null) {
+            clonedAuthListeners.stream().forEach(l -> l.authenticate(new AuthenticationEvent(AuthenticationProviderAbstract.this, authCxt)));
+        }
+    }
 }

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/providers/auth/AuthenticationProviderByPass.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/providers/auth/AuthenticationProviderByPass.java
@@ -5,125 +5,126 @@
  */
 package ru.skbkontur.sdk.extern.providers.auth;
 
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
 import ru.skbkontur.sdk.extern.providers.ApiKeyProvider;
-import ru.skbkontur.sdk.extern.service.transport.adaptors.QueryContext;
-import static ru.skbkontur.sdk.extern.service.transport.adaptors.QueryContext.SESSION_ID;
-import ru.skbkontur.sdk.extern.service.transport.invoker.ApiClient;
-import ru.skbkontur.sdk.extern.providers.UriProvider;
 import ru.skbkontur.sdk.extern.providers.LoginAndPasswordProvider;
+import ru.skbkontur.sdk.extern.providers.UriProvider;
+import ru.skbkontur.sdk.extern.service.transport.adaptors.QueryContext;
+import ru.skbkontur.sdk.extern.service.transport.invoker.ApiClient;
 import ru.skbkontur.sdk.extern.service.transport.invoker.ApiException;
 import ru.skbkontur.sdk.extern.service.transport.invoker.ApiResponse;
 
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static ru.skbkontur.sdk.extern.service.transport.adaptors.QueryContext.SESSION_ID;
+
+
 /**
- *
  * @author AlexS
  */
-public class AuthenticationProviderByPass extends  AuthenticationProviderAbstract {
+public class AuthenticationProviderByPass extends AuthenticationProviderAbstract {
 
-	private ApiKeyProvider apiKeyProvider;
-	private LoginAndPasswordProvider loginAndPasswordProvider;
-	private UriProvider authBaseUriProvider;
-	private final String authPrefix;
-	
-	public AuthenticationProviderByPass(UriProvider authBaseUriProvider, LoginAndPasswordProvider loginAndPasswordProvider, ApiKeyProvider apiKeyProvider, String authPrefix) {
-		this.authBaseUriProvider = authBaseUriProvider;
-		this.loginAndPasswordProvider = loginAndPasswordProvider;
-		this.apiKeyProvider = apiKeyProvider;
-		this.authPrefix = authPrefix == null ? DEFAULT_AUTH_PREFIX : authPrefix;
-	}
+    private final String authPrefix;
+    private ApiKeyProvider apiKeyProvider;
+    private LoginAndPasswordProvider loginAndPasswordProvider;
+    private UriProvider authBaseUriProvider;
 
-	public AuthenticationProviderByPass(UriProvider authBaseUriProvider, LoginAndPasswordProvider loginAndPasswordProvider, ApiKeyProvider apiKeyProvider) {
-		this(authBaseUriProvider,loginAndPasswordProvider,apiKeyProvider,DEFAULT_AUTH_PREFIX);
-	}
+    public AuthenticationProviderByPass(UriProvider authBaseUriProvider, LoginAndPasswordProvider loginAndPasswordProvider, ApiKeyProvider apiKeyProvider, String authPrefix) {
+        this.authBaseUriProvider = authBaseUriProvider;
+        this.loginAndPasswordProvider = loginAndPasswordProvider;
+        this.apiKeyProvider = apiKeyProvider;
+        this.authPrefix = authPrefix == null ? DEFAULT_AUTH_PREFIX : authPrefix;
+    }
 
-	public void setApiKeyProvider(ApiKeyProvider apiKeyProvider) {
-		this.apiKeyProvider = apiKeyProvider;
-	}
+    public AuthenticationProviderByPass(UriProvider authBaseUriProvider, LoginAndPasswordProvider loginAndPasswordProvider, ApiKeyProvider apiKeyProvider) {
+        this(authBaseUriProvider, loginAndPasswordProvider, apiKeyProvider, DEFAULT_AUTH_PREFIX);
+    }
 
-	public void setLoginAndPasswordProvider(LoginAndPasswordProvider loginAndPasswordProvider) {
-		this.loginAndPasswordProvider = loginAndPasswordProvider;
-	}
+    public void setApiKeyProvider(ApiKeyProvider apiKeyProvider) {
+        this.apiKeyProvider = apiKeyProvider;
+    }
 
-	public void setAuthBaseUriProvider(UriProvider authBaseUriProvider) {
-		this.authBaseUriProvider = authBaseUriProvider;
-	}
+    public void setLoginAndPasswordProvider(LoginAndPasswordProvider loginAndPasswordProvider) {
+        this.loginAndPasswordProvider = loginAndPasswordProvider;
+    }
 
-	@Override
-	public QueryContext<String> sessionId() {
-		QueryContext<String> cxt = createQueryContext("loginAndPasswordAuthenticationProvider");
+    public void setAuthBaseUriProvider(UriProvider authBaseUriProvider) {
+        this.authBaseUriProvider = authBaseUriProvider;
+    }
 
-		try {
+    @Override
+    public QueryContext<String> sessionId() {
+        QueryContext<String> cxt = createQueryContext("loginAndPasswordAuthenticationProvider");
 
-			if (loginAndPasswordProvider == null) {
-				return cxt.setServiceError("Missing the login provider");
-			}
+        try {
 
-			String login = loginAndPasswordProvider.getLogin();
+            if (loginAndPasswordProvider == null) {
+                return cxt.setServiceError("Missing the login provider");
+            }
 
-			String pass = loginAndPasswordProvider.getPass();
+            String login = loginAndPasswordProvider.getLogin();
 
-			if (login == null) {
-				cxt.setServiceError("Missing the required parameter 'login'");
-			}
+            String pass = loginAndPasswordProvider.getPass();
 
-			if (pass == null) {
-				cxt.setServiceError("Missing the required parameter 'pass'");
-			}
+            if (login == null) {
+                cxt.setServiceError("Missing the required parameter 'login'");
+            }
 
-			if (apiKeyProvider == null) {
-				return cxt.setServiceError("Missing the api key provider");
-			}
+            if (pass == null) {
+                cxt.setServiceError("Missing the required parameter 'pass'");
+            }
 
-			String apiKey = apiKeyProvider.getApiKey();
-			
-			if (apiKey == null) {
-				cxt.setServiceError("Missing the required parameter 'api key'");
-			}
+            if (apiKeyProvider == null) {
+                return cxt.setServiceError("Missing the api key provider");
+            }
 
-			ApiClient apiClient = cxt.getApiClient();
-			
-			apiClient.setBasePath(authBaseUriProvider.getUri());
-			
-			Map<String, String> queryParams = new HashMap<String, String>() {
-				{
-					put("login", login);
-					put("apiKey", apiKey);
-				}
-			};
+            String apiKey = apiKeyProvider.getApiKey();
 
-			Map<String, String> headerParams = new HashMap<String, String>() {
-				{
-					put("Content-Type", "text/plain");
-				}
-			};
+            if (apiKey == null) {
+                cxt.setServiceError("Missing the required parameter 'api key'");
+            }
 
-			ApiResponse<ResponseSid> resp = apiClient.submitHttpRequest("/v5.6/authenticate-by-pass", "POST", queryParams, pass, headerParams, Collections.emptyMap(), ResponseSid.class);
-			
-			cxt.setResult(resp.getData().getSid(), SESSION_ID);
-		}
-		catch (ApiException x) {
-			cxt.setServiceError(x);
-		}
+            ApiClient apiClient = cxt.getApiClient();
 
-		fireAuthenticationEvent(cxt);
-		
-		return cxt;
-	}
+            apiClient.setBasePath(authBaseUriProvider.getUri());
 
-	@Override
-	public String authPrefix() {
-		return authPrefix;
-	}
+            Map<String, String> queryParams = new HashMap<String, String>() {
+                {
+                    put("login", login);
+                    put("apiKey", apiKey);
+                }
+            };
 
-	private <T> QueryContext<T> createQueryContext(String entityName) {
-		QueryContext<T> cxt = new QueryContext<>(entityName);
-		cxt.setApiClient(new ApiClient());
-		cxt.setServiceBaseUri(authBaseUriProvider.getUri());
-		cxt.setApiKeyProvider(apiKeyProvider);
-		cxt.configureApiClient();
-		return cxt;
-	}
+            Map<String, String> headerParams = new HashMap<String, String>() {
+                {
+                    put("Content-Type", "text/plain");
+                }
+            };
+
+            ApiResponse<ResponseSid> resp = apiClient.submitHttpRequest("/v5.6/authenticate-by-pass", "POST", queryParams, pass, headerParams, Collections.emptyMap(), ResponseSid.class);
+
+            cxt.setResult(resp.getData().getSid(), SESSION_ID);
+        } catch (ApiException x) {
+            cxt.setServiceError(x);
+        }
+
+        fireAuthenticationEvent(cxt);
+
+        return cxt;
+    }
+
+    @Override
+    public String authPrefix() {
+        return authPrefix;
+    }
+
+    private <T> QueryContext<T> createQueryContext(String entityName) {
+        QueryContext<T> cxt = new QueryContext<>(entityName);
+        cxt.setApiClient(new ApiClient());
+        cxt.setServiceBaseUri(authBaseUriProvider.getUri());
+        cxt.setApiKeyProvider(apiKeyProvider);
+        cxt.configureApiClient();
+        return cxt;
+    }
 }

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/providers/auth/AuthenticationProviderByPass.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/providers/auth/AuthenticationProviderByPass.java
@@ -1,8 +1,27 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * MIT License
+ *
+ * Copyright (c) 2018 SKB Kontur
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  */
+
 package ru.skbkontur.sdk.extern.providers.auth;
 
 import ru.skbkontur.sdk.extern.providers.ApiKeyProvider;

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/providers/auth/Credential.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/providers/auth/Credential.java
@@ -6,33 +6,33 @@
 package ru.skbkontur.sdk.extern.providers.auth;
 
 /**
- *
  * @author AlexS
  */
 public class Credential {
-	private String name;
-	private String value;
-	
-	public Credential(String name, String value) {
-		this.name = name;
-		this.value = value;
-	}
 
-	public String getName() {
-		return name;
-	}
+    private String name;
+    private String value;
 
-	public void setName(String name) {
-		this.name = name;
-	}
+    public Credential(String name, String value) {
+        this.name = name;
+        this.value = value;
+    }
 
-	public String getValue() {
-		return value;
-	}
+    public String getName() {
+        return name;
+    }
 
-	public void setValue(String value) {
-		this.value = value;
-	}
-	
-	
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+
+
 }

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/providers/auth/Credential.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/providers/auth/Credential.java
@@ -1,8 +1,27 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * MIT License
+ *
+ * Copyright (c) 2018 SKB Kontur
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  */
+
 package ru.skbkontur.sdk.extern.providers.auth;
 
 /**

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/providers/auth/Link.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/providers/auth/Link.java
@@ -1,8 +1,27 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * MIT License
+ *
+ * Copyright (c) 2018 SKB Kontur
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  */
+
 package ru.skbkontur.sdk.extern.providers.auth;
 
 import com.google.gson.annotations.SerializedName;

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/providers/auth/Link.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/providers/auth/Link.java
@@ -7,39 +7,39 @@ package ru.skbkontur.sdk.extern.providers.auth;
 
 import com.google.gson.annotations.SerializedName;
 
+
 /**
- *
  * @author alexs
  */
 public class Link {
 
-	@SerializedName("Rel")
-	private String rel;
-	@SerializedName("Href")
-	private String href;
+    @SerializedName("Rel")
+    private String rel;
+    @SerializedName("Href")
+    private String href;
 
-	public Link() {
+    public Link() {
 
-	}
+    }
 
-	public Link(String rel, String href) {
-		this.rel = rel;
-		this.href = href;
-	}
+    public Link(String rel, String href) {
+        this.rel = rel;
+        this.href = href;
+    }
 
-	public String getRel() {
-		return rel;
-	}
+    public String getRel() {
+        return rel;
+    }
 
-	public void setRel(String rel) {
-		this.rel = rel;
-	}
+    public void setRel(String rel) {
+        this.rel = rel;
+    }
 
-	public String getHref() {
-		return href;
-	}
+    public String getHref() {
+        return href;
+    }
 
-	public void setHref(String href) {
-		this.href = href;
-	}
+    public void setHref(String href) {
+        this.href = href;
+    }
 }

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/providers/auth/ResponseLink.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/providers/auth/ResponseLink.java
@@ -7,33 +7,33 @@ package ru.skbkontur.sdk.extern.providers.auth;
 
 import com.google.gson.annotations.SerializedName;
 
+
 /**
- *
  * @author alexs
  */
 public class ResponseLink {
 
-		@SerializedName("Link")
-		private Link link;
-		@SerializedName("Key")
-		private String key;
+    @SerializedName("Link")
+    private Link link;
+    @SerializedName("Key")
+    private String key;
 
-		public ResponseLink() {
-		}
+    public ResponseLink() {
+    }
 
-		public Link getLink() {
-			return link;
-		}
+    public Link getLink() {
+        return link;
+    }
 
-		public void setLink(Link link) {
-			this.link = link;
-		}
+    public void setLink(Link link) {
+        this.link = link;
+    }
 
-		public String getKey() {
-			return key;
-		}
+    public String getKey() {
+        return key;
+    }
 
-		public void setKey(String key) {
-			this.key = key;
-		}
+    public void setKey(String key) {
+        this.key = key;
+    }
 }

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/providers/auth/ResponseLink.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/providers/auth/ResponseLink.java
@@ -1,8 +1,27 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * MIT License
+ *
+ * Copyright (c) 2018 SKB Kontur
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  */
+
 package ru.skbkontur.sdk.extern.providers.auth;
 
 import com.google.gson.annotations.SerializedName;

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/providers/auth/ResponseSid.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/providers/auth/ResponseSid.java
@@ -7,20 +7,20 @@ package ru.skbkontur.sdk.extern.providers.auth;
 
 import com.google.gson.annotations.SerializedName;
 
+
 /**
- *
  * @author AlexS
  */
 public class ResponseSid {
 
-		@SerializedName("Sid")
-		private String sid;
+    @SerializedName("Sid")
+    private String sid;
 
-		public String getSid() {
-			return sid;
-		}
+    public String getSid() {
+        return sid;
+    }
 
-		public void setSid(String sid) {
-			this.sid = sid;
-		}
+    public void setSid(String sid) {
+        this.sid = sid;
+    }
 }

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/providers/auth/ResponseSid.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/providers/auth/ResponseSid.java
@@ -1,8 +1,27 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * MIT License
+ *
+ * Copyright (c) 2018 SKB Kontur
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  */
+
 package ru.skbkontur.sdk.extern.providers.auth;
 
 import com.google.gson.annotations.SerializedName;

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/providers/auth/TrustedAuthentication.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/providers/auth/TrustedAuthentication.java
@@ -5,249 +5,249 @@
  */
 package ru.skbkontur.sdk.extern.providers.auth;
 
-import java.text.SimpleDateFormat;
-import java.util.Collections;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.Map;
 import ru.argosgrp.cryptoservice.utils.IOUtil;
 import ru.skbkontur.sdk.extern.Messages;
-import static ru.skbkontur.sdk.extern.Messages.C_CRYPTO_ERROR_NO_CRYPTO_PROVIDER;
 import ru.skbkontur.sdk.extern.providers.ApiKeyProvider;
 import ru.skbkontur.sdk.extern.providers.CredentialProvider;
 import ru.skbkontur.sdk.extern.providers.CryptoProvider;
 import ru.skbkontur.sdk.extern.providers.ServiceError;
 import ru.skbkontur.sdk.extern.providers.ServiceUserIdProvider;
 import ru.skbkontur.sdk.extern.providers.SignatureKeyProvider;
+import ru.skbkontur.sdk.extern.providers.UriProvider;
 import ru.skbkontur.sdk.extern.service.transport.adaptors.QueryContext;
-import static ru.skbkontur.sdk.extern.service.transport.adaptors.QueryContext.SESSION_ID;
 import ru.skbkontur.sdk.extern.service.transport.invoker.ApiClient;
 import ru.skbkontur.sdk.extern.service.transport.invoker.ApiException;
 import ru.skbkontur.sdk.extern.service.transport.invoker.ApiResponse;
-import ru.skbkontur.sdk.extern.providers.UriProvider;
+
+import java.text.SimpleDateFormat;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+
+import static ru.skbkontur.sdk.extern.Messages.C_CRYPTO_ERROR_NO_CRYPTO_PROVIDER;
 import static ru.skbkontur.sdk.extern.service.transport.adaptors.QueryContext.NOTHING;
+import static ru.skbkontur.sdk.extern.service.transport.adaptors.QueryContext.SESSION_ID;
+
 
 /**
- *
  * @author AlexS
  */
 public class TrustedAuthentication extends AuthenticationProviderAbstract {
 
-	private static final String EOL = System.getProperty("line.separator", "\r\n");
-	private static final String APIKEY = "apikey";
-	private static final String SERVICE_USER_ID = "serviceUserId";
-	private static final String ID = "id";
-	private static final String PHONE = "phone";
-	private static final String TIMESTAMP = "timestamp";
+    private static final String EOL = System.getProperty("line.separator", "\r\n");
+    private static final String APIKEY = "apikey";
+    private static final String SERVICE_USER_ID = "serviceUserId";
+    private static final String ID = "id";
+    private static final String PHONE = "phone";
+    private static final String TIMESTAMP = "timestamp";
 
-	private final ApiClient apiClient;
-	private ApiKeyProvider apiKeyProvider;
-	private UriProvider authBaseUriProvider;
-	private CryptoProvider cryptoProvider;
-	private SignatureKeyProvider signatureKeyProvider;
-	private ServiceUserIdProvider serviceUserIdProvider;
-	private String authPrefix;
-	private String timestamp;
-	private CredentialProvider credentialProvider;
+    private final ApiClient apiClient;
+    private ApiKeyProvider apiKeyProvider;
+    private UriProvider authBaseUriProvider;
+    private CryptoProvider cryptoProvider;
+    private SignatureKeyProvider signatureKeyProvider;
+    private ServiceUserIdProvider serviceUserIdProvider;
+    private String authPrefix;
+    private String timestamp;
+    private CredentialProvider credentialProvider;
 
-	public TrustedAuthentication(String authPrefix) {
-		this.apiClient = new ApiClient();
-		this.authPrefix = authPrefix == null ? DEFAULT_AUTH_PREFIX : authPrefix;
-	}
+    public TrustedAuthentication(String authPrefix) {
+        this.apiClient = new ApiClient();
+        this.authPrefix = authPrefix == null ? DEFAULT_AUTH_PREFIX : authPrefix;
+    }
 
-	public TrustedAuthentication() {
-		this.apiClient = new ApiClient();
-		this.authPrefix = DEFAULT_AUTH_PREFIX;
-	}
+    public TrustedAuthentication() {
+        this.apiClient = new ApiClient();
+        this.authPrefix = DEFAULT_AUTH_PREFIX;
+    }
 
-	public ApiKeyProvider getApiKeyProvider() {
-		return apiKeyProvider;
-	}
+    public ApiKeyProvider getApiKeyProvider() {
+        return apiKeyProvider;
+    }
 
-	public void setApiKeyProvider(ApiKeyProvider apiKeyProvider) {
-		this.apiKeyProvider = apiKeyProvider;
-	}
+    public void setApiKeyProvider(ApiKeyProvider apiKeyProvider) {
+        this.apiKeyProvider = apiKeyProvider;
+    }
 
-	public TrustedAuthentication apiKeyProvider(ApiKeyProvider apiKeyProvider) {
-		this.apiKeyProvider = apiKeyProvider;
-		return this;
-	}
+    public TrustedAuthentication apiKeyProvider(ApiKeyProvider apiKeyProvider) {
+        this.apiKeyProvider = apiKeyProvider;
+        return this;
+    }
 
-	public ServiceUserIdProvider getServiceUserIdProvider() {
-		return serviceUserIdProvider;
-	}
+    public ServiceUserIdProvider getServiceUserIdProvider() {
+        return serviceUserIdProvider;
+    }
 
-	public void setServiceUserIdProvider(ServiceUserIdProvider serviceUserIdProvider) {
-		this.serviceUserIdProvider = serviceUserIdProvider;
-	}
+    public void setServiceUserIdProvider(ServiceUserIdProvider serviceUserIdProvider) {
+        this.serviceUserIdProvider = serviceUserIdProvider;
+    }
 
-	public TrustedAuthentication serviceUserIdProvider(ServiceUserIdProvider serviceUserIdProvider) {
-		this.serviceUserIdProvider = serviceUserIdProvider;
-		return this;
-	}
+    public TrustedAuthentication serviceUserIdProvider(ServiceUserIdProvider serviceUserIdProvider) {
+        this.serviceUserIdProvider = serviceUserIdProvider;
+        return this;
+    }
 
-	public UriProvider getAuthBaseUriProvider() {
-		return authBaseUriProvider;
-	}
+    public UriProvider getAuthBaseUriProvider() {
+        return authBaseUriProvider;
+    }
 
-	public void setAuthBaseUriProvider(UriProvider authBaseUriProvider) {
-		this.authBaseUriProvider = authBaseUriProvider;
-	}
+    public void setAuthBaseUriProvider(UriProvider authBaseUriProvider) {
+        this.authBaseUriProvider = authBaseUriProvider;
+    }
 
-	public TrustedAuthentication authBaseUriProvider(UriProvider authBaseUriProvider) {
-		this.authBaseUriProvider = authBaseUriProvider;
-		return this;
-	}
+    public TrustedAuthentication authBaseUriProvider(UriProvider authBaseUriProvider) {
+        this.authBaseUriProvider = authBaseUriProvider;
+        return this;
+    }
 
-	public CryptoProvider geCryptoProvider() {
-		return cryptoProvider;
-	}
+    public CryptoProvider geCryptoProvider() {
+        return cryptoProvider;
+    }
 
-	public void setCryptoProvider(CryptoProvider cryptoProvider) {
-		this.cryptoProvider = cryptoProvider;
-	}
+    public void setCryptoProvider(CryptoProvider cryptoProvider) {
+        this.cryptoProvider = cryptoProvider;
+    }
 
-	public TrustedAuthentication cryptoProvider(CryptoProvider cryptoProvider) {
-		setCryptoProvider(cryptoProvider);
-		return this;
-	}
+    public TrustedAuthentication cryptoProvider(CryptoProvider cryptoProvider) {
+        setCryptoProvider(cryptoProvider);
+        return this;
+    }
 
-	public SignatureKeyProvider getSignatureKeyProvider() {
-		return signatureKeyProvider;
-	}
+    public SignatureKeyProvider getSignatureKeyProvider() {
+        return signatureKeyProvider;
+    }
 
-	public void setSignatureKeyProvider(SignatureKeyProvider signatureKeyProvider) {
-		this.signatureKeyProvider = signatureKeyProvider;
-	}
+    public void setSignatureKeyProvider(SignatureKeyProvider signatureKeyProvider) {
+        this.signatureKeyProvider = signatureKeyProvider;
+    }
 
-	public TrustedAuthentication signatureKeyProvider(SignatureKeyProvider signatureKeyProvider) {
-		setSignatureKeyProvider(signatureKeyProvider);
-		return this;
-	}
+    public TrustedAuthentication signatureKeyProvider(SignatureKeyProvider signatureKeyProvider) {
+        setSignatureKeyProvider(signatureKeyProvider);
+        return this;
+    }
 
-	public String getAuthPrefix() {
-		return authPrefix;
-	}
+    public String getAuthPrefix() {
+        return authPrefix;
+    }
 
-	public void setAuthPrefix(String authPrefix) {
-		this.authPrefix = authPrefix;
-	}
+    public void setAuthPrefix(String authPrefix) {
+        this.authPrefix = authPrefix;
+    }
 
-	public CredentialProvider getCredentialProvider() {
-		return credentialProvider;
-	}
+    public CredentialProvider getCredentialProvider() {
+        return credentialProvider;
+    }
 
-	public void setCredentialProvider(CredentialProvider credentialProvider) {
-		this.credentialProvider = credentialProvider;
-	}
+    public void setCredentialProvider(CredentialProvider credentialProvider) {
+        this.credentialProvider = credentialProvider;
+    }
 
-	public TrustedAuthentication credentialProvider(CredentialProvider credentialProvider) {
-		this.credentialProvider = credentialProvider;
-		return this;
-	}
+    public TrustedAuthentication credentialProvider(CredentialProvider credentialProvider) {
+        this.credentialProvider = credentialProvider;
+        return this;
+    }
 
-	@Override
-	public QueryContext<String> sessionId() {
-		if (cryptoProvider == null)
-			return new QueryContext<String>().setServiceError(ServiceError.ErrorCode.auth, Messages.get(C_CRYPTO_ERROR_NO_CRYPTO_PROVIDER), 0, null, null);
-		
-		apiClient.setBasePath(authBaseUriProvider.getUri());
+    @Override
+    public QueryContext<String> sessionId() {
+        if (cryptoProvider == null)
+            return new QueryContext<String>().setServiceError(ServiceError.ErrorCode.auth, Messages.get(C_CRYPTO_ERROR_NO_CRYPTO_PROVIDER), 0, null, null);
 
-		timestamp = new SimpleDateFormat("dd.MM.yyyy HH:mm:ss").format(new Date());
+        apiClient.setBasePath(authBaseUriProvider.getUri());
 
-		return authenticateRequest();
-	}
+        timestamp = new SimpleDateFormat("dd.MM.yyyy HH:mm:ss").format(new Date());
 
-	@Override
-	public String authPrefix() {
-		return authPrefix;
-	}
+        return authenticateRequest();
+    }
 
-	public QueryContext<Void> registerExternalServiceId(String serviceUserId, String phone) {
-		QueryContext<Void> registerCxt;
-		
-		try {
-			apiClient.setBasePath(authBaseUriProvider.getUri());
-			
-			Map<String, String> queryParams = new HashMap<>();
-			
-			queryParams.put(APIKEY, apiKeyProvider.getApiKey());
-			
-			queryParams.put(SERVICE_USER_ID, serviceUserId);
-			
-			queryParams.put(PHONE, phone);
-			
-			Map<String, String> localHeaderParams = new HashMap<>();
+    @Override
+    public String authPrefix() {
+        return authPrefix;
+    }
 
-			Map<String, Object> localVarFormParams = new HashMap<>();
+    public QueryContext<Void> registerExternalServiceId(String serviceUserId, String phone) {
+        QueryContext<Void> registerCxt;
 
-			apiClient.submitHttpRequest("/auth/v5.9/register-external-service-id", "PUT", queryParams, null, localHeaderParams, localVarFormParams, Object.class);
-			
-			registerCxt = new QueryContext<Void>().setResult(null, NOTHING);
-		}
-		catch (ApiException x) {
-			registerCxt = new QueryContext<Void>().setServiceError(x);
-		}
-		return registerCxt;
-	}
-	
-	private QueryContext<String> authenticateRequest() {
-		
-		QueryContext<String> authCxt;
-		
-		try {
-			StringBuilder identityData = new StringBuilder();
+        try {
+            apiClient.setBasePath(authBaseUriProvider.getUri());
 
-			Map<String, String> queryParams = new HashMap<>();
+            Map<String, String> queryParams = new HashMap<>();
 
-			String apiKey = apiKeyProvider.getApiKey().toLowerCase();
-			queryParams.put(APIKEY, apiKey);
-			identityData.append(APIKEY).append("=").append(apiKey).append(EOL);
+            queryParams.put(APIKEY, apiKeyProvider.getApiKey());
 
-			if (credentialProvider != null) {
-				queryParams.put(credentialProvider.getCredential().getName(), credentialProvider.getCredential().getValue());
-				identityData.append(ID).append("=").append(credentialProvider.getCredential().getValue()).append(EOL);
-			}
+            queryParams.put(SERVICE_USER_ID, serviceUserId);
 
-			queryParams.put(TIMESTAMP, timestamp);
-			identityData.append(TIMESTAMP).append("=").append(timestamp).append(EOL);
+            queryParams.put(PHONE, phone);
 
-			queryParams.put(SERVICE_USER_ID, serviceUserIdProvider.getServiceUserIdProvider());
+            Map<String, String> localHeaderParams = new HashMap<>();
 
-			Map<String, String> localHeaderParams = new HashMap<>();
+            Map<String, Object> localVarFormParams = new HashMap<>();
 
-			Map<String, Object> localVarFormParams = new HashMap<>();
+            apiClient.submitHttpRequest("/auth/v5.9/register-external-service-id", "PUT", queryParams, null, localHeaderParams, localVarFormParams, Object.class);
 
-			QueryContext<byte[]> signature = cryptoProvider.sign(
-				new QueryContext<byte[]>()
-					.setThumbprint(signatureKeyProvider.getThumbprint())
-					.setContent(identityData.toString().getBytes())
-			);
+            registerCxt = new QueryContext<Void>().setResult(null, NOTHING);
+        } catch (ApiException x) {
+            registerCxt = new QueryContext<Void>().setServiceError(x);
+        }
+        return registerCxt;
+    }
 
-			if (signature.isFail()) {
-				return new QueryContext<String>().setServiceError(signature);
-			}
-			
-			ApiResponse<ResponseLink> responseLink = apiClient.submitHttpRequest("/v5.9/authenticate-by-truster", "POST", queryParams, signature.get(), localHeaderParams, localVarFormParams, ResponseLink.class);
+    private QueryContext<String> authenticateRequest() {
 
-			apiClient.setBasePath("");
-			
-			ResponseLink link = responseLink.getData();
-			
-			byte[] key = IOUtil.hexToBytes(link.getKey());
-			
-			String approveRequest = link.getLink().getHref(); // + "&" + APIKEY + "=" + apiKey;
-			
-			ApiResponse<ResponseSid> sid = apiClient.submitHttpRequest(approveRequest, "POST", Collections.emptyMap(), key, localHeaderParams, localVarFormParams, ResponseSid.class);
-			
-			authCxt = new QueryContext<String>().setResult(sid.getData().getSid(), SESSION_ID);
-		}
-		catch (ApiException x) {
-			authCxt = new QueryContext<String>().setServiceError(x);
-		}
-		
-		fireAuthenticationEvent(authCxt);
-		
-		return authCxt;
-	}
+        QueryContext<String> authCxt;
+
+        try {
+            StringBuilder identityData = new StringBuilder();
+
+            Map<String, String> queryParams = new HashMap<>();
+
+            String apiKey = apiKeyProvider.getApiKey().toLowerCase();
+            queryParams.put(APIKEY, apiKey);
+            identityData.append(APIKEY).append("=").append(apiKey).append(EOL);
+
+            if (credentialProvider != null) {
+                queryParams.put(credentialProvider.getCredential().getName(), credentialProvider.getCredential().getValue());
+                identityData.append(ID).append("=").append(credentialProvider.getCredential().getValue()).append(EOL);
+            }
+
+            queryParams.put(TIMESTAMP, timestamp);
+            identityData.append(TIMESTAMP).append("=").append(timestamp).append(EOL);
+
+            queryParams.put(SERVICE_USER_ID, serviceUserIdProvider.getServiceUserIdProvider());
+
+            Map<String, String> localHeaderParams = new HashMap<>();
+
+            Map<String, Object> localVarFormParams = new HashMap<>();
+
+            QueryContext<byte[]> signature = cryptoProvider.sign(
+                    new QueryContext<byte[]>()
+                            .setThumbprint(signatureKeyProvider.getThumbprint())
+                            .setContent(identityData.toString().getBytes())
+            );
+
+            if (signature.isFail()) {
+                return new QueryContext<String>().setServiceError(signature);
+            }
+
+            ApiResponse<ResponseLink> responseLink = apiClient.submitHttpRequest("/v5.9/authenticate-by-truster", "POST", queryParams, signature.get(), localHeaderParams, localVarFormParams, ResponseLink.class);
+
+            apiClient.setBasePath("");
+
+            ResponseLink link = responseLink.getData();
+
+            byte[] key = IOUtil.hexToBytes(link.getKey());
+
+            String approveRequest = link.getLink().getHref(); // + "&" + APIKEY + "=" + apiKey;
+
+            ApiResponse<ResponseSid> sid = apiClient.submitHttpRequest(approveRequest, "POST", Collections.emptyMap(), key, localHeaderParams, localVarFormParams, ResponseSid.class);
+
+            authCxt = new QueryContext<String>().setResult(sid.getData().getSid(), SESSION_ID);
+        } catch (ApiException x) {
+            authCxt = new QueryContext<String>().setServiceError(x);
+        }
+
+        fireAuthenticationEvent(authCxt);
+
+        return authCxt;
+    }
 }

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/providers/auth/TrustedAuthentication.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/providers/auth/TrustedAuthentication.java
@@ -1,8 +1,27 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * MIT License
+ *
+ * Copyright (c) 2018 SKB Kontur
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  */
+
 package ru.skbkontur.sdk.extern.providers.auth;
 
 import ru.argosgrp.cryptoservice.utils.IOUtil;

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/providers/crypt/cloud/CloudCryptoProvider.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/providers/crypt/cloud/CloudCryptoProvider.java
@@ -1,8 +1,27 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * MIT License
+ *
+ * Copyright (c) 2018 SKB Kontur
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  */
+
 package ru.skbkontur.sdk.extern.providers.crypt.cloud;
 
 import ru.skbkontur.sdk.extern.Messages;

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/providers/crypt/cloud/CloudCryptoProvider.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/providers/crypt/cloud/CloudCryptoProvider.java
@@ -5,391 +5,383 @@
  */
 package ru.skbkontur.sdk.extern.providers.crypt.cloud;
 
-import ru.skbkontur.sdk.extern.providers.crypt.cloud.model.ContentRequest;
-import java.util.Base64;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.concurrent.CompletableFuture;
-import java.util.function.Function;
 import ru.skbkontur.sdk.extern.Messages;
-import static ru.skbkontur.sdk.extern.Messages.C_NO_DECRYPT;
-import static ru.skbkontur.sdk.extern.Messages.C_NO_SIGNATURE;
 import ru.skbkontur.sdk.extern.providers.ApiKeyProvider;
 import ru.skbkontur.sdk.extern.providers.AuthenticationProvider;
 import ru.skbkontur.sdk.extern.providers.CryptoProvider;
 import ru.skbkontur.sdk.extern.providers.ServiceError;
 import ru.skbkontur.sdk.extern.providers.crypt.cloud.model.ApprovedDecryptResponse;
-import ru.skbkontur.sdk.extern.providers.crypt.cloud.model.RequestResponse;
 import ru.skbkontur.sdk.extern.providers.crypt.cloud.model.ApprovedSignaturesResponse;
+import ru.skbkontur.sdk.extern.providers.crypt.cloud.model.ContentRequest;
+import ru.skbkontur.sdk.extern.providers.crypt.cloud.model.RequestResponse;
 import ru.skbkontur.sdk.extern.service.transport.adaptors.Query;
 import ru.skbkontur.sdk.extern.service.transport.adaptors.QueryContext;
-import static ru.skbkontur.sdk.extern.service.transport.adaptors.QueryContext.CONTENT;
 import ru.skbkontur.sdk.extern.service.transport.invoker.ApiClient;
 import ru.skbkontur.sdk.extern.service.transport.invoker.ApiException;
 import ru.skbkontur.sdk.extern.service.transport.invoker.ApiResponse;
 import ru.skbkontur.sdk.extern.service.transport.swagger.invoker.auth.ApiKeyAuth;
 import ru.skbkontur.sdk.extern.service.transport.swagger.invoker.auth.Authentication;
 
+import java.util.Base64;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
+
+import static ru.skbkontur.sdk.extern.Messages.C_NO_DECRYPT;
+import static ru.skbkontur.sdk.extern.Messages.C_NO_SIGNATURE;
+import static ru.skbkontur.sdk.extern.service.transport.adaptors.QueryContext.CONTENT;
+
+
 /**
- *
  * @author AlexS
  */
 public class CloudCryptoProvider implements CryptoProvider {
 
-	private static final String SIGNATURE = "подпись";
-	private static final String DECRYPT = "дешифрование";
-	
-	private static final String REQUEST_RESPONSE = "requestResponse";
-	private static final String APPROVED_SIGNATURE_RESPONSE = "approvedSignaturesResponse";
-	private static final String APPROVED_DECRYPT_RESPONSE = "approvedDecryptResponse";
-	private static final String APPROVE_CODE = "approveCode";
-	private static final String RESULT_ID = "resultId";
+    private static final String SIGNATURE = "подпись";
+    private static final String DECRYPT = "дешифрование";
 
-	private static final String SIGN_REQUEST = "/sign";
-	private static final String DECRYPT_REQUEST = "/decrypt";
-	private static final String APPROVE_SIGNATURES_REQUEST = "/signatures/{0}";
-	private static final String APPROVE_DECRYPTED_REQUEST = "/decrypted/{0}";
-	private static final String SMS_CODE = "X-CloudCrypt-SmsCode";
+    private static final String REQUEST_RESPONSE = "requestResponse";
+    private static final String APPROVED_SIGNATURE_RESPONSE = "approvedSignaturesResponse";
+    private static final String APPROVED_DECRYPT_RESPONSE = "approvedDecryptResponse";
+    private static final String APPROVE_CODE = "approveCode";
+    private static final String RESULT_ID = "resultId";
 
-	private final String cloudCryptoBaseUri;
+    private static final String SIGN_REQUEST = "/sign";
+    private static final String DECRYPT_REQUEST = "/decrypt";
+    private static final String APPROVE_SIGNATURES_REQUEST = "/signatures/{0}";
+    private static final String APPROVE_DECRYPTED_REQUEST = "/decrypted/{0}";
+    private static final String SMS_CODE = "X-CloudCrypt-SmsCode";
 
-	protected AuthenticationProvider authenticationProvider;
+    private final String cloudCryptoBaseUri;
 
-	protected ApiKeyProvider apiKeyProvider;
+    protected AuthenticationProvider authenticationProvider;
 
-	private Function<String, String> approveCodeProvider;
+    protected ApiKeyProvider apiKeyProvider;
 
-	private Function<String, byte[]> certificateProvider;
+    private Function<String, String> approveCodeProvider;
 
-	public CloudCryptoProvider(String cloudCryptoBaseUri) {
-		this.cloudCryptoBaseUri = cloudCryptoBaseUri;
-	}
+    private Function<String, byte[]> certificateProvider;
 
-	public void setApproveCodeProvider(Function<String, String> approveCodeProvider) {
-		this.approveCodeProvider = approveCodeProvider;
-	}
+    public CloudCryptoProvider(String cloudCryptoBaseUri) {
+        this.cloudCryptoBaseUri = cloudCryptoBaseUri;
+    }
 
-	public void setAuthenticationProvider(AuthenticationProvider authenticationProvider) {
-		this.authenticationProvider = authenticationProvider;
-	}
+    private static void acceptAccessToken(QueryContext<?> cxt) { //String apiKeyPrefix, String accessToken) {
+        if (cxt.getSessionId() != null && !cxt.getSessionId().isEmpty()) {
+            Authentication apiKeyAuth = cxt.getApiClient().getAuthentication("auth.sid");
+            if (apiKeyAuth != null) {
+                ((ApiKeyAuth) apiKeyAuth).setApiKey(cxt.getSessionId());
+                ((ApiKeyAuth) apiKeyAuth).setApiKeyPrefix(cxt.getAuthenticationProvider().authPrefix());
+            }
+        }
+    }
 
-	public CloudCryptoProvider authenticationProvider(AuthenticationProvider authenticationProvider) {
-		this.authenticationProvider = authenticationProvider;
-		return this;
-	}
+    public void setApproveCodeProvider(Function<String, String> approveCodeProvider) {
+        this.approveCodeProvider = approveCodeProvider;
+    }
 
-	public void setApiKeyProvider(ApiKeyProvider apiKeyProvider) {
-		this.apiKeyProvider = apiKeyProvider;
-	}
+    public void setAuthenticationProvider(AuthenticationProvider authenticationProvider) {
+        this.authenticationProvider = authenticationProvider;
+    }
 
-	public CloudCryptoProvider apiKeyProvider(ApiKeyProvider apiKeyProvider) {
-		this.apiKeyProvider = apiKeyProvider;
-		return this;
-	}
+    public CloudCryptoProvider authenticationProvider(AuthenticationProvider authenticationProvider) {
+        this.authenticationProvider = authenticationProvider;
+        return this;
+    }
 
-	public CloudCryptoProvider approveCodeProvider(Function<String, String> approveCodeProvider) {
-		this.approveCodeProvider = approveCodeProvider;
-		return this;
-	}
+    public void setApiKeyProvider(ApiKeyProvider apiKeyProvider) {
+        this.apiKeyProvider = apiKeyProvider;
+    }
 
-	public void setCertificateProvider(Function<String, byte[]> certificateProvider) {
-		this.certificateProvider = certificateProvider;
-	}
+    public CloudCryptoProvider apiKeyProvider(ApiKeyProvider apiKeyProvider) {
+        this.apiKeyProvider = apiKeyProvider;
+        return this;
+    }
 
-	public CloudCryptoProvider certificateProvider(Function<String, byte[]> certificateProvider) {
-		this.certificateProvider = certificateProvider;
-		return this;
-	}
+    public CloudCryptoProvider approveCodeProvider(Function<String, String> approveCodeProvider) {
+        this.approveCodeProvider = approveCodeProvider;
+        return this;
+    }
 
-	@Override
-	public CompletableFuture<QueryContext<byte[]>> signAsync(String thumbprint, byte[] content) {
+    public void setCertificateProvider(Function<String, byte[]> certificateProvider) {
+        this.certificateProvider = certificateProvider;
+    }
 
-		QueryContext<byte[]> cxt = createQueryContext(SIGNATURE);
+    public CloudCryptoProvider certificateProvider(Function<String, byte[]> certificateProvider) {
+        this.certificateProvider = certificateProvider;
+        return this;
+    }
 
-		return CompletableFuture
-			.supplyAsync(
-				()
-				-> {
-				return sign(
-					cxt
-						.setThumbprint(thumbprint)
-						.setContent(content)
-				);
-			}
-			);
-	}
+    @Override
+    public CompletableFuture<QueryContext<byte[]>> signAsync(String thumbprint, byte[] content) {
 
-	@Override
-	public QueryContext<byte[]> sign(QueryContext<byte[]> parent) {
+        QueryContext<byte[]> cxt = createQueryContext(SIGNATURE);
 
-		QueryContext<byte[]> cxt = createQueryContext(parent, SIGNATURE);
+        return CompletableFuture
+                .supplyAsync(
+                        ()
+                                -> {
+                            return sign(
+                                    cxt
+                                            .setThumbprint(thumbprint)
+                                            .setContent(content)
+                            );
+                        }
+                );
+    }
 
-		// получить смс-код для подтверждения подписи
-		if (approveCodeProvider == null) {
-			return cxt.setServiceError("SMS provider does not installed.");
-		}
+    @Override
+    public QueryContext<byte[]> sign(QueryContext<byte[]> parent) {
 
-		try {
-			// запросить облачную подпись у сервиса
-			QueryContext<RequestResponse> signatureReqRespCxt = operateRequest(cxt, SIGN_REQUEST, SIGNATURE);
-			if (signatureReqRespCxt.isFail()) {
-				return cxt.setServiceError(signatureReqRespCxt);
-			}
-			// ответ сервиса содержит идентификатор запроса
-			RequestResponse signatureReqResp = (RequestResponse) signatureReqRespCxt.get(REQUEST_RESPONSE);
-			// запросить код подтверждения у владельца облачного сертификата
-			String approveCode = approveCodeProvider.apply(signatureReqResp.getResultId());
-			// устанавливаем в контекст код подтверждения
-			cxt.set(APPROVE_CODE, approveCode);
-			// устанавливаем в контекст код подтверждения
-			cxt.set(RESULT_ID, signatureReqResp.getResultId());
-			// подтвердить создание подписи смс-кодом
-			QueryContext<ApprovedSignaturesResponse> approvedCxt = approveRequest(cxt, ApprovedSignaturesResponse.class, SIGNATURE, APPROVED_SIGNATURE_RESPONSE, APPROVE_SIGNATURES_REQUEST);
-			if (approvedCxt.isFail()) {
-				return cxt.setServiceError(approvedCxt);
-			}
-			// проверяем наличие подписи в ответе сервиса
-			if (approvedCxt.get() == null || approvedCxt.get().getSignatures() == null || approvedCxt.get().getSignatures().isEmpty()) {
-				return cxt.setServiceError(Messages.get(C_NO_SIGNATURE));
-			}
-			// ожидается только одна подпись в ответе
-			String base64 = approvedCxt.get().getSignatures().get(0).getContent();
+        QueryContext<byte[]> cxt = createQueryContext(parent, SIGNATURE);
 
-			return cxt.setResult(Base64.getDecoder().decode(base64), CONTENT);
-		}
-		catch (ApiException x) {
-			return cxt.setServiceError(ServiceError.ErrorCode.server, x.getMessage(), x.getCode(), x.getResponseHeaders(), x.getResponseBody());
-		}
-	}
+        // получить смс-код для подтверждения подписи
+        if (approveCodeProvider == null) {
+            return cxt.setServiceError("SMS provider does not installed.");
+        }
 
-	@Override
-	public CompletableFuture<QueryContext<byte[]>> getSignerCertificateAsync(String thumbprint) {
+        // запросить облачную подпись у сервиса
+        QueryContext<RequestResponse> signatureReqRespCxt = operateRequest(cxt, SIGN_REQUEST, SIGNATURE);
+        if (signatureReqRespCxt.isFail()) {
+            return cxt.setServiceError(signatureReqRespCxt);
+        }
+        // ответ сервиса содержит идентификатор запроса
+        RequestResponse signatureReqResp = signatureReqRespCxt.get(REQUEST_RESPONSE);
+        // запросить код подтверждения у владельца облачного сертификата
+        String approveCode = approveCodeProvider.apply(signatureReqResp.getResultId());
+        // устанавливаем в контекст код подтверждения
+        cxt.set(APPROVE_CODE, approveCode);
+        // устанавливаем в контекст код подтверждения
+        cxt.set(RESULT_ID, signatureReqResp.getResultId());
+        // подтвердить создание подписи смс-кодом
+        QueryContext<ApprovedSignaturesResponse> approvedCxt = approveRequest(cxt, ApprovedSignaturesResponse.class, SIGNATURE, APPROVED_SIGNATURE_RESPONSE, APPROVE_SIGNATURES_REQUEST);
+        if (approvedCxt.isFail()) {
+            return cxt.setServiceError(approvedCxt);
+        }
+        // проверяем наличие подписи в ответе сервиса
+        if (approvedCxt.get() == null || approvedCxt.get().getSignatures() == null || approvedCxt.get().getSignatures().isEmpty()) {
+            return cxt.setServiceError(Messages.get(C_NO_SIGNATURE));
+        }
+        // ожидается только одна подпись в ответе
+        String base64 = approvedCxt.get().getSignatures().get(0).getContent();
 
-		QueryContext<byte[]> cxt = createQueryContext(SIGNATURE);
+        return cxt.setResult(Base64.getDecoder().decode(base64), CONTENT);
+    }
 
-		return CompletableFuture
-			.supplyAsync(
-				()
-				-> {
-				return getSignerCertificate(
-					cxt
-						.setThumbprint(thumbprint)
-				);
-			}
-			);
-	}
+    @Override
+    public CompletableFuture<QueryContext<byte[]>> getSignerCertificateAsync(String thumbprint) {
 
-	@Override
-	public QueryContext<byte[]> getSignerCertificate(QueryContext<byte[]> parent) {
-		QueryContext<byte[]> cxt = createQueryContext(parent, SIGNATURE);
+        QueryContext<byte[]> cxt = createQueryContext(SIGNATURE);
 
-		if (certificateProvider == null) {
-			return cxt.setServiceError("Certificate provider does not installed.");
-		}
+        return CompletableFuture
+                .supplyAsync(
+                        ()
+                                -> {
+                            return getSignerCertificate(
+                                    cxt
+                                            .setThumbprint(thumbprint)
+                            );
+                        }
+                );
+    }
 
-		String thumbprint = cxt.getThumbprint();
+    @Override
+    public QueryContext<byte[]> getSignerCertificate(QueryContext<byte[]> parent) {
+        QueryContext<byte[]> cxt = createQueryContext(parent, SIGNATURE);
 
-		return cxt.setResult(certificateProvider.apply(thumbprint), CONTENT);
-	}
+        if (certificateProvider == null) {
+            return cxt.setServiceError("Certificate provider does not installed.");
+        }
 
-	@Override
-	public CompletableFuture<QueryContext<byte[]>> decryptAsync(String thumbprint, byte[] content) {
-		return CompletableFuture
-			.supplyAsync(
-				()->
-					{
-						return decrypt(
-							new QueryContext<byte[]>()
-								.setThumbprint(thumbprint)
-								.setContent(content)
-						);
-					}
-			);
-	}
-	
-	@Override
-	public QueryContext<byte[]> decrypt(QueryContext<byte[]> parent) {
+        String thumbprint = cxt.getThumbprint();
 
-		QueryContext<byte[]> cxt = createQueryContext(parent, DECRYPT);
+        return cxt.setResult(certificateProvider.apply(thumbprint), CONTENT);
+    }
 
-		// провайдер смс-кода для подтверждения подписи
-		if (approveCodeProvider == null) {
-			return cxt.setServiceError("SMS provider does not installed.");
-		}
+    @Override
+    public CompletableFuture<QueryContext<byte[]>> decryptAsync(String thumbprint, byte[] content) {
+        return CompletableFuture
+                .supplyAsync(
+                        () ->
+                        {
+                            return decrypt(
+                                    new QueryContext<byte[]>()
+                                            .setThumbprint(thumbprint)
+                                            .setContent(content)
+                            );
+                        }
+                );
+    }
 
-		try {
-			// запросить расшифрование контента у сервиса
-			QueryContext<RequestResponse> decryptReqRespCxt = operateRequest(cxt,DECRYPT_REQUEST, DECRYPT);
-			if (decryptReqRespCxt.isFail()) {
-				return cxt.setServiceError(decryptReqRespCxt);
-			}
-			// ответ сервиса содержит идентификатор запроса
-			RequestResponse decryptReqResp = (RequestResponse) decryptReqRespCxt.get(REQUEST_RESPONSE);
-			// запросить код подтверждения у владельца облачного сертификата
-			String approveCode = approveCodeProvider.apply(decryptReqResp.getResultId());
-			// устанавливаем в контекст код подтверждения
-			cxt.set(APPROVE_CODE, approveCode);
-			// устанавливаем в контекст код подтверждения
-			cxt.set(RESULT_ID, decryptReqResp.getResultId());
-			// подтвердить полномочия смс-кодом
-			QueryContext<ApprovedDecryptResponse> approvedCxt = approveRequest(cxt, ApprovedDecryptResponse.class, DECRYPT, APPROVED_DECRYPT_RESPONSE, APPROVE_DECRYPTED_REQUEST);
-			if (approvedCxt.isFail()) {
-				return cxt.setServiceError(approvedCxt);
-			}
-			// проверяем наличие контента в ответе сервиса
-			if (approvedCxt.get() == null || approvedCxt.get().getData() == null || approvedCxt.get().getData().isEmpty()) {
-				return cxt.setServiceError(Messages.get(C_NO_DECRYPT));
-			}
-			// ожидается только одна подпись в ответе
-			String base64 = approvedCxt.get().getData().get(0).getContent();
+    @Override
+    public QueryContext<byte[]> decrypt(QueryContext<byte[]> parent) {
 
-			return cxt.setResult(Base64.getDecoder().decode(base64), CONTENT);
-		}
-		catch (ApiException x) {
-			return cxt.setServiceError(ServiceError.ErrorCode.server, x.getMessage(), x.getCode(), x.getResponseHeaders(), x.getResponseBody());
-		}
-	}
-	
-	private QueryContext<RequestResponse> operateRequest(QueryContext<byte[]> cxt, String request, String operateName) throws ApiException {
+        QueryContext<byte[]> cxt = createQueryContext(parent, DECRYPT);
 
-		String thumbprint = cxt.getThumbprint();
+        // провайдер смс-кода для подтверждения подписи
+        if (approveCodeProvider == null) {
+            return cxt.setServiceError("SMS provider does not installed.");
+        }
 
-		byte[] content = cxt.getContent();
+        // запросить расшифрование контента у сервиса
+        QueryContext<RequestResponse> decryptReqRespCxt = operateRequest(cxt, DECRYPT_REQUEST, DECRYPT);
+        if (decryptReqRespCxt.isFail()) {
+            return cxt.setServiceError(decryptReqRespCxt);
+        }
+        // ответ сервиса содержит идентификатор запроса
+        RequestResponse decryptReqResp = decryptReqRespCxt.get(REQUEST_RESPONSE);
+        // запросить код подтверждения у владельца облачного сертификата
+        String approveCode = approveCodeProvider.apply(decryptReqResp.getResultId());
+        // устанавливаем в контекст код подтверждения
+        cxt.set(APPROVE_CODE, approveCode);
+        // устанавливаем в контекст код подтверждения
+        cxt.set(RESULT_ID, decryptReqResp.getResultId());
+        // подтвердить полномочия смс-кодом
+        QueryContext<ApprovedDecryptResponse> approvedCxt = approveRequest(cxt, ApprovedDecryptResponse.class, DECRYPT, APPROVED_DECRYPT_RESPONSE, APPROVE_DECRYPTED_REQUEST);
+        if (approvedCxt.isFail()) {
+            return cxt.setServiceError(approvedCxt);
+        }
+        // проверяем наличие контента в ответе сервиса
+        if (approvedCxt.get() == null || approvedCxt.get().getData() == null || approvedCxt.get().getData().isEmpty()) {
+            return cxt.setServiceError(Messages.get(C_NO_DECRYPT));
+        }
+        // ожидается только одна подпись в ответе
+        String base64 = approvedCxt.get().getData().get(0).getContent();
 
-		String base64 = Base64.getEncoder().encodeToString(content);
+        return cxt.setResult(Base64.getDecoder().decode(base64), CONTENT);
+    }
 
-		ContentRequest contentRequest = new ContentRequest(thumbprint, base64);
+    private QueryContext<RequestResponse> operateRequest(QueryContext<byte[]> cxt, String request, String operateName) {
 
-		QueryContext<RequestResponse> respCxt = createQueryContext(cxt, operateName);
+        String thumbprint = cxt.getThumbprint();
 
-		return respCxt.apply(new RequestResponseQuery(contentRequest, request));
-	}
+        byte[] content = cxt.getContent();
 
-	private <T> QueryContext<T> approveRequest(QueryContext<byte[]> cxt, Class<T> clazz, String operateName, String entityName, String request) throws ApiException {
-		// идентификатор запроса
-		String resultId = cxt.get(RESULT_ID);
-		// смс-код подтверждения
-		String approveCode = cxt.get(APPROVE_CODE);
+        String base64 = Base64.getEncoder().encodeToString(content);
 
-		QueryContext<T> respCxt = createQueryContext(cxt, operateName);
+        ContentRequest contentRequest = new ContentRequest(thumbprint, base64);
 
-		return respCxt.apply(new ApprovedQuery<>(resultId, approveCode, clazz, entityName, request));
-	}
+        QueryContext<RequestResponse> respCxt = createQueryContext(cxt, operateName);
 
-	private <T> QueryContext<T> createQueryContext(String entityName) {
-		QueryContext<T> cxt = new QueryContext<>(entityName);
-		cxt.setApiClient(new ApiClient());
-		cxt.setServiceBaseUri(cloudCryptoBaseUri);
-		cxt.setAuthenticationProvider(authenticationProvider);
-		cxt.setApiKeyProvider(apiKeyProvider);
-		cxt.configureApiClient();
-		return cxt;
-	}
+        return respCxt.apply(new RequestResponseQuery(contentRequest, request));
+    }
 
-	private <T> QueryContext<T> createQueryContext(QueryContext<?> parent, String entityName) {
-		QueryContext<T> cxt = new QueryContext<>(parent, entityName);
-		cxt.setApiClient(new ApiClient());
-		cxt.setServiceBaseUri(cloudCryptoBaseUri);
-		cxt.setAuthenticationProvider(authenticationProvider);
-		cxt.setApiKeyProvider(apiKeyProvider);
-		cxt.configureApiClient();
-		return cxt;
-	}
+    private <T> QueryContext<T> approveRequest(QueryContext<byte[]> cxt, Class<T> clazz, String operateName, String entityName, String request) {
+        // идентификатор запроса
+        String resultId = cxt.get(RESULT_ID);
+        // смс-код подтверждения
+        String approveCode = cxt.get(APPROVE_CODE);
 
-	private static void acceptAccessToken(QueryContext<?> cxt) { //String apiKeyPrefix, String accessToken) {
-		if (cxt.getSessionId() != null && !cxt.getSessionId().isEmpty()) {
-			Authentication apiKeyAuth = cxt.getApiClient().getAuthentication("auth.sid");
-			if (apiKeyAuth != null) {
-				((ApiKeyAuth) apiKeyAuth).setApiKey(cxt.getSessionId());
-				((ApiKeyAuth) apiKeyAuth).setApiKeyPrefix(cxt.getAuthenticationProvider().authPrefix());
-			}
-		}
-	}
-	
-	static class RequestResponseQuery implements Query<RequestResponse> {
+        QueryContext<T> respCxt = createQueryContext(cxt, operateName);
 
-		private final ContentRequest contentRequest;
-		private final String request;
+        return respCxt.apply(new ApprovedQuery<>(resultId, approveCode, clazz, entityName, request));
+    }
 
-		RequestResponseQuery(ContentRequest contentRequest, String request) {
-			this.contentRequest = contentRequest;
-			this.request = request;
-		}
+    private <T> QueryContext<T> createQueryContext(String entityName) {
+        QueryContext<T> cxt = new QueryContext<>(entityName);
+        cxt.setApiClient(new ApiClient());
+        cxt.setServiceBaseUri(cloudCryptoBaseUri);
+        cxt.setAuthenticationProvider(authenticationProvider);
+        cxt.setApiKeyProvider(apiKeyProvider);
+        cxt.configureApiClient();
+        return cxt;
+    }
 
-		@Override
-		public QueryContext<RequestResponse> apply(QueryContext<RequestResponse> context) {
-			try {
-				acceptAccessToken(context);
-				
-				ApiResponse<RequestResponse> resp 
-					= context
-						.getApiClient()
-						.submitHttpRequest(request,
-							"POST",
-							Collections.emptyMap(),
-							contentRequest,
-							new HashMap<>(),
-							Collections.emptyMap(),
-							RequestResponse.class
-						);
+    private <T> QueryContext<T> createQueryContext(QueryContext<?> parent, String entityName) {
+        QueryContext<T> cxt = new QueryContext<>(parent, entityName);
+        cxt.setApiClient(new ApiClient());
+        cxt.setServiceBaseUri(cloudCryptoBaseUri);
+        cxt.setAuthenticationProvider(authenticationProvider);
+        cxt.setApiKeyProvider(apiKeyProvider);
+        cxt.configureApiClient();
+        return cxt;
+    }
 
-				return context.setResult(resp.getData(), REQUEST_RESPONSE);
-			}
-			catch (ApiException x) {
-				return context.setServiceError(ServiceError.ErrorCode.server, x.getMessage(), x.getCode(), x.getResponseHeaders(), x.getResponseBody());
-			}
-		}
-	}
 
-	static class ApprovedQuery<T> implements Query<T> {
+    static class RequestResponseQuery implements Query<RequestResponse> {
 
-		private final String resultId;
-		private final String approveCode;
-		private final Class<T> clazz;
-		private final String entityName;
-		private final String request;
+        private final ContentRequest contentRequest;
+        private final String request;
 
-		ApprovedQuery(String resultId, String approveCode, Class<T> clazz, String entityName, String request) {
-			this.resultId = resultId;
-			this.approveCode = approveCode;
-			this.clazz = clazz;
-			this.entityName = entityName;
-			this.request = request;
-		}
+        RequestResponseQuery(ContentRequest contentRequest, String request) {
+            this.contentRequest = contentRequest;
+            this.request = request;
+        }
 
-		@Override
-		public QueryContext<T> apply(QueryContext<T> context) {
-			// запрос на отправку кода подтверждения
-			final String theRequest = java.text.MessageFormat.format(request, resultId);
-			// заголовок запроса
-			Map<String, String> headers = new HashMap<String, String>() {
-				{
-					put(SMS_CODE, approveCode);
-				}
-			};
+        @Override
+        public QueryContext<RequestResponse> apply(QueryContext<RequestResponse> context) {
+            try {
+                acceptAccessToken(context);
 
-			try {
-				acceptAccessToken(context);
-				
-				ApiResponse<T> resp 
-					= context
-						.getApiClient()
-						.submitHttpRequest(
-							theRequest,
-							"GET",
-							Collections.emptyMap(),
-							null,
-							headers,
-							Collections.emptyMap(),
-							clazz
-					);
+                ApiResponse<RequestResponse> resp
+                        = context
+                        .getApiClient()
+                        .submitHttpRequest(request,
+                                "POST",
+                                Collections.emptyMap(),
+                                contentRequest,
+                                new HashMap<>(),
+                                Collections.emptyMap(),
+                                RequestResponse.class
+                        );
 
-				return context.setResult(resp.getData(), entityName);
-			}
-			catch (ApiException x) {
-				return context.setServiceError(ServiceError.ErrorCode.server, x.getMessage(), x.getCode(), x.getResponseHeaders(), x.getResponseBody());
-			}
-		}
-	}
+                return context.setResult(resp.getData(), REQUEST_RESPONSE);
+            } catch (ApiException x) {
+                return context.setServiceError(ServiceError.ErrorCode.server, x.getMessage(), x.getCode(), x.getResponseHeaders(), x.getResponseBody());
+            }
+        }
+    }
+
+
+    static class ApprovedQuery<T> implements Query<T> {
+
+        private final String resultId;
+        private final String approveCode;
+        private final Class<T> clazz;
+        private final String entityName;
+        private final String request;
+
+        ApprovedQuery(String resultId, String approveCode, Class<T> clazz, String entityName, String request) {
+            this.resultId = resultId;
+            this.approveCode = approveCode;
+            this.clazz = clazz;
+            this.entityName = entityName;
+            this.request = request;
+        }
+
+        @Override
+        public QueryContext<T> apply(QueryContext<T> context) {
+            // запрос на отправку кода подтверждения
+            final String theRequest = java.text.MessageFormat.format(request, resultId);
+            // заголовок запроса
+            Map<String, String> headers = new HashMap<String, String>() {
+                {
+                    put(SMS_CODE, approveCode);
+                }
+            };
+
+            try {
+                acceptAccessToken(context);
+
+                ApiResponse<T> resp
+                        = context
+                        .getApiClient()
+                        .submitHttpRequest(
+                                theRequest,
+                                "GET",
+                                Collections.emptyMap(),
+                                null,
+                                headers,
+                                Collections.emptyMap(),
+                                clazz
+                        );
+
+                return context.setResult(resp.getData(), entityName);
+            } catch (ApiException x) {
+                return context.setServiceError(ServiceError.ErrorCode.server, x.getMessage(), x.getCode(), x.getResponseHeaders(), x.getResponseBody());
+            }
+        }
+    }
 }

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/providers/crypt/cloud/model/ApprovedDecryptResponse.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/providers/crypt/cloud/model/ApprovedDecryptResponse.java
@@ -6,21 +6,23 @@
 package ru.skbkontur.sdk.extern.providers.crypt.cloud.model;
 
 import com.google.gson.annotations.SerializedName;
+
 import java.util.List;
 
+
 /**
- *
  * @author alexs
  */
 public class ApprovedDecryptResponse {
-	@SerializedName("Data")
-	private List<Entry> data;
 
-	public List<Entry> getData() {
-		return data;
-	}
+    @SerializedName("Data")
+    private List<Entry> data;
 
-	public void setData(List<Entry> data) {
-		this.data = data;
-	}
+    public List<Entry> getData() {
+        return data;
+    }
+
+    public void setData(List<Entry> data) {
+        this.data = data;
+    }
 }

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/providers/crypt/cloud/model/ApprovedDecryptResponse.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/providers/crypt/cloud/model/ApprovedDecryptResponse.java
@@ -1,8 +1,27 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * MIT License
+ *
+ * Copyright (c) 2018 SKB Kontur
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  */
+
 package ru.skbkontur.sdk.extern.providers.crypt.cloud.model;
 
 import com.google.gson.annotations.SerializedName;

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/providers/crypt/cloud/model/ApprovedSignaturesResponse.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/providers/crypt/cloud/model/ApprovedSignaturesResponse.java
@@ -6,21 +6,23 @@
 package ru.skbkontur.sdk.extern.providers.crypt.cloud.model;
 
 import com.google.gson.annotations.SerializedName;
+
 import java.util.List;
 
+
 /**
- *
  * @author alexs
  */
 public class ApprovedSignaturesResponse {
-	@SerializedName("Signatures")
-	private List<Entry> signatures;
 
-	public List<Entry> getSignatures() {
-		return signatures;
-	}
+    @SerializedName("Signatures")
+    private List<Entry> signatures;
 
-	public void setSignatures(List<Entry> signatures) {
-		this.signatures = signatures;
-	}
+    public List<Entry> getSignatures() {
+        return signatures;
+    }
+
+    public void setSignatures(List<Entry> signatures) {
+        this.signatures = signatures;
+    }
 }

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/providers/crypt/cloud/model/ApprovedSignaturesResponse.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/providers/crypt/cloud/model/ApprovedSignaturesResponse.java
@@ -1,8 +1,27 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * MIT License
+ *
+ * Copyright (c) 2018 SKB Kontur
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  */
+
 package ru.skbkontur.sdk.extern.providers.crypt.cloud.model;
 
 import com.google.gson.annotations.SerializedName;

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/providers/crypt/cloud/model/ContentRequest.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/providers/crypt/cloud/model/ContentRequest.java
@@ -1,8 +1,27 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * MIT License
+ *
+ * Copyright (c) 2018 SKB Kontur
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  */
+
 package ru.skbkontur.sdk.extern.providers.crypt.cloud.model;
 
 import com.google.gson.annotations.SerializedName;

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/providers/crypt/cloud/model/ContentRequest.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/providers/crypt/cloud/model/ContentRequest.java
@@ -6,44 +6,45 @@
 package ru.skbkontur.sdk.extern.providers.crypt.cloud.model;
 
 import com.google.gson.annotations.SerializedName;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
+
 /**
- *
  * @author AlexS
  */
 public class ContentRequest {
 
-	@SerializedName("CertificateThumbprint")
-	private String thumbprint;
-	@SerializedName("Files")
-	private List<File> files;
+    @SerializedName("CertificateThumbprint")
+    private String thumbprint;
+    @SerializedName("Files")
+    private List<File> files;
 
-	public ContentRequest() {
-	}
+    public ContentRequest() {
+    }
 
-	public ContentRequest(String thumbprint, String content) {
-		this.thumbprint = thumbprint;
-		this.files = new ArrayList<>();
-		File file = new File(UUID.randomUUID().toString(), content);
-		files.add(file);
-	}
+    public ContentRequest(String thumbprint, String content) {
+        this.thumbprint = thumbprint;
+        this.files = new ArrayList<>();
+        File file = new File(UUID.randomUUID().toString(), content);
+        files.add(file);
+    }
 
-	public String getThumbprint() {
-		return thumbprint;
-	}
+    public String getThumbprint() {
+        return thumbprint;
+    }
 
-	public void setThumbprint(String thumbprint) {
-		this.thumbprint = thumbprint;
-	}
+    public void setThumbprint(String thumbprint) {
+        this.thumbprint = thumbprint;
+    }
 
-	public List<File> getFiles() {
-		return files;
-	}
+    public List<File> getFiles() {
+        return files;
+    }
 
-	public void setFiles(List<File> files) {
-		this.files = files;
-	}
+    public void setFiles(List<File> files) {
+        this.files = files;
+    }
 }

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/providers/crypt/cloud/model/Entry.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/providers/crypt/cloud/model/Entry.java
@@ -7,39 +7,40 @@ package ru.skbkontur.sdk.extern.providers.crypt.cloud.model;
 
 import com.google.gson.annotations.SerializedName;
 
+
 /**
- *
  * @author alexs
  */
 public class Entry {
-	@SerializedName("Id")
-	private String id;
-	@SerializedName("FileName")
-	private String fileName;
-	@SerializedName("Content")
-	private String content;
 
-	public String getId() {
-		return id;
-	}
+    @SerializedName("Id")
+    private String id;
+    @SerializedName("FileName")
+    private String fileName;
+    @SerializedName("Content")
+    private String content;
 
-	public void setId(String id) {
-		this.id = id;
-	}
+    public String getId() {
+        return id;
+    }
 
-	public String getFileName() {
-		return fileName;
-	}
+    public void setId(String id) {
+        this.id = id;
+    }
 
-	public void setFileName(String fileName) {
-		this.fileName = fileName;
-	}
+    public String getFileName() {
+        return fileName;
+    }
 
-	public String getContent() {
-		return content;
-	}
+    public void setFileName(String fileName) {
+        this.fileName = fileName;
+    }
 
-	public void setContent(String content) {
-		this.content = content;
-	}
+    public String getContent() {
+        return content;
+    }
+
+    public void setContent(String content) {
+        this.content = content;
+    }
 }

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/providers/crypt/cloud/model/Entry.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/providers/crypt/cloud/model/Entry.java
@@ -1,8 +1,27 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * MIT License
+ *
+ * Copyright (c) 2018 SKB Kontur
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  */
+
 package ru.skbkontur.sdk.extern.providers.crypt.cloud.model;
 
 import com.google.gson.annotations.SerializedName;

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/providers/crypt/cloud/model/File.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/providers/crypt/cloud/model/File.java
@@ -1,8 +1,27 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * MIT License
+ *
+ * Copyright (c) 2018 SKB Kontur
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  */
+
 package ru.skbkontur.sdk.extern.providers.crypt.cloud.model;
 
 import com.google.gson.annotations.SerializedName;

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/providers/crypt/cloud/model/File.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/providers/crypt/cloud/model/File.java
@@ -7,56 +7,56 @@ package ru.skbkontur.sdk.extern.providers.crypt.cloud.model;
 
 import com.google.gson.annotations.SerializedName;
 
+
 /**
- *
  * @author AlexS
  */
 public class File {
 
-	@SerializedName("Id")
-	private String id;
-	@SerializedName("Name")
-	private String name;
-	@SerializedName("Base64Content")
-	private String content;
+    @SerializedName("Id")
+    private String id;
+    @SerializedName("Name")
+    private String name;
+    @SerializedName("Base64Content")
+    private String content;
 
-	File() {
-	}
+    File() {
+    }
 
-	File(String name, String content) {
-		this.name = name;
-		this.content = content;
-	}
+    File(String name, String content) {
+        this.name = name;
+        this.content = content;
+    }
 
-	public String getId() {
-		return id;
-	}
+    public String getId() {
+        return id;
+    }
 
-	public void setId(String id) {
-		this.id = id;
-	}
+    public void setId(String id) {
+        this.id = id;
+    }
 
-	public String getContent() {
-		return content;
-	}
+    public String getContent() {
+        return content;
+    }
 
-	public void setContent(String content) {
-		this.content = content;
-	}
+    public void setContent(String content) {
+        this.content = content;
+    }
 
-	public String getName() {
-		return name;
-	}
+    public String getName() {
+        return name;
+    }
 
-	public void setName(String name) {
-		this.name = name;
-	}
+    public void setName(String name) {
+        this.name = name;
+    }
 
-	public String getСontent() {
-		return content;
-	}
+    public String getСontent() {
+        return content;
+    }
 
-	public void setСontent(String content) {
-		this.content = content;
-	}
+    public void setСontent(String content) {
+        this.content = content;
+    }
 }

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/providers/crypt/cloud/model/Link.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/providers/crypt/cloud/model/Link.java
@@ -7,49 +7,50 @@ package ru.skbkontur.sdk.extern.providers.crypt.cloud.model;
 
 import com.google.gson.annotations.SerializedName;
 
+
 /**
- *
  * @author AlexS
  */
 public class Link {
-	@SerializedName("href")
-	private String href;
-	@SerializedName("Rel")
-	private String rel;
-	@SerializedName("Method")
-	private String method;
-	@SerializedName("InputModelExample")
-	private String inputModelExample;
 
-	public String getHref() {
-		return href;
-	}
+    @SerializedName("href")
+    private String href;
+    @SerializedName("Rel")
+    private String rel;
+    @SerializedName("Method")
+    private String method;
+    @SerializedName("InputModelExample")
+    private String inputModelExample;
 
-	public void setHref(String href) {
-		this.href = href;
-	}
+    public String getHref() {
+        return href;
+    }
 
-	public String getRel() {
-		return rel;
-	}
+    public void setHref(String href) {
+        this.href = href;
+    }
 
-	public void setRel(String rel) {
-		this.rel = rel;
-	}
+    public String getRel() {
+        return rel;
+    }
 
-	public String getMethod() {
-		return method;
-	}
+    public void setRel(String rel) {
+        this.rel = rel;
+    }
 
-	public void setMethod(String method) {
-		this.method = method;
-	}
+    public String getMethod() {
+        return method;
+    }
 
-	public String getInputModelExample() {
-		return inputModelExample;
-	}
+    public void setMethod(String method) {
+        this.method = method;
+    }
 
-	public void setInputModelExample(String inputModelExample) {
-		this.inputModelExample = inputModelExample;
-	}
+    public String getInputModelExample() {
+        return inputModelExample;
+    }
+
+    public void setInputModelExample(String inputModelExample) {
+        this.inputModelExample = inputModelExample;
+    }
 }

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/providers/crypt/cloud/model/Link.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/providers/crypt/cloud/model/Link.java
@@ -1,8 +1,27 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * MIT License
+ *
+ * Copyright (c) 2018 SKB Kontur
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  */
+
 package ru.skbkontur.sdk.extern.providers.crypt.cloud.model;
 
 import com.google.gson.annotations.SerializedName;

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/providers/crypt/cloud/model/RequestResponse.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/providers/crypt/cloud/model/RequestResponse.java
@@ -6,41 +6,43 @@
 package ru.skbkontur.sdk.extern.providers.crypt.cloud.model;
 
 import com.google.gson.annotations.SerializedName;
+
 import java.util.List;
 
+
 /**
- *
  * @author AlexS
  */
 public class RequestResponse {
-		@SerializedName("ResultId")
-		private String resultId;
-		@SerializedName("FileIds")
-		private List<File> fileIds;
-		@SerializedName("Links")
-		private List<Link> links;
 
-	public String getResultId() {
-		return resultId;
-	}
+    @SerializedName("ResultId")
+    private String resultId;
+    @SerializedName("FileIds")
+    private List<File> fileIds;
+    @SerializedName("Links")
+    private List<Link> links;
 
-	public void setResultId(String resultId) {
-		this.resultId = resultId;
-	}
+    public String getResultId() {
+        return resultId;
+    }
 
-	public List<File> getFileIds() {
-		return fileIds;
-	}
+    public void setResultId(String resultId) {
+        this.resultId = resultId;
+    }
 
-	public void setFileIds(List<File> fileIds) {
-		this.fileIds = fileIds;
-	}
+    public List<File> getFileIds() {
+        return fileIds;
+    }
 
-	public List<Link> getLinks() {
-		return links;
-	}
+    public void setFileIds(List<File> fileIds) {
+        this.fileIds = fileIds;
+    }
 
-	public void setLinks(List<Link> links) {
-		this.links = links;
-	}
+    public List<Link> getLinks() {
+        return links;
+    }
+
+    public void setLinks(List<Link> links) {
+        this.links = links;
+    }
 }

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/providers/crypt/cloud/model/RequestResponse.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/providers/crypt/cloud/model/RequestResponse.java
@@ -1,8 +1,27 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * MIT License
+ *
+ * Copyright (c) 2018 SKB Kontur
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  */
+
 package ru.skbkontur.sdk.extern.providers.crypt.cloud.model;
 
 import com.google.gson.annotations.SerializedName;

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/providers/crypt/mscapi/CryptoProviderMSCapi.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/providers/crypt/mscapi/CryptoProviderMSCapi.java
@@ -5,11 +5,6 @@
  */
 package ru.skbkontur.sdk.extern.providers.crypt.mscapi;
 
-import java.util.Arrays;
-import java.util.Map;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.stream.Stream;
 import ru.argosgrp.cryptoservice.CryptoException;
 import ru.argosgrp.cryptoservice.CryptoService;
 import ru.argosgrp.cryptoservice.Key;
@@ -17,155 +12,158 @@ import ru.argosgrp.cryptoservice.mscapi.MSCapi;
 import ru.argosgrp.cryptoservice.pkcs7.PKCS7;
 import ru.argosgrp.cryptoservice.utils.IOUtil;
 import ru.skbkontur.sdk.extern.Messages;
-import static ru.skbkontur.sdk.extern.Messages.C_CRYPTO_ERROR;
-import static ru.skbkontur.sdk.extern.Messages.C_CRYPTO_ERROR_INIT;
-import static ru.skbkontur.sdk.extern.Messages.C_CRYPTO_ERROR_KEY_NOT_FOUND;
 import ru.skbkontur.sdk.extern.providers.CryptoProvider;
 import ru.skbkontur.sdk.extern.service.SDKException;
 import ru.skbkontur.sdk.extern.service.transport.adaptors.QueryContext;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Stream;
+
+import static ru.skbkontur.sdk.extern.Messages.C_CRYPTO_ERROR;
+import static ru.skbkontur.sdk.extern.Messages.C_CRYPTO_ERROR_INIT;
+import static ru.skbkontur.sdk.extern.Messages.C_CRYPTO_ERROR_KEY_NOT_FOUND;
 import static ru.skbkontur.sdk.extern.service.transport.adaptors.QueryContext.CONTENT;
 
+
 /**
- *
  * @author AlexS
  */
 public class CryptoProviderMSCapi implements CryptoProvider {
-	
-	private final CryptoService cryptoService;
-	private final Map<String,Key> cacheSignKey;
-	
-	public CryptoProviderMSCapi() throws SDKException {
-		try {
-			cryptoService = new MSCapi(true);
-			cacheSignKey = new ConcurrentHashMap<>();
-		}
-		catch (CryptoException x) {
-			throw new SDKException(Messages.get(C_CRYPTO_ERROR_INIT), x);
-		}
-	}
-	
-	@Override
-	public CompletableFuture<QueryContext<byte[]>> signAsync(String thumbprint, byte[] content) {
-		return CompletableFuture
-			.supplyAsync(
-				()->
-					{
-						return sign(
-							new QueryContext<byte[]>()
-								.setThumbprint(thumbprint)
-								.setContent(content)
-						);
-					}
-			);
-	}
-	
-	@Override
-	public QueryContext<byte[]> sign(QueryContext<byte[]> cxt) {
-		try {
-			String thumbprint = cxt.getThumbprint();
-			
-			Key key = getKeyByThumbprint(thumbprint);
-			if (key == null) {
-				return new QueryContext<byte[]>().setServiceError(Messages.get(C_CRYPTO_ERROR_KEY_NOT_FOUND,thumbprint));
-			}
-			
-			PKCS7 p7p = new PKCS7(cryptoService);
-			
-			byte[] content = cxt.getContent();
-			
-			return new QueryContext<byte[]>().setResult(p7p.sign(key, null, content, false),CONTENT);
-		}
-		catch (CryptoException x) {
-			return new QueryContext<byte[]>().setServiceError(Messages.get(C_CRYPTO_ERROR, x.getMessage()));
-		}
-	}
 
-	@Override
-	public CompletableFuture<QueryContext<byte[]>> getSignerCertificateAsync(String thumbprint) {
-		return CompletableFuture
-			.supplyAsync(
-				()->
-					{
-						return getSignerCertificate(
-							new QueryContext<byte[]>()
-								.setThumbprint(thumbprint)
-						);
-					}
-			);
-	}
-	
-	@Override
-	public QueryContext<byte[]> getSignerCertificate(QueryContext<byte[]> cxt) {
-		try {
-			String thumbprint = cxt.getThumbprint();
-			
-			Key key = getKeyByThumbprint(thumbprint);
-			if (key == null) {
-				return new QueryContext<byte[]>().setServiceError(Messages.get(C_CRYPTO_ERROR_KEY_NOT_FOUND,thumbprint));
-			}
-			
-			return new QueryContext<byte[]>().setResult(key.getX509ctx(),CONTENT);
-		}
-		catch (CryptoException x) {
-			return new QueryContext<byte[]>().setServiceError(Messages.get(C_CRYPTO_ERROR,x.getMessage()));
-		}
-	}
-	
-	@Override
-	public CompletableFuture<QueryContext<byte[]>> decryptAsync(String thumbprint, byte[] content) {
-		return CompletableFuture
-			.supplyAsync(
-				()->
-					{
-						return decrypt(
-							new QueryContext<byte[]>()
-								.setThumbprint(thumbprint)
-								.setContent(content)
-						);
-					}
-			);
-	}
-	
-	@Override
-	public QueryContext<byte[]> decrypt(QueryContext<byte[]> cxt) {
-		try {
-			String thumbprint = cxt.getThumbprint();
-			
-			Key key = getKeyByThumbprint(thumbprint);
-			if (key == null) {
-				return new QueryContext<byte[]>().setServiceError(Messages.get(C_CRYPTO_ERROR_KEY_NOT_FOUND,thumbprint));
-			}
-			
-			PKCS7 p7p = new PKCS7(cryptoService);
-			
-			byte[] content = cxt.getContent();
-			
-			return new QueryContext<byte[]>().setResult(p7p.decrypt(key, null, content),CONTENT);
-		}
-		catch (CryptoException x) {
-			return new QueryContext<byte[]>().setServiceError(Messages.get(C_CRYPTO_ERROR, x.getMessage()));
-		}
-	}
-	
-	public void removeKey(String thumbprint) {
-		cacheSignKey.remove(thumbprint);
-	}
-	
-	public void removeAllKeys() {
-		cacheSignKey.clear();
-	}
-	
-	private Key getKeyByThumbprint(String thumbprint) throws CryptoException {
-		Key key = cacheSignKey.get(thumbprint);
-		if (key == null) {
-			Key[] keys = cryptoService.getKeys();
-			if (keys != null && keys.length > 0) {
-				byte[] t = IOUtil.hexToBytes(thumbprint);
-				key = Stream.of(keys).filter(k->Arrays.equals(k.getThumbprint(),t)).findAny().orElse(null);
-				if (key != null)
-					cacheSignKey.put(thumbprint, key);
-			}
-		}
-		return key;
-	}
+    private final CryptoService cryptoService;
+    private final Map<String, Key> cacheSignKey;
+
+    public CryptoProviderMSCapi() throws SDKException {
+        try {
+            cryptoService = new MSCapi(true);
+            cacheSignKey = new ConcurrentHashMap<>();
+        } catch (CryptoException x) {
+            throw new SDKException(Messages.get(C_CRYPTO_ERROR_INIT), x);
+        }
+    }
+
+    @Override
+    public CompletableFuture<QueryContext<byte[]>> signAsync(String thumbprint, byte[] content) {
+        return CompletableFuture
+                .supplyAsync(
+                        () ->
+                        {
+                            return sign(
+                                    new QueryContext<byte[]>()
+                                            .setThumbprint(thumbprint)
+                                            .setContent(content)
+                            );
+                        }
+                );
+    }
+
+    @Override
+    public QueryContext<byte[]> sign(QueryContext<byte[]> cxt) {
+        try {
+            String thumbprint = cxt.getThumbprint();
+
+            Key key = getKeyByThumbprint(thumbprint);
+            if (key == null) {
+                return new QueryContext<byte[]>().setServiceError(Messages.get(C_CRYPTO_ERROR_KEY_NOT_FOUND, thumbprint));
+            }
+
+            PKCS7 p7p = new PKCS7(cryptoService);
+
+            byte[] content = cxt.getContent();
+
+            return new QueryContext<byte[]>().setResult(p7p.sign(key, null, content, false), CONTENT);
+        } catch (CryptoException x) {
+            return new QueryContext<byte[]>().setServiceError(Messages.get(C_CRYPTO_ERROR, x.getMessage()));
+        }
+    }
+
+    @Override
+    public CompletableFuture<QueryContext<byte[]>> getSignerCertificateAsync(String thumbprint) {
+        return CompletableFuture
+                .supplyAsync(
+                        () ->
+                        {
+                            return getSignerCertificate(
+                                    new QueryContext<byte[]>()
+                                            .setThumbprint(thumbprint)
+                            );
+                        }
+                );
+    }
+
+    @Override
+    public QueryContext<byte[]> getSignerCertificate(QueryContext<byte[]> cxt) {
+        try {
+            String thumbprint = cxt.getThumbprint();
+
+            Key key = getKeyByThumbprint(thumbprint);
+            if (key == null) {
+                return new QueryContext<byte[]>().setServiceError(Messages.get(C_CRYPTO_ERROR_KEY_NOT_FOUND, thumbprint));
+            }
+
+            return new QueryContext<byte[]>().setResult(key.getX509ctx(), CONTENT);
+        } catch (CryptoException x) {
+            return new QueryContext<byte[]>().setServiceError(Messages.get(C_CRYPTO_ERROR, x.getMessage()));
+        }
+    }
+
+    @Override
+    public CompletableFuture<QueryContext<byte[]>> decryptAsync(String thumbprint, byte[] content) {
+        return CompletableFuture
+                .supplyAsync(
+                        () ->
+                        {
+                            return decrypt(
+                                    new QueryContext<byte[]>()
+                                            .setThumbprint(thumbprint)
+                                            .setContent(content)
+                            );
+                        }
+                );
+    }
+
+    @Override
+    public QueryContext<byte[]> decrypt(QueryContext<byte[]> cxt) {
+        try {
+            String thumbprint = cxt.getThumbprint();
+
+            Key key = getKeyByThumbprint(thumbprint);
+            if (key == null) {
+                return new QueryContext<byte[]>().setServiceError(Messages.get(C_CRYPTO_ERROR_KEY_NOT_FOUND, thumbprint));
+            }
+
+            PKCS7 p7p = new PKCS7(cryptoService);
+
+            byte[] content = cxt.getContent();
+
+            return new QueryContext<byte[]>().setResult(p7p.decrypt(key, null, content), CONTENT);
+        } catch (CryptoException x) {
+            return new QueryContext<byte[]>().setServiceError(Messages.get(C_CRYPTO_ERROR, x.getMessage()));
+        }
+    }
+
+    public void removeKey(String thumbprint) {
+        cacheSignKey.remove(thumbprint);
+    }
+
+    public void removeAllKeys() {
+        cacheSignKey.clear();
+    }
+
+    private Key getKeyByThumbprint(String thumbprint) throws CryptoException {
+        Key key = cacheSignKey.get(thumbprint);
+        if (key == null) {
+            Key[] keys = cryptoService.getKeys();
+            if (keys != null && keys.length > 0) {
+                byte[] t = IOUtil.hexToBytes(thumbprint);
+                key = Stream.of(keys).filter(k -> Arrays.equals(k.getThumbprint(), t)).findAny().orElse(null);
+                if (key != null)
+                    cacheSignKey.put(thumbprint, key);
+            }
+        }
+        return key;
+    }
 }

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/providers/crypt/mscapi/CryptoProviderMSCapi.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/providers/crypt/mscapi/CryptoProviderMSCapi.java
@@ -1,8 +1,27 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * MIT License
+ *
+ * Copyright (c) 2018 SKB Kontur
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  */
+
 package ru.skbkontur.sdk.extern.providers.crypt.mscapi;
 
 import ru.argosgrp.cryptoservice.CryptoException;

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/providers/crypt/rsa/CryptoProviderRSA.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/providers/crypt/rsa/CryptoProviderRSA.java
@@ -7,6 +7,14 @@ package ru.skbkontur.sdk.extern.providers.crypt.rsa;
 
 import com.argos.asn1.Asn1Exception;
 import com.argos.cipher.asn1ext.X509certificate;
+import ru.argosgrp.cryptoservice.CryptoException;
+import ru.argosgrp.cryptoservice.pkcs7.PKCS7;
+import ru.argosgrp.cryptoservice.utils.IOUtil;
+import ru.skbkontur.sdk.extern.Messages;
+import ru.skbkontur.sdk.extern.providers.CryptoProvider;
+import ru.skbkontur.sdk.extern.providers.ServiceError;
+import ru.skbkontur.sdk.extern.service.transport.adaptors.QueryContext;
+
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -25,270 +33,263 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Supplier;
-import ru.argosgrp.cryptoservice.CryptoException;
-import ru.argosgrp.cryptoservice.pkcs7.PKCS7;
-import ru.argosgrp.cryptoservice.utils.IOUtil;
-import ru.skbkontur.sdk.extern.Messages;
+
 import static ru.skbkontur.sdk.extern.Messages.C_CRYPTO_ERROR;
 import static ru.skbkontur.sdk.extern.Messages.C_CRYPTO_ERROR_KEY_NOT_FOUND;
-import ru.skbkontur.sdk.extern.providers.CryptoProvider;
-import ru.skbkontur.sdk.extern.providers.ServiceError;
-import ru.skbkontur.sdk.extern.service.transport.adaptors.QueryContext;
 import static ru.skbkontur.sdk.extern.service.transport.adaptors.QueryContext.CONTENT;
 
+
 /**
- *
  * @author alexs
  */
 public class CryptoProviderRSA implements CryptoProvider {
-	private final Map<String,String> DIGEST_ALGORITHMS = new HashMap<String,String>() {
-		private static final long serialVersionUID = 1L;
-		{
-			put("1.2.840.113549.1.1.5","SHA1");
-			put("1.3.14.3.2.29","SHA1");
-			put("1.2.840.113549.1.1.11","SHA-256");
-			put("1.2.840.113549.1.1.12","SHA-384");
-			put("1.2.840.113549.1.1.13","SHA-512");
-		}
-	}; 
 
-	private final String keyPass;
-	private final String keyStorePass;
-	private final Map<String, KeyPair> cacheSignKey;
-	
-	private KeyStore keyStore;
-	private Supplier<String> keyStoreProvider;
+    private final Map<String, String> DIGEST_ALGORITHMS = new HashMap<String, String>() {
+        private static final long serialVersionUID = 1L;
 
-	public CryptoProviderRSA(String keyStorePass, String keyPass) {
-		// default key store source: the jre key store
-		keyStoreProvider = () -> System.getProperty("java.home")+File.separator+"lib"+File.separator+"security"+File.separator+"cacerts";
-		// cache for keys
-		this.cacheSignKey = new ConcurrentHashMap<>();
-		// 
-		this.keyStorePass = keyStorePass;
-		this.keyPass = keyPass;
-	}
+        {
+            put("1.2.840.113549.1.1.5", "SHA1");
+            put("1.3.14.3.2.29", "SHA1");
+            put("1.2.840.113549.1.1.11", "SHA-256");
+            put("1.2.840.113549.1.1.12", "SHA-384");
+            put("1.2.840.113549.1.1.13", "SHA-512");
+        }
+    };
 
-	public Supplier<String> getKeyStoreProvider() {
-		return keyStoreProvider;
-	}
-	
-	public void setKeyStoreProvider(Supplier<String> keyStoreProvider) {
-		this.keyStore = null;
-		cacheSignKey.clear();
-		this.keyStoreProvider = keyStoreProvider;
-	}
-	
-	public CryptoProviderRSA keyStoreProvider(Supplier<String> keyStoreProvider) {
-		this.keyStore = null;
-		cacheSignKey.clear();
-		this.keyStoreProvider = keyStoreProvider;
-		return this;
-	}
-	
-	@Override
-	public CompletableFuture<QueryContext<byte[]>> signAsync(String thumbprint, byte[] content) {
-		return CompletableFuture
-			.supplyAsync(
-				()->
-					{
-						return sign(
-							new QueryContext<byte[]>()
-								.setThumbprint(thumbprint)
-								.setContent(content)
-						);
-					}
-			);
-	}
+    private final String keyPass;
+    private final String keyStorePass;
+    private final Map<String, KeyPair> cacheSignKey;
 
-	@Override
-	public QueryContext<byte[]> sign(QueryContext<byte[]> cxt) {
-		try {
-			String thumbprint = cxt.getThumbprint();
-			
-			KeyPair key = getKeyByThumbprint(thumbprint);
-			if (key == null) {
-				return new QueryContext<byte[]>().setServiceError(Messages.get(C_CRYPTO_ERROR_KEY_NOT_FOUND,thumbprint));
-			}
-			
-			byte[] content = cxt.getContent();
-			
-			byte[] signature = sign(key, content);
-			
-			return new QueryContext<byte[]>().setResult(signature,CONTENT);
-		}
-		catch (Asn1Exception | GeneralSecurityException | CryptoException | IOException x) {
-			return new QueryContext<byte[]>().setServiceError(Messages.get(C_CRYPTO_ERROR, x.getMessage()), x);
-		}
-	}
+    private KeyStore keyStore;
+    private Supplier<String> keyStoreProvider;
 
-	@Override
-	public CompletableFuture<QueryContext<byte[]>> getSignerCertificateAsync(String thumbprint) {
-		return CompletableFuture
-			.supplyAsync(
-				()->
-					{
-						return getSignerCertificate(
-							new QueryContext<byte[]>()
-								.setThumbprint(thumbprint)
-						);
-					}
-			);
-	}
+    public CryptoProviderRSA(String keyStorePass, String keyPass) {
+        // default key store source: the jre key store
+        keyStoreProvider = () -> System.getProperty("java.home") + File.separator + "lib" + File.separator + "security" + File.separator + "cacerts";
+        // cache for keys
+        this.cacheSignKey = new ConcurrentHashMap<>();
+        //
+        this.keyStorePass = keyStorePass;
+        this.keyPass = keyPass;
+    }
 
-	@Override
-	public QueryContext<byte[]> getSignerCertificate(QueryContext<byte[]> cxt) {
-		try {
-			String thumbprint = cxt.getThumbprint();
-			
-			KeyPair key = getKeyByThumbprint(thumbprint);
-			if (key == null) {
-				return new QueryContext<byte[]>().setServiceError(MessageFormat.format(C_CRYPTO_ERROR_KEY_NOT_FOUND,thumbprint));
-			}
-			
-			return new QueryContext<byte[]>().setContent(key.getX509()==null ? null : key.getX509().getEncoded());
-		}
-		catch (Asn1Exception | GeneralSecurityException | IOException  x) {
-			return new QueryContext<byte[]>().setServiceError(ServiceError.ErrorCode.business, MessageFormat.format(C_CRYPTO_ERROR,x.getMessage()), 0, null, null);
-		}
-	}
+    public Supplier<String> getKeyStoreProvider() {
+        return keyStoreProvider;
+    }
 
-	@Override
-	public CompletableFuture<QueryContext<byte[]>> decryptAsync(String thumbprint, byte[] content) {
-		throw new UnsupportedOperationException("Not supported yet.");
-	}
+    public void setKeyStoreProvider(Supplier<String> keyStoreProvider) {
+        this.keyStore = null;
+        cacheSignKey.clear();
+        this.keyStoreProvider = keyStoreProvider;
+    }
 
-	@Override
-	public QueryContext<byte[]> decrypt(QueryContext<byte[]> cxt) {
-		throw new UnsupportedOperationException("Not supported yet.");
-	}
+    public CryptoProviderRSA keyStoreProvider(Supplier<String> keyStoreProvider) {
+        this.keyStore = null;
+        cacheSignKey.clear();
+        this.keyStoreProvider = keyStoreProvider;
+        return this;
+    }
 
-	private byte[] sign(KeyPair key, byte[] content) throws GeneralSecurityException, Asn1Exception, CryptoException {
-		// OID для SHA & RSA 
-		String sha_rsa_oid = PKCS7.getCertificateAlgorithmOID(key.x509.getEncoded());
-		// алгоритм хеширования контента
-		String digestAlgorithm = DIGEST_ALGORITHMS.get(sha_rsa_oid);
-		// хеш контента
-		byte[] digest = this.getDigest(content, digestAlgorithm);
-		// массив байт подписываемых атрибутов
-		byte[] authenticatedAttributes = PKCS7.createRSAAuthenticatedAttributes(digest);
-		// вычисление подписи
-		// получаем экземпляр механизма подписи
-		Signature signer = Signature.getInstance(sha_rsa_oid);
-		// инициализируем механизм подписи секретным ключом
-		signer.initSign(key.getPrivateKey());
-		// вычисляем подпись
-		signer.update(authenticatedAttributes);
-		// извлекаем подпись
-		byte[] signature = signer.sign();
-		// создаем сообщение PKCS#7
-		return PKCS7.createSignCMS(key.getX509().getEncoded(), signature, authenticatedAttributes, null);
-	}
-	
-	private byte[] sign_(KeyPair key, byte[] content) throws GeneralSecurityException, Asn1Exception, CryptoException {
-		// OID для SHA & RSA 
-		String sha_rsa_oid = PKCS7.getCertificateAlgorithmOID(key.x509.getEncoded());
-		// получаем экземпляр механизма подписи
-		Signature signer = Signature.getInstance(sha_rsa_oid);
-		// инициализируем механизм подписи секретным ключом
-		signer.initSign(key.getPrivateKey());
-		// вычисляем подпись
-		signer.update(content);
-		// извлекаем подпись
-		byte[] signature = signer.sign();
-		// создаем сообщение PKCS#7
-		return PKCS7.createSignCMS(key.getX509(), signature, null);
-	}
-	
-	private KeyStore getKeyStore() throws IOException, GeneralSecurityException {
-		if (keyStore == null) {
-			// acquires an java key store instance
-			this.keyStore = KeyStore.getInstance(KeyStore.getDefaultType());
-			// initialize the key store
-			try (FileInputStream is = new FileInputStream(keyStoreProvider.get())) {
-				this.keyStore.load(is, keyStorePass == null ? new char[0] : keyStorePass.toCharArray());
-			}
-		}
-		return keyStore;
-	}
-	
-	private KeyPair getKeyByThumbprint(String thumbprint) throws GeneralSecurityException, Asn1Exception, IOException {
-		KeyPair key = cacheSignKey.get(thumbprint);
-		if (key == null) {
-			Enumeration<String> aliases = getKeyStore().aliases();
-			if (aliases != null) {
-				byte[] goal = IOUtil.hexToBytes(thumbprint);
+    @Override
+    public CompletableFuture<QueryContext<byte[]>> signAsync(String thumbprint, byte[] content) {
+        return CompletableFuture
+                .supplyAsync(
+                        () ->
+                        {
+                            return sign(
+                                    new QueryContext<byte[]>()
+                                            .setThumbprint(thumbprint)
+                                            .setContent(content)
+                            );
+                        }
+                );
+    }
 
-				while (key == null && aliases.hasMoreElements()) {
-					String alias = aliases.nextElement();
-					X509Certificate x509 = (X509Certificate) keyStore.getCertificate(alias);
-					byte[] theThumbprint = getThumbprint(x509);
-					if (Arrays.equals(goal, theThumbprint)) {
-						PrivateKey privateKey = (PrivateKey)keyStore.getKey(alias, keyPass == null ? new char[0] : keyPass.toCharArray());
-						if (privateKey != null) {
-							key = new KeyPair();
-							key.setPrivateKey(privateKey);
-							key.setX509(x509);
-							key.setSigningAlgorithm(extractSigningAlgorithm(x509));
-							cacheSignKey.put(thumbprint, key);
-						}
-					}
-				}
-			}
-		}
-		return key;
-	}
+    @Override
+    public QueryContext<byte[]> sign(QueryContext<byte[]> cxt) {
+        try {
+            String thumbprint = cxt.getThumbprint();
 
-	private byte[] getThumbprint(X509Certificate x509) {
-		try {
-			MessageDigest digest = MessageDigest.getInstance("SHA-1");
-			return digest.digest(x509.getEncoded());
-		}
-		catch (GeneralSecurityException unexpected) {
-			return "unknown thumbprint".getBytes();
-		}
-	}
+            KeyPair key = getKeyByThumbprint(thumbprint);
+            if (key == null) {
+                return new QueryContext<byte[]>().setServiceError(Messages.get(C_CRYPTO_ERROR_KEY_NOT_FOUND, thumbprint));
+            }
 
-	private String extractSigningAlgorithm(X509Certificate x509Cert) throws CertificateEncodingException, Asn1Exception {
-		return PKCS7.getEncryptOID(new X509certificate(x509Cert.getEncoded()));
-	}
+            byte[] content = cxt.getContent();
 
-	private byte[] getDigest(byte[] data,String digestAlgorithm) throws GeneralSecurityException {
-		MessageDigest md = MessageDigest.getInstance(digestAlgorithm);
-		md.update(data);
-		return md.digest();
-	}
-	
-	class KeyPair {
+            byte[] signature = sign(key, content);
 
-		private PrivateKey privateKey;
-		
-		private X509Certificate x509;
-		
-		private String signingAlgorithm;
+            return new QueryContext<byte[]>().setResult(signature, CONTENT);
+        } catch (Asn1Exception | GeneralSecurityException | CryptoException | IOException x) {
+            return new QueryContext<byte[]>().setServiceError(Messages.get(C_CRYPTO_ERROR, x.getMessage()), x);
+        }
+    }
 
-		public PrivateKey getPrivateKey() {
-			return privateKey;
-		}
+    @Override
+    public CompletableFuture<QueryContext<byte[]>> getSignerCertificateAsync(String thumbprint) {
+        return CompletableFuture
+                .supplyAsync(
+                        () ->
+                        {
+                            return getSignerCertificate(
+                                    new QueryContext<byte[]>()
+                                            .setThumbprint(thumbprint)
+                            );
+                        }
+                );
+    }
 
-		public void setPrivateKey(PrivateKey privateKey) {
-			this.privateKey = privateKey;
-		}
+    @Override
+    public QueryContext<byte[]> getSignerCertificate(QueryContext<byte[]> cxt) {
+        try {
+            String thumbprint = cxt.getThumbprint();
 
-		public X509Certificate getX509() {
-			return x509;
-		}
+            KeyPair key = getKeyByThumbprint(thumbprint);
+            if (key == null) {
+                return new QueryContext<byte[]>().setServiceError(MessageFormat.format(C_CRYPTO_ERROR_KEY_NOT_FOUND, thumbprint));
+            }
 
-		public void setX509(X509Certificate x509) {
-			this.x509 = x509;
-		}
-		
-		public String getSigningAlgorithm() {
-			return signingAlgorithm;
-		}
+            return new QueryContext<byte[]>().setContent(key.getX509() == null ? null : key.getX509().getEncoded());
+        } catch (Asn1Exception | GeneralSecurityException | IOException x) {
+            return new QueryContext<byte[]>().setServiceError(ServiceError.ErrorCode.business, MessageFormat.format(C_CRYPTO_ERROR, x.getMessage()), 0, null, null);
+        }
+    }
 
-		public void setSigningAlgorithm(String signingAlgorithm) {
-			this.signingAlgorithm = signingAlgorithm;
-		}
-	}
+    @Override
+    public CompletableFuture<QueryContext<byte[]>> decryptAsync(String thumbprint, byte[] content) {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
+
+    @Override
+    public QueryContext<byte[]> decrypt(QueryContext<byte[]> cxt) {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
+
+    private byte[] sign(KeyPair key, byte[] content) throws GeneralSecurityException, Asn1Exception, CryptoException {
+        // OID для SHA & RSA
+        String sha_rsa_oid = PKCS7.getCertificateAlgorithmOID(key.x509.getEncoded());
+        // алгоритм хеширования контента
+        String digestAlgorithm = DIGEST_ALGORITHMS.get(sha_rsa_oid);
+        // хеш контента
+        byte[] digest = this.getDigest(content, digestAlgorithm);
+        // массив байт подписываемых атрибутов
+        byte[] authenticatedAttributes = PKCS7.createRSAAuthenticatedAttributes(digest);
+        // вычисление подписи
+        // получаем экземпляр механизма подписи
+        Signature signer = Signature.getInstance(sha_rsa_oid);
+        // инициализируем механизм подписи секретным ключом
+        signer.initSign(key.getPrivateKey());
+        // вычисляем подпись
+        signer.update(authenticatedAttributes);
+        // извлекаем подпись
+        byte[] signature = signer.sign();
+        // создаем сообщение PKCS#7
+        return PKCS7.createSignCMS(key.getX509().getEncoded(), signature, authenticatedAttributes, null);
+    }
+
+    private byte[] sign_(KeyPair key, byte[] content) throws GeneralSecurityException, Asn1Exception, CryptoException {
+        // OID для SHA & RSA
+        String sha_rsa_oid = PKCS7.getCertificateAlgorithmOID(key.x509.getEncoded());
+        // получаем экземпляр механизма подписи
+        Signature signer = Signature.getInstance(sha_rsa_oid);
+        // инициализируем механизм подписи секретным ключом
+        signer.initSign(key.getPrivateKey());
+        // вычисляем подпись
+        signer.update(content);
+        // извлекаем подпись
+        byte[] signature = signer.sign();
+        // создаем сообщение PKCS#7
+        return PKCS7.createSignCMS(key.getX509(), signature, null);
+    }
+
+    private KeyStore getKeyStore() throws IOException, GeneralSecurityException {
+        if (keyStore == null) {
+            // acquires an java key store instance
+            this.keyStore = KeyStore.getInstance(KeyStore.getDefaultType());
+            // initialize the key store
+            try (FileInputStream is = new FileInputStream(keyStoreProvider.get())) {
+                this.keyStore.load(is, keyStorePass == null ? new char[0] : keyStorePass.toCharArray());
+            }
+        }
+        return keyStore;
+    }
+
+    private KeyPair getKeyByThumbprint(String thumbprint) throws GeneralSecurityException, Asn1Exception, IOException {
+        KeyPair key = cacheSignKey.get(thumbprint);
+        if (key == null) {
+            Enumeration<String> aliases = getKeyStore().aliases();
+            if (aliases != null) {
+                byte[] goal = IOUtil.hexToBytes(thumbprint);
+
+                while (key == null && aliases.hasMoreElements()) {
+                    String alias = aliases.nextElement();
+                    X509Certificate x509 = (X509Certificate) keyStore.getCertificate(alias);
+                    byte[] theThumbprint = getThumbprint(x509);
+                    if (Arrays.equals(goal, theThumbprint)) {
+                        PrivateKey privateKey = (PrivateKey) keyStore.getKey(alias, keyPass == null ? new char[0] : keyPass.toCharArray());
+                        if (privateKey != null) {
+                            key = new KeyPair();
+                            key.setPrivateKey(privateKey);
+                            key.setX509(x509);
+                            key.setSigningAlgorithm(extractSigningAlgorithm(x509));
+                            cacheSignKey.put(thumbprint, key);
+                        }
+                    }
+                }
+            }
+        }
+        return key;
+    }
+
+    private byte[] getThumbprint(X509Certificate x509) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-1");
+            return digest.digest(x509.getEncoded());
+        } catch (GeneralSecurityException unexpected) {
+            return "unknown thumbprint".getBytes();
+        }
+    }
+
+    private String extractSigningAlgorithm(X509Certificate x509Cert) throws CertificateEncodingException, Asn1Exception {
+        return PKCS7.getEncryptOID(new X509certificate(x509Cert.getEncoded()));
+    }
+
+    private byte[] getDigest(byte[] data, String digestAlgorithm) throws GeneralSecurityException {
+        MessageDigest md = MessageDigest.getInstance(digestAlgorithm);
+        md.update(data);
+        return md.digest();
+    }
+
+    class KeyPair {
+
+        private PrivateKey privateKey;
+
+        private X509Certificate x509;
+
+        private String signingAlgorithm;
+
+        public PrivateKey getPrivateKey() {
+            return privateKey;
+        }
+
+        public void setPrivateKey(PrivateKey privateKey) {
+            this.privateKey = privateKey;
+        }
+
+        public X509Certificate getX509() {
+            return x509;
+        }
+
+        public void setX509(X509Certificate x509) {
+            this.x509 = x509;
+        }
+
+        public String getSigningAlgorithm() {
+            return signingAlgorithm;
+        }
+
+        public void setSigningAlgorithm(String signingAlgorithm) {
+            this.signingAlgorithm = signingAlgorithm;
+        }
+    }
 }

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/providers/crypt/rsa/CryptoProviderRSA.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/providers/crypt/rsa/CryptoProviderRSA.java
@@ -1,8 +1,27 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * MIT License
+ *
+ * Copyright (c) 2018 SKB Kontur
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  */
+
 package ru.skbkontur.sdk.extern.providers.crypt.rsa;
 
 import com.argos.asn1.Asn1Exception;

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/AccountService.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/AccountService.java
@@ -1,8 +1,27 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * MIT License
+ *
+ * Copyright (c) 2018 SKB Kontur
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  */
+
 package ru.skbkontur.sdk.extern.service;
 
 import ru.skbkontur.sdk.extern.model.Account;

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/AccountService.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/AccountService.java
@@ -5,31 +5,35 @@
  */
 package ru.skbkontur.sdk.extern.service;
 
-import java.util.List;
-import java.util.concurrent.CompletableFuture;
 import ru.skbkontur.sdk.extern.model.Account;
 import ru.skbkontur.sdk.extern.model.AccountList;
 import ru.skbkontur.sdk.extern.model.CreateAccountRequest;
 import ru.skbkontur.sdk.extern.model.Link;
 import ru.skbkontur.sdk.extern.service.transport.adaptors.QueryContext;
 
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
 
 /**
- *
  * @author AlexS
  */
 public interface AccountService {
 
-	public CompletableFuture<QueryContext<List<Link>>> acquireBaseUriAsync();
-	public QueryContext<List<Link>> acquireBaseUri(QueryContext<?> cxt);
+    CompletableFuture<QueryContext<List<Link>>> acquireBaseUriAsync();
+
+    QueryContext<List<Link>> acquireBaseUri(QueryContext<?> cxt);
 
 
-	public CompletableFuture<QueryContext<AccountList>> acquireAccountsAsync();
-	public QueryContext<AccountList> acquireAccounts(QueryContext<?> cxt);
+    CompletableFuture<QueryContext<AccountList>> acquireAccountsAsync();
 
-	public CompletableFuture<QueryContext<Object>> createrAccountAsync(CreateAccountRequest createAccountRequest);
-	public QueryContext<Object> createrAccount(QueryContext<?> cxt);
+    QueryContext<AccountList> acquireAccounts(QueryContext<?> cxt);
 
-	public CompletableFuture<QueryContext<Account>> getAccountAsync(String accountId);
-	public QueryContext<Account> getAccount(QueryContext<?> cxt);
+    CompletableFuture<QueryContext<Object>> createrAccountAsync(CreateAccountRequest createAccountRequest);
+
+    QueryContext<Object> createrAccount(QueryContext<?> cxt);
+
+    CompletableFuture<QueryContext<Account>> getAccountAsync(String accountId);
+
+    QueryContext<Account> getAccount(QueryContext<?> cxt);
 }

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/BusinessDriver.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/BusinessDriver.java
@@ -1,7 +1,7 @@
 /*
- * The MIT License
+ * MIT License
  *
- * Copyright 2018 SKB Kontur
+ * Copyright (c) 2018 SKB Kontur
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -10,17 +10,18 @@
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
  *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
  *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
  * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
  * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  */
+
 package ru.skbkontur.sdk.extern.service;
 
 import ru.argosgrp.cryptoservice.utils.IOUtil;

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/CertificateService.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/CertificateService.java
@@ -5,15 +5,18 @@
  */
 package ru.skbkontur.sdk.extern.service;
 
-import java.util.concurrent.CompletableFuture;
 import ru.skbkontur.sdk.extern.model.CertificateList;
 import ru.skbkontur.sdk.extern.service.transport.adaptors.QueryContext;
 
+import java.util.concurrent.CompletableFuture;
+
+
 /**
- *
  * @author alexs
  */
 public interface CertificateService {
-	public CompletableFuture<QueryContext<CertificateList>> getCertificateListAsync();
-	public QueryContext<CertificateList> getCertificateList(QueryContext<?> cxt);
+
+    CompletableFuture<QueryContext<CertificateList>> getCertificateListAsync();
+
+    QueryContext<CertificateList> getCertificateList(QueryContext<?> cxt);
 }

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/CertificateService.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/CertificateService.java
@@ -1,8 +1,27 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * MIT License
+ *
+ * Copyright (c) 2018 SKB Kontur
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  */
+
 package ru.skbkontur.sdk.extern.service;
 
 import ru.skbkontur.sdk.extern.model.CertificateList;

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/DocflowService.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/DocflowService.java
@@ -1,8 +1,27 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * MIT License
+ *
+ * Copyright (c) 2018 SKB Kontur
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  */
+
 package ru.skbkontur.sdk.extern.service;
 
 import org.joda.time.DateTime;

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/DocflowService.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/DocflowService.java
@@ -5,8 +5,6 @@
  */
 package ru.skbkontur.sdk.extern.service;
 
-import java.util.List;
-import java.util.concurrent.CompletableFuture;
 import org.joda.time.DateTime;
 import ru.skbkontur.sdk.extern.model.Docflow;
 import ru.skbkontur.sdk.extern.model.DocflowPage;
@@ -16,54 +14,72 @@ import ru.skbkontur.sdk.extern.model.DocumentToSend;
 import ru.skbkontur.sdk.extern.model.Signature;
 import ru.skbkontur.sdk.extern.service.transport.adaptors.QueryContext;
 
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+
 /**
- *
  * @author AlexS
  */
 public interface DocflowService {
-	
-	public CompletableFuture<QueryContext<Docflow>> lookupDocflowAsync(String docflowId);
-	public QueryContext<Docflow> lookupDocflow(QueryContext<?> cxt);
 
-	public CompletableFuture<QueryContext<List<Document>>> getDocumentsAsync(String docflowId);
-	public QueryContext<List<Document>> getDocuments(QueryContext<?> parent);
-	
-	public CompletableFuture<QueryContext<Document>> lookupDocumentAsync(String docflowId, String documentId);
-	public QueryContext<Document> lookupDocument(QueryContext<?> parent);
+    CompletableFuture<QueryContext<Docflow>> lookupDocflowAsync(String docflowId);
 
-	public CompletableFuture<QueryContext<DocumentDescription>> lookupDescriptionAsync(String docflowId, String documentId);
-	public QueryContext<DocumentDescription> lookupDescription(QueryContext<?> parent);
-	
-	public CompletableFuture<QueryContext<byte[]>> getEncryptedContentAsync(String docflowId, String documentId);
-	public QueryContext<byte[]> getEncryptedContent(QueryContext<?> parent);
-	
-	public CompletableFuture<QueryContext<byte[]>> getDecryptedContentAsync(String docflowId, String documentId);
-	public QueryContext<byte[]> getDecryptedContent(QueryContext<?> parent);
-	
-	public CompletableFuture<QueryContext<List<Signature>>> getSignaturesAsync(String docflowId, String documentId);
-	public QueryContext<List<Signature>> getSignatures(QueryContext<?> parent);
-	
-	public CompletableFuture<QueryContext<Signature>> getSignatureAsync(String docflowId, String documentId, String signatureId);
-	public QueryContext<Signature> getSignature(QueryContext<?> parent);
-	
-	public CompletableFuture<QueryContext<byte[]>> getSignatureContentAsync(String docflowId, String documentId, String signatureId);
-	public QueryContext<byte[]> getSignatureContent(QueryContext<?> parent);
-	
-	public CompletableFuture<QueryContext<DocumentToSend>> generateDocumentTypeReplyAsync(String docflowId, String documentType, String documentId, String x509Base64);
-	public QueryContext<DocumentToSend> generateDocumentTypeReply(QueryContext<?> parent);
+    QueryContext<Docflow> lookupDocflow(QueryContext<?> cxt);
 
-	public CompletableFuture<QueryContext<Docflow>> addDocumentTypeReplyAsync(String docflowId, String documentType, String documentId, DocumentToSend documentToSend);
-	public QueryContext<Docflow> addDocumentTypeReply(QueryContext<?> parent);
+    CompletableFuture<QueryContext<List<Document>>> getDocumentsAsync(String docflowId);
 
-	public CompletableFuture<QueryContext<List<DocumentToSend>>> generateRepliesAsync(Docflow docflow, String signerX509Base64);
-	public QueryContext<List<DocumentToSend>> generateReplies(QueryContext<?> parent);
+    QueryContext<List<Document>> getDocuments(QueryContext<?> parent);
 
-	public CompletableFuture<QueryContext<Docflow>> createReplyAsync(Docflow docflow);
-	public QueryContext<Docflow> sendReply(QueryContext<?> parent);
+    CompletableFuture<QueryContext<Document>> lookupDocumentAsync(String docflowId, String documentId);
 
-	public CompletableFuture<QueryContext<DocflowPage>> getDocflows(boolean finished,boolean incoming,long skip,int take,String innKpp,DateTime updatedFrom,DateTime updatedTo,DateTime createdFrom,DateTime createdTo,String type);
-	public QueryContext<DocflowPage> getDocflows(QueryContext<?> parent);
+    QueryContext<Document> lookupDocument(QueryContext<?> parent);
 
-	public CompletableFuture<QueryContext<String>> print(String docflowId, String documentId, String documentContentBase64);
-	public QueryContext<String> print(QueryContext<?> parent);
+    CompletableFuture<QueryContext<DocumentDescription>> lookupDescriptionAsync(String docflowId, String documentId);
+
+    QueryContext<DocumentDescription> lookupDescription(QueryContext<?> parent);
+
+    CompletableFuture<QueryContext<byte[]>> getEncryptedContentAsync(String docflowId, String documentId);
+
+    QueryContext<byte[]> getEncryptedContent(QueryContext<?> parent);
+
+    CompletableFuture<QueryContext<byte[]>> getDecryptedContentAsync(String docflowId, String documentId);
+
+    QueryContext<byte[]> getDecryptedContent(QueryContext<?> parent);
+
+    CompletableFuture<QueryContext<List<Signature>>> getSignaturesAsync(String docflowId, String documentId);
+
+    QueryContext<List<Signature>> getSignatures(QueryContext<?> parent);
+
+    CompletableFuture<QueryContext<Signature>> getSignatureAsync(String docflowId, String documentId, String signatureId);
+
+    QueryContext<Signature> getSignature(QueryContext<?> parent);
+
+    CompletableFuture<QueryContext<byte[]>> getSignatureContentAsync(String docflowId, String documentId, String signatureId);
+
+    QueryContext<byte[]> getSignatureContent(QueryContext<?> parent);
+
+    CompletableFuture<QueryContext<DocumentToSend>> generateDocumentTypeReplyAsync(String docflowId, String documentType, String documentId, String x509Base64);
+
+    QueryContext<DocumentToSend> generateDocumentTypeReply(QueryContext<?> parent);
+
+    CompletableFuture<QueryContext<Docflow>> addDocumentTypeReplyAsync(String docflowId, String documentType, String documentId, DocumentToSend documentToSend);
+
+    QueryContext<Docflow> addDocumentTypeReply(QueryContext<?> parent);
+
+    CompletableFuture<QueryContext<List<DocumentToSend>>> generateRepliesAsync(Docflow docflow, String signerX509Base64);
+
+    QueryContext<List<DocumentToSend>> generateReplies(QueryContext<?> parent);
+
+    CompletableFuture<QueryContext<Docflow>> createReplyAsync(Docflow docflow);
+
+    QueryContext<Docflow> sendReply(QueryContext<?> parent);
+
+    CompletableFuture<QueryContext<DocflowPage>> getDocflows(boolean finished, boolean incoming, long skip, int take, String innKpp, DateTime updatedFrom, DateTime updatedTo, DateTime createdFrom, DateTime createdTo, String type);
+
+    QueryContext<DocflowPage> getDocflows(QueryContext<?> parent);
+
+    CompletableFuture<QueryContext<String>> print(String docflowId, String documentId, String documentContentBase64);
+
+    QueryContext<String> print(QueryContext<?> parent);
 }

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/DocumentContentsBuilder.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/DocumentContentsBuilder.java
@@ -27,23 +27,24 @@ import ru.argosgrp.cryptoservice.utils.IOUtil;
 import ru.skbkontur.sdk.extern.model.DocumentContents;
 import ru.skbkontur.sdk.extern.model.DocumentDescription;
 
+
 /**
- *
  * @author AlexS
  */
 public class DocumentContentsBuilder {
-	public static DocumentContents build(File file, byte[] signPKCS7) {
-		// создаем описание документа
-		DocumentDescription dd = new DocumentDescription();
-		dd.setContentType(file.getContentType().getValue());
-		dd.setFilename(file.getFileName());
 
-		// создаем контекст документа
-		DocumentContents dc = new DocumentContents();
-		dc.setDocumentDescription(dd);
-		dc.setBase64Content(file.getContent() != null ? IOUtil.encodeBase64(file.getContent()) : null);
-		dc.setSignature(signPKCS7 != null ? IOUtil.encodeBase64(signPKCS7) : null);
-		
-		return dc;
-	}
+    public static DocumentContents build(File file, byte[] signPKCS7) {
+        // создаем описание документа
+        DocumentDescription dd = new DocumentDescription();
+        dd.setContentType(file.getContentType().getValue());
+        dd.setFilename(file.getFileName());
+
+        // создаем контекст документа
+        DocumentContents dc = new DocumentContents();
+        dc.setDocumentDescription(dd);
+        dc.setBase64Content(file.getContent() != null ? IOUtil.encodeBase64(file.getContent()) : null);
+        dc.setSignature(signPKCS7 != null ? IOUtil.encodeBase64(signPKCS7) : null);
+
+        return dc;
+    }
 }

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/DocumentContentsBuilder.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/DocumentContentsBuilder.java
@@ -1,7 +1,7 @@
 /*
- * The MIT License
+ * MIT License
  *
- * Copyright 2018 SKB Kontur
+ * Copyright (c) 2018 SKB Kontur
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -10,17 +10,18 @@
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
  *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
  *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
  * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
  * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  */
+
 package ru.skbkontur.sdk.extern.service;
 
 import ru.argosgrp.cryptoservice.utils.IOUtil;

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/DraftService.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/DraftService.java
@@ -1,8 +1,27 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * MIT License
+ *
+ * Copyright (c) 2018 SKB Kontur
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  */
+
 package ru.skbkontur.sdk.extern.service;
 
 import ru.skbkontur.sdk.extern.model.Docflow;

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/DraftService.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/DraftService.java
@@ -5,10 +5,6 @@
  */
 package ru.skbkontur.sdk.extern.service;
 
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
-import java.util.concurrent.CompletableFuture;
 import ru.skbkontur.sdk.extern.model.Docflow;
 import ru.skbkontur.sdk.extern.model.DocumentContents;
 import ru.skbkontur.sdk.extern.model.Draft;
@@ -22,87 +18,112 @@ import ru.skbkontur.sdk.extern.model.UsnServiceContractInfo;
 import ru.skbkontur.sdk.extern.model.UsnServiceContractInfoV2;
 import ru.skbkontur.sdk.extern.service.transport.adaptors.QueryContext;
 
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+
+
 /**
- *
  * @author AlexS
  */
 public interface DraftService {
-	/**
-	 * Create new a draft
-	 *
-	 * POST /v1/{accountId}/drafts
-	 *
-	 * @param sender Sender отправитель декларации
-	 * @param recipient Recipient получатель декларации
-	 * @param organization Organization организация, на которую создана декларация
-	 * @return CompletableFuture&lt;QueryContext&lt;UUID&gt;&gt; идентификатор черновика 
-	 */
-	public CompletableFuture<QueryContext<UUID>> createAsync(Sender sender, Recipient recipient, Organization organization);
-	public QueryContext<UUID> create(QueryContext<?> cxt);
 
-	/**
-	 * lookup a draft by an identifier
-	 *
-	 * GET /v1/{accountId}/drafts/{draftId}
-	 *
-	 * @param draftId String a draft identifier
-	 * 
-	 * @return Draft
-	 */
-	public CompletableFuture<QueryContext<Draft>> lookupAsync(String draftId);
-	public QueryContext<Draft> lookup(QueryContext<?> cxt);
+    /**
+     * Create new a draft
+     * <p>
+     * POST /v1/{accountId}/drafts
+     *
+     * @param sender       Sender отправитель декларации
+     * @param recipient    Recipient получатель декларации
+     * @param organization Organization организация, на которую создана декларация
+     * @return CompletableFuture&lt;QueryContext&lt;UUID&gt;&gt; идентификатор черновика
+     */
+    CompletableFuture<QueryContext<UUID>> createAsync(Sender sender, Recipient recipient, Organization organization);
 
-	public CompletableFuture<QueryContext<Void>> deleteAsync(String draftId);
-	public QueryContext<Void> delete(QueryContext<?> cxt);
+    QueryContext<UUID> create(QueryContext<?> cxt);
 
-	public CompletableFuture<QueryContext<DraftMeta>> lookupDraftMetaAsync(String draftId);
-	public QueryContext<DraftMeta> lookupDraftMeta(QueryContext<?> cxt);
+    /**
+     * lookup a draft by an identifier
+     * <p>
+     * GET /v1/{accountId}/drafts/{draftId}
+     *
+     * @param draftId String a draft identifier
+     * @return Draft
+     */
+    CompletableFuture<QueryContext<Draft>> lookupAsync(String draftId);
 
-	public CompletableFuture<QueryContext<DraftMeta>> updateDraftMetaAsync(String draftId, DraftMeta draftMeta);
-	public QueryContext<DraftMeta> updateDraftMeta(QueryContext<?> cxt);
+    QueryContext<Draft> lookup(QueryContext<?> cxt);
 
-	public CompletableFuture<QueryContext<Map<String,Object>>> checkAsync(String draftId);
-	public QueryContext<Map<String,Object>> check(QueryContext<?> cxt);
-	
-	public CompletableFuture<QueryContext<PrepareResult>> prepareAsync(String draftId);
-	public QueryContext<PrepareResult> prepare(QueryContext<?> cxt);
-	
-	public CompletableFuture<QueryContext<List<Docflow>>> sendAsync(String draftId);
-	public QueryContext<List<Docflow>> send(QueryContext<?> cxt);
-	
-	public CompletableFuture<QueryContext<Void>> deleteDocumentAsync(String draftId, String documentId);
-	public QueryContext<Void> deleteDocument(QueryContext<?> cxt);
+    CompletableFuture<QueryContext<Void>> deleteAsync(String draftId);
 
-	public CompletableFuture<QueryContext<DraftDocument>> lookupDocumentAsync(String draftId, String documentId);
-	public QueryContext<DraftDocument> lookupDocument(QueryContext<?> cxt);
+    QueryContext<Void> delete(QueryContext<?> cxt);
 
-	public CompletableFuture<QueryContext<DraftDocument>> updateDocumentAsync(String draftId, String documentId, DocumentContents documentContents);
-	public QueryContext<DraftDocument> updateDocument(QueryContext<?> cxt);
-	
-	public CompletableFuture<QueryContext<String>> printDocumentAsync(String draftId, String documentId);
-	public QueryContext<String> printDocument(QueryContext<?> cxt);
+    CompletableFuture<QueryContext<DraftMeta>> lookupDraftMetaAsync(String draftId);
 
-	public CompletableFuture<QueryContext<DraftDocument>> addDecryptedDocumentAsync(UUID draftId, DocumentContents documentContents);
-	public QueryContext<DraftDocument> addDecryptedDocument(QueryContext<?> cxt);
-	
-	public CompletableFuture<QueryContext<String>> getDecryptedDocumentContentAsync(String draftId, String documentId);
-	public QueryContext<String> getDecryptedDocumentContent(QueryContext<?> cxt);
-	
-	public CompletableFuture<QueryContext<Void>> updateDecryptedDocumentContentAsync(String draftId, String documentId, byte[] content);
-	public QueryContext<Void> updateDecryptedDocumentContent(QueryContext<?> cxt);
+    QueryContext<DraftMeta> lookupDraftMeta(QueryContext<?> cxt);
 
-	public CompletableFuture<QueryContext<String>> getEncryptedDocumentContentAsync(String draftId, String documentId);
-	public QueryContext<String> getEncryptedDocumentContent(QueryContext<?> cxt);
-	
-	public CompletableFuture<QueryContext<String>> getSignatureContentAsync(String draftId, String documentId);
-	public QueryContext<String> getSignatureContent(QueryContext<?> cxt);
+    CompletableFuture<QueryContext<DraftMeta>> updateDraftMetaAsync(String draftId, DraftMeta draftMeta);
 
-	public CompletableFuture<QueryContext<Void>> updateSignatureAsync(String draftId, String documentId, byte[] content);
-	public QueryContext<Void> updateSignature(QueryContext<?> cxt);
+    QueryContext<DraftMeta> updateDraftMeta(QueryContext<?> cxt);
 
-	public CompletableFuture<QueryContext<Void>> createUSN1Async(String draftId, String documentId, UsnServiceContractInfo usn);
-	public QueryContext<Void> createUSN1(QueryContext<?> cxt);
+    CompletableFuture<QueryContext<Map<String, Object>>> checkAsync(String draftId);
 
-	public CompletableFuture<QueryContext<Void>> createUSN2Async(String draftId, String documentId, UsnServiceContractInfoV2 usn);
-	public QueryContext<Void> createUSN2(QueryContext<?> cxt);
+    QueryContext<Map<String, Object>> check(QueryContext<?> cxt);
+
+    CompletableFuture<QueryContext<PrepareResult>> prepareAsync(String draftId);
+
+    QueryContext<PrepareResult> prepare(QueryContext<?> cxt);
+
+    CompletableFuture<QueryContext<List<Docflow>>> sendAsync(String draftId);
+
+    QueryContext<List<Docflow>> send(QueryContext<?> cxt);
+
+    CompletableFuture<QueryContext<Void>> deleteDocumentAsync(String draftId, String documentId);
+
+    QueryContext<Void> deleteDocument(QueryContext<?> cxt);
+
+    CompletableFuture<QueryContext<DraftDocument>> lookupDocumentAsync(String draftId, String documentId);
+
+    QueryContext<DraftDocument> lookupDocument(QueryContext<?> cxt);
+
+    CompletableFuture<QueryContext<DraftDocument>> updateDocumentAsync(String draftId, String documentId, DocumentContents documentContents);
+
+    QueryContext<DraftDocument> updateDocument(QueryContext<?> cxt);
+
+    CompletableFuture<QueryContext<String>> printDocumentAsync(String draftId, String documentId);
+
+    QueryContext<String> printDocument(QueryContext<?> cxt);
+
+    CompletableFuture<QueryContext<DraftDocument>> addDecryptedDocumentAsync(UUID draftId, DocumentContents documentContents);
+
+    QueryContext<DraftDocument> addDecryptedDocument(QueryContext<?> cxt);
+
+    CompletableFuture<QueryContext<String>> getDecryptedDocumentContentAsync(String draftId, String documentId);
+
+    QueryContext<String> getDecryptedDocumentContent(QueryContext<?> cxt);
+
+    CompletableFuture<QueryContext<Void>> updateDecryptedDocumentContentAsync(String draftId, String documentId, byte[] content);
+
+    QueryContext<Void> updateDecryptedDocumentContent(QueryContext<?> cxt);
+
+    CompletableFuture<QueryContext<String>> getEncryptedDocumentContentAsync(String draftId, String documentId);
+
+    QueryContext<String> getEncryptedDocumentContent(QueryContext<?> cxt);
+
+    CompletableFuture<QueryContext<String>> getSignatureContentAsync(String draftId, String documentId);
+
+    QueryContext<String> getSignatureContent(QueryContext<?> cxt);
+
+    CompletableFuture<QueryContext<Void>> updateSignatureAsync(String draftId, String documentId, byte[] content);
+
+    QueryContext<Void> updateSignature(QueryContext<?> cxt);
+
+    CompletableFuture<QueryContext<Void>> createUSN1Async(String draftId, String documentId, UsnServiceContractInfo usn);
+
+    QueryContext<Void> createUSN1(QueryContext<?> cxt);
+
+    CompletableFuture<QueryContext<Void>> createUSN2Async(String draftId, String documentId, UsnServiceContractInfoV2 usn);
+
+    QueryContext<Void> createUSN2(QueryContext<?> cxt);
 }

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/File.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/File.java
@@ -1,7 +1,7 @@
 /*
- * The MIT License
+ * MIT License
  *
- * Copyright 2018 SKB Kontur
+ * Copyright (c) 2018 SKB Kontur
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -10,17 +10,18 @@
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
  *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
  *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
  * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
  * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  */
+
 package ru.skbkontur.sdk.extern.service;
 
 import java.util.stream.Stream;
@@ -44,6 +45,7 @@ public class File {
         this.content = content;
         this.contentType = contentType;
     }
+
     public File(String fileName, byte[] content) {
         this(fileName, content, DEFAULT_CONTENT_TYPE);
     }

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/File.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/File.java
@@ -25,69 +25,68 @@ package ru.skbkontur.sdk.extern.service;
 
 import java.util.stream.Stream;
 
+
 /**
- *
  * @author AlexS
  */
 public class File {
-	private static final ContentType DEFAULT_CONTENT_TYPE = ContentType.XML;
-	
-	public static enum ContentType {
-		XML("application/xml");
-		
-		private final String value;
-		
-		ContentType(String value) {
-			this.value = value;
-		}
-		
-		public String getValue() {
-			return value;
-		}
-		
-    public static ContentType fromValue(String v) {
-			return Stream.of(ContentType.values()).filter(t->t.value.equals(v)).findAny().orElse(null);
+
+    private static final ContentType DEFAULT_CONTENT_TYPE = ContentType.XML;
+    private ContentType contentType;
+    private String fileName;
+    private byte[] content;
+
+    public File() {
     }
-	}
-	
-	public File() {
-	}
 
-	public File(String fileName, byte[] content, ContentType contentType) {
-		this.fileName = fileName;
-		this.content = content;
-		this.contentType = contentType;
-	}
-	
-	public File(String fileName, byte[] content) {
-		this(fileName, content, DEFAULT_CONTENT_TYPE);
-	}
-	
-	private ContentType contentType;
-	private String fileName;
-	private byte[] content;
+    public File(String fileName, byte[] content, ContentType contentType) {
+        this.fileName = fileName;
+        this.content = content;
+        this.contentType = contentType;
+    }
+    public File(String fileName, byte[] content) {
+        this(fileName, content, DEFAULT_CONTENT_TYPE);
+    }
 
-	public ContentType getContentType() {
-		return contentType;
-	}
+    public ContentType getContentType() {
+        return contentType;
+    }
 
-	public void setContentType(ContentType contentType) {
-		this.contentType = contentType;
-	}
+    public void setContentType(ContentType contentType) {
+        this.contentType = contentType;
+    }
 
-	public String getFileName() {
-		return fileName;
-	}
+    public String getFileName() {
+        return fileName;
+    }
 
-	public void setFileName(String fileName) {
-		this.fileName = fileName;
-	}
+    public void setFileName(String fileName) {
+        this.fileName = fileName;
+    }
 
-	public byte[] getContent() {
-		return content;
-	}
+    public byte[] getContent() {
+        return content;
+    }
 
-	public void setContent(byte[] content) {
-		this.content = content;
-	}
+    public void setContent(byte[] content) {
+        this.content = content;
+    }
+
+    public enum ContentType {
+        XML("application/xml");
+
+        private final String value;
+
+        ContentType(String value) {
+            this.value = value;
+        }
+
+        public static ContentType fromValue(String v) {
+            return Stream.of(ContentType.values()).filter(t -> t.value.equals(v)).findAny().orElse(null);
+        }
+
+        public String getValue() {
+            return value;
+        }
+    }
 }

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/SDKException.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/SDKException.java
@@ -7,25 +7,25 @@ package ru.skbkontur.sdk.extern.service;
 
 import java.text.MessageFormat;
 
+
 /**
- *
  * @author AlexS
  */
 public class SDKException extends RuntimeException {
 
-	public SDKException(String message, Throwable x) {
-		super(message, x);
-	}
-	
-	public SDKException(String message) {
-		super(message);
-	}
-	
-	public SDKException(String template, Object ... params) {
-		super(MessageFormat.format(template, params));
-	}
-	
-	public SDKException(String template, Throwable x, Object ... params) {
-		super(MessageFormat.format(template, params), x);
-	}
+    public SDKException(String message, Throwable x) {
+        super(message, x);
+    }
+
+    public SDKException(String message) {
+        super(message);
+    }
+
+    public SDKException(String template, Object... params) {
+        super(MessageFormat.format(template, params));
+    }
+
+    public SDKException(String template, Throwable x, Object... params) {
+        super(MessageFormat.format(template, params), x);
+    }
 }

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/SDKException.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/SDKException.java
@@ -1,8 +1,27 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * MIT License
+ *
+ * Copyright (c) 2018 SKB Kontur
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  */
+
 package ru.skbkontur.sdk.extern.service;
 
 import java.text.MessageFormat;

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/impl/AccountServiceImpl.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/impl/AccountServiceImpl.java
@@ -5,8 +5,6 @@
  */
 package ru.skbkontur.sdk.extern.service.impl;
 
-import java.util.List;
-import java.util.concurrent.CompletableFuture;
 import ru.skbkontur.sdk.extern.model.Account;
 import ru.skbkontur.sdk.extern.model.AccountList;
 import ru.skbkontur.sdk.extern.model.CreateAccountRequest;
@@ -15,62 +13,66 @@ import ru.skbkontur.sdk.extern.service.AccountService;
 import ru.skbkontur.sdk.extern.service.transport.adaptors.AccountsAdaptor;
 import ru.skbkontur.sdk.extern.service.transport.adaptors.QueryContext;
 
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+
 /**
- *
  * @author AlexS
  */
 public class AccountServiceImpl extends BaseService<AccountsAdaptor> implements AccountService {
-	private static final String EN_ACC = "account";
-	
-	@Override
-	public CompletableFuture<QueryContext<List<Link>>> acquireBaseUriAsync() {
-		QueryContext<List<Link>> cxt = createQueryContext(EN_ACC);
-		return cxt.applyAsync(api::acquireBaseUri);
-	}
 
-	@Override
-	public QueryContext<List<Link>> acquireBaseUri(QueryContext<?> parent) {
-		QueryContext<List<Link>> cxt = createQueryContext(parent, EN_ACC);
-		return cxt.apply(api::acquireBaseUri);
-	}
+    private static final String EN_ACC = "account";
 
-	@Override
-	public CompletableFuture<QueryContext<AccountList>> acquireAccountsAsync() {
-		QueryContext<AccountList> cxt = createQueryContext(EN_ACC);
-		return cxt.applyAsync(api::acquireAccounts);
-	}
+    @Override
+    public CompletableFuture<QueryContext<List<Link>>> acquireBaseUriAsync() {
+        QueryContext<List<Link>> cxt = createQueryContext(EN_ACC);
+        return cxt.applyAsync(api::acquireBaseUri);
+    }
 
-	@Override
-	public QueryContext<AccountList> acquireAccounts(QueryContext<?> parent) {
-		QueryContext<AccountList> cxt = createQueryContext(parent, EN_ACC);
-		return cxt.apply(api::acquireAccounts);
-	}
+    @Override
+    public QueryContext<List<Link>> acquireBaseUri(QueryContext<?> parent) {
+        QueryContext<List<Link>> cxt = createQueryContext(parent, EN_ACC);
+        return cxt.apply(api::acquireBaseUri);
+    }
 
-	@Override
-	public CompletableFuture<QueryContext<Object>> createrAccountAsync(CreateAccountRequest createAccountRequest) {
-		QueryContext<Object> cxt = createQueryContext(EN_ACC);
-		return cxt
-			.setCreateAccountRequest(createAccountRequest)
-			.applyAsync(api::createAccount);
-	}
+    @Override
+    public CompletableFuture<QueryContext<AccountList>> acquireAccountsAsync() {
+        QueryContext<AccountList> cxt = createQueryContext(EN_ACC);
+        return cxt.applyAsync(api::acquireAccounts);
+    }
 
-	@Override
-	public QueryContext<Object> createrAccount(QueryContext<?> parent) {
-		QueryContext<Object> cxt = createQueryContext(parent, EN_ACC);
-		return cxt.apply(api::createAccount);
-	}
+    @Override
+    public QueryContext<AccountList> acquireAccounts(QueryContext<?> parent) {
+        QueryContext<AccountList> cxt = createQueryContext(parent, EN_ACC);
+        return cxt.apply(api::acquireAccounts);
+    }
 
-	@Override
-	public CompletableFuture<QueryContext<Account>> getAccountAsync(String accountId) {
-		QueryContext<Account> cxt = createQueryContext(EN_ACC);
-		return cxt
-			.setAccountId(accountId)
-			.applyAsync(api::getAccount);
-	}
+    @Override
+    public CompletableFuture<QueryContext<Object>> createrAccountAsync(CreateAccountRequest createAccountRequest) {
+        QueryContext<Object> cxt = createQueryContext(EN_ACC);
+        return cxt
+                .setCreateAccountRequest(createAccountRequest)
+                .applyAsync(api::createAccount);
+    }
 
-	@Override
-	public QueryContext<Account> getAccount(QueryContext<?> parent) {
-		QueryContext<Account> cxt = createQueryContext(parent, EN_ACC);
-		return cxt.apply(api::getAccount);
-	}
+    @Override
+    public QueryContext<Object> createrAccount(QueryContext<?> parent) {
+        QueryContext<Object> cxt = createQueryContext(parent, EN_ACC);
+        return cxt.apply(api::createAccount);
+    }
+
+    @Override
+    public CompletableFuture<QueryContext<Account>> getAccountAsync(String accountId) {
+        QueryContext<Account> cxt = createQueryContext(EN_ACC);
+        return cxt
+                .setAccountId(accountId)
+                .applyAsync(api::getAccount);
+    }
+
+    @Override
+    public QueryContext<Account> getAccount(QueryContext<?> parent) {
+        QueryContext<Account> cxt = createQueryContext(parent, EN_ACC);
+        return cxt.apply(api::getAccount);
+    }
 }

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/impl/AccountServiceImpl.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/impl/AccountServiceImpl.java
@@ -1,8 +1,27 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * MIT License
+ *
+ * Copyright (c) 2018 SKB Kontur
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  */
+
 package ru.skbkontur.sdk.extern.service.impl;
 
 import ru.skbkontur.sdk.extern.model.Account;

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/impl/BaseService.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/impl/BaseService.java
@@ -1,8 +1,27 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * MIT License
+ *
+ * Copyright (c) 2018 SKB Kontur
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  */
+
 package ru.skbkontur.sdk.extern.service.impl;
 
 import ru.skbkontur.sdk.extern.providers.AccountProvider;

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/impl/BaseService.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/impl/BaseService.java
@@ -13,76 +13,70 @@ import ru.skbkontur.sdk.extern.providers.ServiceBaseUriProvider;
 import ru.skbkontur.sdk.extern.service.transport.adaptors.QueryContext;
 import ru.skbkontur.sdk.extern.service.transport.invoker.ApiClient;
 
+
 /**
- *
- * @author AlexS
- * 
  * @param <T> T transport service API
+ * @author AlexS
  */
 public class BaseService<T> {
-	
-	protected T api;
-	
-	public void setApi(T api) {
-		this.api = api;
-	}
-	
-	protected ServiceBaseUriProvider serviceBaseUriProvider;
-	
-	protected AuthenticationProvider authenticationProvider;
-	
-	protected AccountProvider accountProvider;
 
-	protected ApiKeyProvider apiKeyProvider;
-	
-	protected CryptoProvider cryptoProvider;
-	
-	public void setServiceBaseUriProvider(ServiceBaseUriProvider serviceBaseUriProvider) {
-		this.serviceBaseUriProvider = serviceBaseUriProvider;
-	}
+    protected T api;
+    protected ServiceBaseUriProvider serviceBaseUriProvider;
+    protected AuthenticationProvider authenticationProvider;
+    protected AccountProvider accountProvider;
+    protected ApiKeyProvider apiKeyProvider;
+    protected CryptoProvider cryptoProvider;
 
-	public void setAuthenticationProvider(AuthenticationProvider authenticationProvider) {
-		this.authenticationProvider = authenticationProvider;
-	}
+    public void setApi(T api) {
+        this.api = api;
+    }
 
-	public void setAccountProvider(AccountProvider accountProvider) {
-		this.accountProvider = accountProvider;
-	}
+    public void setServiceBaseUriProvider(ServiceBaseUriProvider serviceBaseUriProvider) {
+        this.serviceBaseUriProvider = serviceBaseUriProvider;
+    }
 
-	public void setApiKeyProvider(ApiKeyProvider apiKeyProvider) {
-		this.apiKeyProvider = apiKeyProvider;
-	}
+    public void setAuthenticationProvider(AuthenticationProvider authenticationProvider) {
+        this.authenticationProvider = authenticationProvider;
+    }
+
+    public void setAccountProvider(AccountProvider accountProvider) {
+        this.accountProvider = accountProvider;
+    }
+
+    public void setApiKeyProvider(ApiKeyProvider apiKeyProvider) {
+        this.apiKeyProvider = apiKeyProvider;
+    }
 /*
 	public CryptoProvider getCryptoProvider() throws SDKException {
 		if (cryptoProvider == null)
 			throw new SDKException(Messages.get(C_CRYPTO_ERROR_NO_CRYPTO_PROVIDER));
 		return cryptoProvider;
 	}
-*/	
-	
-	public void setCryptoProvider(CryptoProvider cryptoProvider) {
-		this.cryptoProvider = cryptoProvider;
-	}
+*/
 
-	protected <T> QueryContext<T> createQueryContext(String entityName) {
-		QueryContext<T> cxt = new QueryContext<>(entityName);
-		cxt.setApiClient(new ApiClient());
-		cxt.setServiceBaseUri(serviceBaseUriProvider.getServiceBaseUri());
-		cxt.setAuthenticationProvider(authenticationProvider);
-		cxt.setAccountProvider(accountProvider);
-		cxt.setApiKeyProvider(apiKeyProvider);
-		cxt.configureApiClient();
-		return cxt;
-	}
+    public void setCryptoProvider(CryptoProvider cryptoProvider) {
+        this.cryptoProvider = cryptoProvider;
+    }
 
-	protected <T> QueryContext<T> createQueryContext(QueryContext<?> parent, String entityName) {
-		QueryContext<T> cxt = new QueryContext<>(parent,entityName);
-		cxt.setApiClient(new ApiClient());
-		cxt.setServiceBaseUri(serviceBaseUriProvider.getServiceBaseUri());
-		cxt.setAuthenticationProvider(authenticationProvider);
-		cxt.setAccountProvider(accountProvider);
-		cxt.setApiKeyProvider(apiKeyProvider);
-		cxt.configureApiClient();
-		return cxt;
-	}
+    protected <T> QueryContext<T> createQueryContext(String entityName) {
+        QueryContext<T> cxt = new QueryContext<>(entityName);
+        cxt.setApiClient(new ApiClient());
+        cxt.setServiceBaseUri(serviceBaseUriProvider.getServiceBaseUri());
+        cxt.setAuthenticationProvider(authenticationProvider);
+        cxt.setAccountProvider(accountProvider);
+        cxt.setApiKeyProvider(apiKeyProvider);
+        cxt.configureApiClient();
+        return cxt;
+    }
+
+    protected <T> QueryContext<T> createQueryContext(QueryContext<?> parent, String entityName) {
+        QueryContext<T> cxt = new QueryContext<>(parent, entityName);
+        cxt.setApiClient(new ApiClient());
+        cxt.setServiceBaseUri(serviceBaseUriProvider.getServiceBaseUri());
+        cxt.setAuthenticationProvider(authenticationProvider);
+        cxt.setAccountProvider(accountProvider);
+        cxt.setApiKeyProvider(apiKeyProvider);
+        cxt.configureApiClient();
+        return cxt;
+    }
 }

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/impl/CertificateServiceImpl.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/impl/CertificateServiceImpl.java
@@ -1,8 +1,27 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * MIT License
+ *
+ * Copyright (c) 2018 SKB Kontur
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  */
+
 package ru.skbkontur.sdk.extern.service.impl;
 
 import ru.skbkontur.sdk.extern.model.CertificateList;

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/impl/CertificateServiceImpl.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/impl/CertificateServiceImpl.java
@@ -5,28 +5,30 @@
  */
 package ru.skbkontur.sdk.extern.service.impl;
 
-import java.util.concurrent.CompletableFuture;
 import ru.skbkontur.sdk.extern.model.CertificateList;
 import ru.skbkontur.sdk.extern.service.CertificateService;
 import ru.skbkontur.sdk.extern.service.transport.adaptors.CertificatesAdaptor;
 import ru.skbkontur.sdk.extern.service.transport.adaptors.QueryContext;
 
+import java.util.concurrent.CompletableFuture;
+
+
 /**
- *
  * @author alexs
  */
 public class CertificateServiceImpl extends BaseService<CertificatesAdaptor> implements CertificateService {
-	private static final String EN_CER = "certificate";
 
-	@Override
-	public CompletableFuture<QueryContext<CertificateList>> getCertificateListAsync() {
-		QueryContext<CertificateList> cxt = createQueryContext(EN_CER);
-		return cxt.applyAsync(api::getCertificates);
-	}
+    private static final String EN_CER = "certificate";
 
-	@Override
-	public QueryContext<CertificateList> getCertificateList(QueryContext<?> parent) {
-		QueryContext<CertificateList> cxt = createQueryContext(parent, EN_CER);
-		return cxt.apply(api::getCertificates);
-	}
+    @Override
+    public CompletableFuture<QueryContext<CertificateList>> getCertificateListAsync() {
+        QueryContext<CertificateList> cxt = createQueryContext(EN_CER);
+        return cxt.applyAsync(api::getCertificates);
+    }
+
+    @Override
+    public QueryContext<CertificateList> getCertificateList(QueryContext<?> parent) {
+        QueryContext<CertificateList> cxt = createQueryContext(parent, EN_CER);
+        return cxt.apply(api::getCertificates);
+    }
 }

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/impl/DocflowServiceImpl.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/impl/DocflowServiceImpl.java
@@ -1,8 +1,27 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * MIT License
+ *
+ * Copyright (c) 2018 SKB Kontur
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  */
+
 package ru.skbkontur.sdk.extern.service.impl;
 
 import org.joda.time.DateTime;

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/impl/DocflowServiceImpl.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/impl/DocflowServiceImpl.java
@@ -5,279 +5,279 @@
  */
 package ru.skbkontur.sdk.extern.service.impl;
 
-import java.util.List;
-import java.util.concurrent.CompletableFuture;
 import org.joda.time.DateTime;
 import ru.skbkontur.sdk.extern.model.Docflow;
 import ru.skbkontur.sdk.extern.model.DocflowPage;
 import ru.skbkontur.sdk.extern.model.Document;
 import ru.skbkontur.sdk.extern.model.DocumentDescription;
+import ru.skbkontur.sdk.extern.model.DocumentToSend;
 import ru.skbkontur.sdk.extern.model.Signature;
 import ru.skbkontur.sdk.extern.service.DocflowService;
 import ru.skbkontur.sdk.extern.service.transport.adaptors.DocflowsAdaptor;
 import ru.skbkontur.sdk.extern.service.transport.adaptors.QueryContext;
-import ru.skbkontur.sdk.extern.model.DocumentToSend;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
 
 /**
- *
  * @author AlexS
  */
 public class DocflowServiceImpl extends BaseService<DocflowsAdaptor> implements DocflowService {
-	private static final String EN_DFW = "Документооборот";
-	private static final String EN_DOC = "Документ";
-	private static final String EN_SGN = "Подпись";
-	
-	/**
-	 * Allow API user to get Docflow object
-	 * 
-	 * GET /v1/{accountId}/docflows/{docflowId}
-	 * 
-	 * @param docflowId String an docflow identity
-	 * 
-	 * @return CompletableFuture&lt;QueryContext&lt;Docflow&gt;&gt;
-	 */
-	@Override
-	public CompletableFuture<QueryContext<Docflow>> lookupDocflowAsync(String docflowId) {
-		QueryContext<Docflow> cxt = createQueryContext(EN_DFW);
-		return cxt
-			.setDocflowId(docflowId)
-			.applyAsync(api::lookupDocflow);
-	}
 
-	@Override
-	public QueryContext<Docflow> lookupDocflow(QueryContext<?> parent) {
-		QueryContext<Docflow> cxt = createQueryContext(parent, EN_DFW);
-		return cxt.apply(api::lookupDocflow);
-	}
+    private static final String EN_DFW = "Документооборот";
+    private static final String EN_DOC = "Документ";
+    private static final String EN_SGN = "Подпись";
 
-	@Override
-	public CompletableFuture<QueryContext<List<Document>>> getDocumentsAsync(String docflowId) {
-		QueryContext<List<Document>> cxt = createQueryContext(EN_DFW);
-		return cxt
-			.setDocflowId(docflowId)
-			.applyAsync(api::getDocuments);
-	}
+    /**
+     * Allow API user to get Docflow object
+     * <p>
+     * GET /v1/{accountId}/docflows/{docflowId}
+     *
+     * @param docflowId String an docflow identity
+     * @return CompletableFuture&lt;QueryContext&lt;Docflow&gt;&gt;
+     */
+    @Override
+    public CompletableFuture<QueryContext<Docflow>> lookupDocflowAsync(String docflowId) {
+        QueryContext<Docflow> cxt = createQueryContext(EN_DFW);
+        return cxt
+                .setDocflowId(docflowId)
+                .applyAsync(api::lookupDocflow);
+    }
 
-	@Override
-	public QueryContext<List<Document>> getDocuments(QueryContext<?> parent) {
-		QueryContext<List<Document>> cxt = createQueryContext(parent, EN_DFW);
-		return cxt.apply(api::getDocuments);
-	}
-	
-	@Override
-	public CompletableFuture<QueryContext<Document>> lookupDocumentAsync(String docflowId, String documentId) {
-		QueryContext<Document> cxt = createQueryContext(EN_DOC);
-		return cxt
-			.setDocflowId(docflowId)
-			.setDocumentId(documentId)
-			.applyAsync(api::lookupDocument);
-	}
+    @Override
+    public QueryContext<Docflow> lookupDocflow(QueryContext<?> parent) {
+        QueryContext<Docflow> cxt = createQueryContext(parent, EN_DFW);
+        return cxt.apply(api::lookupDocflow);
+    }
 
-	@Override
-	public QueryContext<Document> lookupDocument(QueryContext<?> parent) {
-		QueryContext<Document> cxt = createQueryContext(parent, EN_DOC);
-		return cxt.apply(api::lookupDocument);
-	}
+    @Override
+    public CompletableFuture<QueryContext<List<Document>>> getDocumentsAsync(String docflowId) {
+        QueryContext<List<Document>> cxt = createQueryContext(EN_DFW);
+        return cxt
+                .setDocflowId(docflowId)
+                .applyAsync(api::getDocuments);
+    }
 
-	@Override
-	public CompletableFuture<QueryContext<DocumentDescription>> lookupDescriptionAsync(String docflowId, String documentId) {
-		QueryContext<DocumentDescription> cxt = createQueryContext(EN_DOC);
-		return cxt
-			.setDocflowId(docflowId)
-			.setDocumentId(documentId)
-			.applyAsync(api::lookupDescription);
-	}
+    @Override
+    public QueryContext<List<Document>> getDocuments(QueryContext<?> parent) {
+        QueryContext<List<Document>> cxt = createQueryContext(parent, EN_DFW);
+        return cxt.apply(api::getDocuments);
+    }
 
-	@Override
-	public QueryContext<DocumentDescription> lookupDescription(QueryContext<?> parent) {
-		QueryContext<DocumentDescription> cxt = createQueryContext(parent, EN_DOC);
-		return cxt.apply(api::lookupDescription);
-	}
-	
-	@Override
-	public CompletableFuture<QueryContext<byte[]>> getEncryptedContentAsync(String docflowId, String documentId) {
-		QueryContext<byte[]> cxt = createQueryContext(EN_DOC);
-		return cxt
-			.setDocflowId(docflowId)
-			.setDocumentId(documentId)
-			.applyAsync(api::getEncryptedContent);
-	}
+    @Override
+    public CompletableFuture<QueryContext<Document>> lookupDocumentAsync(String docflowId, String documentId) {
+        QueryContext<Document> cxt = createQueryContext(EN_DOC);
+        return cxt
+                .setDocflowId(docflowId)
+                .setDocumentId(documentId)
+                .applyAsync(api::lookupDocument);
+    }
 
-	@Override
-	public QueryContext<byte[]> getEncryptedContent(QueryContext<?> parent) {
-		QueryContext<byte[]> cxt = createQueryContext(parent, EN_DOC);
-		return cxt.apply(api::getEncryptedContent);
-	}
+    @Override
+    public QueryContext<Document> lookupDocument(QueryContext<?> parent) {
+        QueryContext<Document> cxt = createQueryContext(parent, EN_DOC);
+        return cxt.apply(api::lookupDocument);
+    }
 
-	@Override
-	public CompletableFuture<QueryContext<byte[]>> getDecryptedContentAsync(String docflowId, String documentId) {
-		QueryContext<byte[]> cxt = createQueryContext(EN_DOC);
-		return cxt
-			.setDocflowId(docflowId)
-			.setDocumentId(documentId)
-			.applyAsync(api::getDecryptedContent);
-	}
+    @Override
+    public CompletableFuture<QueryContext<DocumentDescription>> lookupDescriptionAsync(String docflowId, String documentId) {
+        QueryContext<DocumentDescription> cxt = createQueryContext(EN_DOC);
+        return cxt
+                .setDocflowId(docflowId)
+                .setDocumentId(documentId)
+                .applyAsync(api::lookupDescription);
+    }
 
-	@Override
-	public QueryContext<byte[]> getDecryptedContent(QueryContext<?> parent) {
-		QueryContext<byte[]> cxt = createQueryContext(parent, EN_DOC);
-		return cxt.apply(api::getDecryptedContent);
-	}
+    @Override
+    public QueryContext<DocumentDescription> lookupDescription(QueryContext<?> parent) {
+        QueryContext<DocumentDescription> cxt = createQueryContext(parent, EN_DOC);
+        return cxt.apply(api::lookupDescription);
+    }
 
-	@Override
-	public CompletableFuture<QueryContext<List<Signature>>> getSignaturesAsync(String docflowId, String documentId) {
-		QueryContext<List<Signature>> cxt = createQueryContext(EN_DOC);
-		return cxt
-			.setDocflowId(docflowId)
-			.setDocumentId(documentId)
-			.applyAsync(api::getSignatures);
-	}
+    @Override
+    public CompletableFuture<QueryContext<byte[]>> getEncryptedContentAsync(String docflowId, String documentId) {
+        QueryContext<byte[]> cxt = createQueryContext(EN_DOC);
+        return cxt
+                .setDocflowId(docflowId)
+                .setDocumentId(documentId)
+                .applyAsync(api::getEncryptedContent);
+    }
 
-	@Override
-	public QueryContext<List<Signature>> getSignatures(QueryContext<?> parent) {
-		QueryContext<List<Signature>> cxt = createQueryContext(parent, EN_DOC);
-		return cxt.apply(api::getSignatures);
-	}
+    @Override
+    public QueryContext<byte[]> getEncryptedContent(QueryContext<?> parent) {
+        QueryContext<byte[]> cxt = createQueryContext(parent, EN_DOC);
+        return cxt.apply(api::getEncryptedContent);
+    }
 
-	@Override
-	public CompletableFuture<QueryContext<Signature>> getSignatureAsync(String docflowId, String documentId, String signatureId) {
-		QueryContext<Signature> cxt = createQueryContext(EN_SGN);
-		return cxt
-			.setDocflowId(docflowId)
-			.setDocumentId(documentId)
-			.applyAsync(api::getSignature);
-	}
+    @Override
+    public CompletableFuture<QueryContext<byte[]>> getDecryptedContentAsync(String docflowId, String documentId) {
+        QueryContext<byte[]> cxt = createQueryContext(EN_DOC);
+        return cxt
+                .setDocflowId(docflowId)
+                .setDocumentId(documentId)
+                .applyAsync(api::getDecryptedContent);
+    }
 
-	@Override
-	public QueryContext<Signature> getSignature(QueryContext<?> parent) {
-		QueryContext<Signature> cxt = createQueryContext(parent, EN_SGN);
-		return cxt.apply(api::getSignature);
-	}
+    @Override
+    public QueryContext<byte[]> getDecryptedContent(QueryContext<?> parent) {
+        QueryContext<byte[]> cxt = createQueryContext(parent, EN_DOC);
+        return cxt.apply(api::getDecryptedContent);
+    }
 
-	@Override
-	public CompletableFuture<QueryContext<byte[]>> getSignatureContentAsync(String docflowId, String documentId, String signatureId) {
-		QueryContext<byte[]> cxt = createQueryContext(EN_SGN);
-		return cxt
-			.setDocflowId(docflowId)
-			.setDocumentId(documentId)
-			.applyAsync(api::getSignatureContent);
-	}
+    @Override
+    public CompletableFuture<QueryContext<List<Signature>>> getSignaturesAsync(String docflowId, String documentId) {
+        QueryContext<List<Signature>> cxt = createQueryContext(EN_DOC);
+        return cxt
+                .setDocflowId(docflowId)
+                .setDocumentId(documentId)
+                .applyAsync(api::getSignatures);
+    }
 
-	@Override
-	public QueryContext<byte[]> getSignatureContent(QueryContext<?> parent) {
-		QueryContext<byte[]> cxt = createQueryContext(parent, EN_SGN);
-		return cxt.apply(api::getSignatureContent);
-	}
+    @Override
+    public QueryContext<List<Signature>> getSignatures(QueryContext<?> parent) {
+        QueryContext<List<Signature>> cxt = createQueryContext(parent, EN_DOC);
+        return cxt.apply(api::getSignatures);
+    }
 
-	@Override
-	public CompletableFuture<QueryContext<DocumentToSend>> generateDocumentTypeReplyAsync(String docflowId, String documentType, String documentId, String x509Base64) {
-		QueryContext<DocumentToSend> cxt = createQueryContext(EN_SGN);
-		return cxt
-			.setDocflowId(docflowId)
-			.setDocumentType(documentType)
-			.setDocumentId(documentId)
-			.setContentString(x509Base64)
-			.applyAsync(api::generateDocumentTypeReply);
-	}
+    @Override
+    public CompletableFuture<QueryContext<Signature>> getSignatureAsync(String docflowId, String documentId, String signatureId) {
+        QueryContext<Signature> cxt = createQueryContext(EN_SGN);
+        return cxt
+                .setDocflowId(docflowId)
+                .setDocumentId(documentId)
+                .applyAsync(api::getSignature);
+    }
 
-	@Override
-	public QueryContext<DocumentToSend> generateDocumentTypeReply(QueryContext<?> parent) {
-		QueryContext<DocumentToSend> cxt = createQueryContext(parent, EN_SGN);
-		return cxt.apply(api::generateDocumentTypeReply);
-	}
+    @Override
+    public QueryContext<Signature> getSignature(QueryContext<?> parent) {
+        QueryContext<Signature> cxt = createQueryContext(parent, EN_SGN);
+        return cxt.apply(api::getSignature);
+    }
 
-	@Override
-	public CompletableFuture<QueryContext<Docflow>> addDocumentTypeReplyAsync(String docflowId, String documentType, String documentId, DocumentToSend documentToSend) {
-		QueryContext<Docflow> cxt = createQueryContext(EN_DOC);
-		return cxt
-			.setDocflowId(docflowId)
-			.setDocumentType(documentType)
-			.setDocumentId(documentId)
-			.setDocumentToSend(documentToSend)
-			.applyAsync(api::addDocumentTypeReply);
-	}
+    @Override
+    public CompletableFuture<QueryContext<byte[]>> getSignatureContentAsync(String docflowId, String documentId, String signatureId) {
+        QueryContext<byte[]> cxt = createQueryContext(EN_SGN);
+        return cxt
+                .setDocflowId(docflowId)
+                .setDocumentId(documentId)
+                .applyAsync(api::getSignatureContent);
+    }
 
-	@Override
-	public QueryContext<Docflow> addDocumentTypeReply(QueryContext<?> parent) {
-		QueryContext<Docflow> cxt = createQueryContext(parent, EN_DOC);
-		return cxt.apply(api::addDocumentTypeReply);
-	}
-	
-	@Override
-	public CompletableFuture<QueryContext<List<DocumentToSend>>> generateRepliesAsync(Docflow docflow, String signerX509Base64) {
-		QueryContext<List<DocumentToSend>> cxt = createQueryContext(EN_DFW);
-		return cxt
-			.setDocflow(docflow)
-			.setCertificate(signerX509Base64)
-			.applyAsync(api::generateReplies);
-	}
+    @Override
+    public QueryContext<byte[]> getSignatureContent(QueryContext<?> parent) {
+        QueryContext<byte[]> cxt = createQueryContext(parent, EN_SGN);
+        return cxt.apply(api::getSignatureContent);
+    }
 
-	@Override
-	public QueryContext<List<DocumentToSend>> generateReplies(QueryContext<?> parent) {
-		QueryContext<List<DocumentToSend>> cxt = createQueryContext(parent, EN_DFW);
-		return cxt.apply(api::generateReplies);
-	}
+    @Override
+    public CompletableFuture<QueryContext<DocumentToSend>> generateDocumentTypeReplyAsync(String docflowId, String documentType, String documentId, String x509Base64) {
+        QueryContext<DocumentToSend> cxt = createQueryContext(EN_SGN);
+        return cxt
+                .setDocflowId(docflowId)
+                .setDocumentType(documentType)
+                .setDocumentId(documentId)
+                .setContentString(x509Base64)
+                .applyAsync(api::generateDocumentTypeReply);
+    }
 
-	@Override
-	public CompletableFuture<QueryContext<Docflow>> createReplyAsync(Docflow docflow) {
-		QueryContext<Docflow> cxt = createQueryContext(EN_DFW);
-		return cxt.applyAsync(api::sendReply);
-	}
-	
-	@Override
-	public QueryContext<Docflow> sendReply(QueryContext<?> parent) {
-		QueryContext<Docflow> cxt = createQueryContext(parent, EN_DFW);
-		return cxt.apply(api::sendReply);
-	}
+    @Override
+    public QueryContext<DocumentToSend> generateDocumentTypeReply(QueryContext<?> parent) {
+        QueryContext<DocumentToSend> cxt = createQueryContext(parent, EN_SGN);
+        return cxt.apply(api::generateDocumentTypeReply);
+    }
 
-	@Override
-	public CompletableFuture<QueryContext<DocflowPage>> getDocflows(
-		boolean finished,
-		boolean incoming,
-		long skip,
-		int take,
-		String innKpp,
-		DateTime updatedFrom,
-		DateTime updatedTo,
-		DateTime createdFrom,
-		DateTime createdTo,
-		String type
-	)
-	{
-		QueryContext<DocflowPage> cxt = createQueryContext(EN_DFW);
-		return cxt
-			.setFinished(finished)
-			.setIncoming(incoming)
-			.setSkip(skip)
-			.setTake(take)
-			.setInnKpp(innKpp)
-			.setUpdatedFrom(updatedFrom)
-			.setUpdatedTo(updatedTo)
-			.setCreatedFrom(createdFrom)
-			.setCreatedTo(createdTo)
-			.setType(type)
-			.applyAsync(api::getDocflows);
-	}
-	
-	@Override
-	public QueryContext<DocflowPage> getDocflows(QueryContext<?> parent) {
-		QueryContext<DocflowPage> cxt = createQueryContext(parent, EN_DFW);
-		return cxt.apply(api::getDocflows);
-	}
+    @Override
+    public CompletableFuture<QueryContext<Docflow>> addDocumentTypeReplyAsync(String docflowId, String documentType, String documentId, DocumentToSend documentToSend) {
+        QueryContext<Docflow> cxt = createQueryContext(EN_DOC);
+        return cxt
+                .setDocflowId(docflowId)
+                .setDocumentType(documentType)
+                .setDocumentId(documentId)
+                .setDocumentToSend(documentToSend)
+                .applyAsync(api::addDocumentTypeReply);
+    }
 
-	@Override
-	public CompletableFuture<QueryContext<String>> print(String docflowId, String documentId, String documentContentBase64) {
-		QueryContext<String> cxt = createQueryContext(EN_DFW);
-		return cxt
-			.setDocflowId(docflowId)
-			.setDocumentId(documentId)
-			.setContentString(documentContentBase64)
-			.applyAsync(api::print);
-	}
+    @Override
+    public QueryContext<Docflow> addDocumentTypeReply(QueryContext<?> parent) {
+        QueryContext<Docflow> cxt = createQueryContext(parent, EN_DOC);
+        return cxt.apply(api::addDocumentTypeReply);
+    }
 
-	@Override
-	public QueryContext<String> print(QueryContext<?> parent) {
-		QueryContext<String> cxt = createQueryContext(parent, EN_DFW);
-		return cxt.apply(api::print);
-	}
+    @Override
+    public CompletableFuture<QueryContext<List<DocumentToSend>>> generateRepliesAsync(Docflow docflow, String signerX509Base64) {
+        QueryContext<List<DocumentToSend>> cxt = createQueryContext(EN_DFW);
+        return cxt
+                .setDocflow(docflow)
+                .setCertificate(signerX509Base64)
+                .applyAsync(api::generateReplies);
+    }
+
+    @Override
+    public QueryContext<List<DocumentToSend>> generateReplies(QueryContext<?> parent) {
+        QueryContext<List<DocumentToSend>> cxt = createQueryContext(parent, EN_DFW);
+        return cxt.apply(api::generateReplies);
+    }
+
+    @Override
+    public CompletableFuture<QueryContext<Docflow>> createReplyAsync(Docflow docflow) {
+        QueryContext<Docflow> cxt = createQueryContext(EN_DFW);
+        return cxt.applyAsync(api::sendReply);
+    }
+
+    @Override
+    public QueryContext<Docflow> sendReply(QueryContext<?> parent) {
+        QueryContext<Docflow> cxt = createQueryContext(parent, EN_DFW);
+        return cxt.apply(api::sendReply);
+    }
+
+    @Override
+    public CompletableFuture<QueryContext<DocflowPage>> getDocflows(
+            boolean finished,
+            boolean incoming,
+            long skip,
+            int take,
+            String innKpp,
+            DateTime updatedFrom,
+            DateTime updatedTo,
+            DateTime createdFrom,
+            DateTime createdTo,
+            String type
+    ) {
+        QueryContext<DocflowPage> cxt = createQueryContext(EN_DFW);
+        return cxt
+                .setFinished(finished)
+                .setIncoming(incoming)
+                .setSkip(skip)
+                .setTake(take)
+                .setInnKpp(innKpp)
+                .setUpdatedFrom(updatedFrom)
+                .setUpdatedTo(updatedTo)
+                .setCreatedFrom(createdFrom)
+                .setCreatedTo(createdTo)
+                .setType(type)
+                .applyAsync(api::getDocflows);
+    }
+
+    @Override
+    public QueryContext<DocflowPage> getDocflows(QueryContext<?> parent) {
+        QueryContext<DocflowPage> cxt = createQueryContext(parent, EN_DFW);
+        return cxt.apply(api::getDocflows);
+    }
+
+    @Override
+    public CompletableFuture<QueryContext<String>> print(String docflowId, String documentId, String documentContentBase64) {
+        QueryContext<String> cxt = createQueryContext(EN_DFW);
+        return cxt
+                .setDocflowId(docflowId)
+                .setDocumentId(documentId)
+                .setContentString(documentContentBase64)
+                .applyAsync(api::print);
+    }
+
+    @Override
+    public QueryContext<String> print(QueryContext<?> parent) {
+        QueryContext<String> cxt = createQueryContext(parent, EN_DFW);
+        return cxt.apply(api::print);
+    }
 }

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/impl/DraftServiceImpl.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/impl/DraftServiceImpl.java
@@ -1,8 +1,27 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * MIT License
+ *
+ * Copyright (c) 2018 SKB Kontur
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  */
+
 package ru.skbkontur.sdk.extern.service.impl;
 
 import ru.skbkontur.sdk.extern.model.Docflow;

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/impl/DraftServiceImpl.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/impl/DraftServiceImpl.java
@@ -5,10 +5,6 @@
  */
 package ru.skbkontur.sdk.extern.service.impl;
 
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
-import java.util.concurrent.CompletableFuture;
 import ru.skbkontur.sdk.extern.model.Docflow;
 import ru.skbkontur.sdk.extern.model.DocumentContents;
 import ru.skbkontur.sdk.extern.model.Draft;
@@ -24,314 +20,319 @@ import ru.skbkontur.sdk.extern.service.DraftService;
 import ru.skbkontur.sdk.extern.service.transport.adaptors.DraftsAdaptor;
 import ru.skbkontur.sdk.extern.service.transport.adaptors.QueryContext;
 
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+
+
 /**
- *
  * @author AlexS
  */
 public class DraftServiceImpl extends BaseService<DraftsAdaptor> implements DraftService {
 
-	private static final String EN_DFT = "Черновик";
-	private static final String EN_DOC = "Документ";
-	private static final String EN_SIGN = "Подпись";
+    private static final String EN_DFT = "Черновик";
+    private static final String EN_DOC = "Документ";
+    private static final String EN_SIGN = "Подпись";
 
-	@Override
-	public CompletableFuture<QueryContext<UUID>> createAsync(Sender sender, Recipient recipient, Organization organization) {
-		QueryContext<UUID> cxt = createQueryContext(EN_DFT);
-		return cxt
-			.setDraftMeta(new DraftMeta(sender,recipient,organization))
-			.applyAsync(api::createDraft);
-	}
+    @Override
+    public CompletableFuture<QueryContext<UUID>> createAsync(Sender sender, Recipient recipient, Organization organization) {
+        QueryContext<UUID> cxt = createQueryContext(EN_DFT);
+        return cxt
+                .setDraftMeta(new DraftMeta(sender, recipient, organization))
+                .applyAsync(api::createDraft);
+    }
 
-	@Override
-	public QueryContext<UUID> create(QueryContext<?> parent) {
-		QueryContext<UUID> cxt = createQueryContext(parent,EN_DFT);
-		return cxt.apply(api::createDraft);
-	}
-	
-	@Override
-	public CompletableFuture<QueryContext<Draft>> lookupAsync(String draftId) {
-		QueryContext<Draft> cxt = createQueryContext(EN_DFT);
-		return cxt
-			.setDraftId(draftId)
-			.applyAsync(api::lookup);
-	}
+    @Override
+    public QueryContext<UUID> create(QueryContext<?> parent) {
+        QueryContext<UUID> cxt = createQueryContext(parent, EN_DFT);
+        return cxt.apply(api::createDraft);
+    }
 
-	@Override
-	public QueryContext<Draft> lookup(QueryContext<?> parent) {
-		QueryContext<Draft> cxt = createQueryContext(parent, EN_DFT);
-		return cxt.apply(api::lookup);
-	}
-	
-	@Override
-	public CompletableFuture<QueryContext<Void>> deleteAsync(String draftId) {
-		QueryContext<Void> cxt = createQueryContext(EN_DFT);
-		return cxt
-			.setDraftId(draftId)
-			.applyAsync(api::delete);
-	}
+    @Override
+    public CompletableFuture<QueryContext<Draft>> lookupAsync(String draftId) {
+        QueryContext<Draft> cxt = createQueryContext(EN_DFT);
+        return cxt
+                .setDraftId(draftId)
+                .applyAsync(api::lookup);
+    }
 
-	@Override
-	public QueryContext<Void> delete(QueryContext<?> parent) {
-		QueryContext<Void> cxt = createQueryContext(parent, EN_DFT);
-		return cxt.apply(api::delete);
-	}
+    @Override
+    public QueryContext<Draft> lookup(QueryContext<?> parent) {
+        QueryContext<Draft> cxt = createQueryContext(parent, EN_DFT);
+        return cxt.apply(api::lookup);
+    }
 
-	@Override
-	public CompletableFuture<QueryContext<DraftMeta>> lookupDraftMetaAsync(String draftId) {
-		QueryContext<DraftMeta> cxt = createQueryContext(EN_DFT);
-		return cxt
-			.setDraftId(draftId)
-			.applyAsync(api::lookupDraftMeta);
-	}
-	
-	@Override
-	public QueryContext<DraftMeta> lookupDraftMeta(QueryContext<?> parent) {
-		QueryContext<DraftMeta> cxt = createQueryContext(parent, EN_DFT);
-		return cxt.apply(api::lookupDraftMeta);
-	}
-	
-	@Override
-	public CompletableFuture<QueryContext<DraftMeta>> updateDraftMetaAsync(String draftId, DraftMeta draftMeta) {
-		QueryContext<DraftMeta> cxt = createQueryContext(EN_DFT);
-		return cxt
-			.setDraftId(draftId)
-			.setDraftMeta(draftMeta)
-			.applyAsync(api::updateDraftMeta);
-	}
-	
-	@Override
-	public QueryContext<DraftMeta> updateDraftMeta(QueryContext<?> parent) {
-		QueryContext<DraftMeta> cxt = createQueryContext(parent, EN_DFT);
-		return cxt.apply(api::updateDraftMeta);
-	}
-	
-	@Override
-	public CompletableFuture<QueryContext<Map<String,Object>>> checkAsync(String draftId) {
-		QueryContext<Map<String,Object>> cxt = createQueryContext(EN_DFT);
-		return cxt
-			.setDraftId(draftId)
-			.applyAsync(api::check);
-	}
+    @Override
+    public CompletableFuture<QueryContext<Void>> deleteAsync(String draftId) {
+        QueryContext<Void> cxt = createQueryContext(EN_DFT);
+        return cxt
+                .setDraftId(draftId)
+                .applyAsync(api::delete);
+    }
 
-	@Override
-	public QueryContext<Map<String,Object>> check(QueryContext<?> parent) {
-		QueryContext<Map<String,Object>> cxt = createQueryContext(parent, EN_DFT);
-		return cxt.apply(api::check);
-	}
+    @Override
+    public QueryContext<Void> delete(QueryContext<?> parent) {
+        QueryContext<Void> cxt = createQueryContext(parent, EN_DFT);
+        return cxt.apply(api::delete);
+    }
 
-	@Override
-	public CompletableFuture<QueryContext<PrepareResult>> prepareAsync(String draftId) {
-		QueryContext<PrepareResult> cxt = createQueryContext(EN_DFT);
-		return cxt
-			.setDraftId(draftId)
-			.applyAsync(api::prepare);
-	}
+    @Override
+    public CompletableFuture<QueryContext<DraftMeta>> lookupDraftMetaAsync(String draftId) {
+        QueryContext<DraftMeta> cxt = createQueryContext(EN_DFT);
+        return cxt
+                .setDraftId(draftId)
+                .applyAsync(api::lookupDraftMeta);
+    }
 
-	@Override
-	public QueryContext<PrepareResult> prepare(QueryContext<?> parent) {
-		QueryContext<PrepareResult> cxt = createQueryContext(parent, EN_DFT);
-		return cxt.apply(api::prepare);
-	}
+    @Override
+    public QueryContext<DraftMeta> lookupDraftMeta(QueryContext<?> parent) {
+        QueryContext<DraftMeta> cxt = createQueryContext(parent, EN_DFT);
+        return cxt.apply(api::lookupDraftMeta);
+    }
 
-	@Override
-	public CompletableFuture<QueryContext<List<Docflow>>> sendAsync(String draftId) {
-		QueryContext<List<Docflow>> cxt = createQueryContext(EN_DFT);
-		return cxt
-			.setDraftId(draftId)
-			.setDeffered(true)
-			.setForce(true)
-			.applyAsync(api::send);
-	}
-	
-	@Override
-	public QueryContext<List<Docflow>> send(QueryContext<?> parent) {
-		QueryContext<List<Docflow>> cxt = createQueryContext(parent, EN_DFT);
-		return cxt.apply(api::send);
-	}
-	
-	@Override
-	public CompletableFuture<QueryContext<Void>> deleteDocumentAsync(String draftId, String documentId) {
-		QueryContext<Void> cxt = createQueryContext(EN_DOC);
-		return cxt
-			.setDraftId(draftId)
-			.setDocumentId(documentId)
-			.applyAsync(api::deleteDocument);
-	}
+    @Override
+    public CompletableFuture<QueryContext<DraftMeta>> updateDraftMetaAsync(String draftId, DraftMeta draftMeta) {
+        QueryContext<DraftMeta> cxt = createQueryContext(EN_DFT);
+        return cxt
+                .setDraftId(draftId)
+                .setDraftMeta(draftMeta)
+                .applyAsync(api::updateDraftMeta);
+    }
 
-	@Override
-	public QueryContext<Void> deleteDocument(QueryContext<?> parent) {
-		QueryContext<Void> cxt = createQueryContext(parent, EN_DOC);
-		return cxt.apply(api::deleteDocument);
-	}
+    @Override
+    public QueryContext<DraftMeta> updateDraftMeta(QueryContext<?> parent) {
+        QueryContext<DraftMeta> cxt = createQueryContext(parent, EN_DFT);
+        return cxt.apply(api::updateDraftMeta);
+    }
 
-	@Override
-	public CompletableFuture<QueryContext<DraftDocument>> lookupDocumentAsync(String draftId, String documentId) {
-		QueryContext<DraftDocument> cxt = createQueryContext(EN_DOC);
-		return cxt
-			.setDraftId(draftId)
-			.setDocumentId(documentId)
-			.applyAsync(api::lookupDocument);
-	}
+    @Override
+    public CompletableFuture<QueryContext<Map<String, Object>>> checkAsync(String draftId) {
+        QueryContext<Map<String, Object>> cxt = createQueryContext(EN_DFT);
+        return cxt
+                .setDraftId(draftId)
+                .applyAsync(api::check);
+    }
 
-	@Override
-	public QueryContext<DraftDocument> lookupDocument(QueryContext<?> parent) {
-		QueryContext<DraftDocument> cxt = createQueryContext(parent, EN_DOC);
-		return cxt.apply(api::lookupDocument);
-	}
+    @Override
+    public QueryContext<Map<String, Object>> check(QueryContext<?> parent) {
+        QueryContext<Map<String, Object>> cxt = createQueryContext(parent, EN_DFT);
+        return cxt.apply(api::check);
+    }
 
-	@Override
-	public CompletableFuture<QueryContext<DraftDocument>> updateDocumentAsync(String draftId, String documentId, DocumentContents documentContents) {
-		QueryContext<DraftDocument> cxt = createQueryContext(EN_DOC);
-		return cxt
-			.setDraftId(draftId)
-			.setDocumentId(documentId)
-			.setDocumentContents(documentContents)
-			.applyAsync(api::updateDocument);
-	}
-	
-	@Override
-	public QueryContext<DraftDocument> updateDocument(QueryContext<?> parent) {
-		QueryContext<DraftDocument> cxt = createQueryContext(parent, EN_DOC);
-		return cxt.apply(api::updateDocument);
-	}
-	
-	@Override
-	public CompletableFuture<QueryContext<String>> printDocumentAsync(String draftId, String documentId) {
-		QueryContext<String> cxt = createQueryContext(EN_DOC);
-		return cxt
-			.setDraftId(draftId)
-			.setDocumentId(documentId)
-			.applyAsync(api::printDocument);
-	}
+    @Override
+    public CompletableFuture<QueryContext<PrepareResult>> prepareAsync(String draftId) {
+        QueryContext<PrepareResult> cxt = createQueryContext(EN_DFT);
+        return cxt
+                .setDraftId(draftId)
+                .applyAsync(api::prepare);
+    }
 
-	@Override
-	public QueryContext<String> printDocument(QueryContext<?> parent) {
-		QueryContext<String> cxt = createQueryContext(parent, EN_DOC);
-		return cxt.apply(api::printDocument);
-	}
+    @Override
+    public QueryContext<PrepareResult> prepare(QueryContext<?> parent) {
+        QueryContext<PrepareResult> cxt = createQueryContext(parent, EN_DFT);
+        return cxt.apply(api::prepare);
+    }
 
-	@Override
-	public CompletableFuture<QueryContext<DraftDocument>> addDecryptedDocumentAsync(UUID draftId, DocumentContents documentContents) {
-		QueryContext<DraftDocument> cxt = createQueryContext(EN_DOC);
-		return cxt
-			.setDraftId(draftId)
-			.setDocumentContents(documentContents)
-			.applyAsync(api::addDecryptedDocument);
-	}
+    @Override
+    public CompletableFuture<QueryContext<List<Docflow>>> sendAsync(String draftId) {
+        QueryContext<List<Docflow>> cxt = createQueryContext(EN_DFT);
+        return cxt
+                .setDraftId(draftId)
+                .setDeffered(true)
+                .setForce(true)
+                .applyAsync(api::send);
+    }
 
-	@Override
-	public QueryContext<DraftDocument> addDecryptedDocument(QueryContext<?> parent) {
-		QueryContext<DraftDocument> cxt = createQueryContext(parent, EN_DOC);
-		return cxt.apply(api::addDecryptedDocument);
-	}
+    @Override
+    public QueryContext<List<Docflow>> send(QueryContext<?> parent) {
+        QueryContext<List<Docflow>> cxt = createQueryContext(parent, EN_DFT);
+        return cxt.apply(api::send);
+    }
 
-	@Override
-	public CompletableFuture<QueryContext<String>> getDecryptedDocumentContentAsync(String draftId, String documentId) {
-		QueryContext<String> cxt = createQueryContext(EN_DOC);
-		return cxt
-			.setDraftId(draftId)
-			.setDocumentId(documentId)
-			.applyAsync(api::getDecryptedDocumentContent);
-	}
+    @Override
+    public CompletableFuture<QueryContext<Void>> deleteDocumentAsync(String draftId, String documentId) {
+        QueryContext<Void> cxt = createQueryContext(EN_DOC);
+        return cxt
+                .setDraftId(draftId)
+                .setDocumentId(documentId)
+                .applyAsync(api::deleteDocument);
+    }
 
-	@Override
-	public QueryContext<String> getDecryptedDocumentContent(QueryContext<?> parent) {
-		QueryContext<String> cxt = createQueryContext(parent, EN_DOC);
-		return cxt.apply(api::getDecryptedDocumentContent);
-	}
+    @Override
+    public QueryContext<Void> deleteDocument(QueryContext<?> parent) {
+        QueryContext<Void> cxt = createQueryContext(parent, EN_DOC);
+        return cxt.apply(api::deleteDocument);
+    }
 
-	@Override
-	public CompletableFuture<QueryContext<Void>> updateDecryptedDocumentContentAsync(String draftId, String documentId, byte[] content) {
-		QueryContext<Void> cxt = createQueryContext(EN_DOC);
-		return cxt
-			.setDraftId(draftId)
-			.setDocumentId(documentId)
-			.setContent(content)
-			.applyAsync(api::updateDecryptedDocumentContent);
-	}
+    @Override
+    public CompletableFuture<QueryContext<DraftDocument>> lookupDocumentAsync(String draftId, String documentId) {
+        QueryContext<DraftDocument> cxt = createQueryContext(EN_DOC);
+        return cxt
+                .setDraftId(draftId)
+                .setDocumentId(documentId)
+                .applyAsync(api::lookupDocument);
+    }
 
-	@Override
-	public QueryContext<Void> updateDecryptedDocumentContent(QueryContext<?> parent) {
-		QueryContext<Void> cxt = createQueryContext(parent, EN_DOC);
-		return cxt.apply(api::updateDecryptedDocumentContent);
-	}
+    @Override
+    public QueryContext<DraftDocument> lookupDocument(QueryContext<?> parent) {
+        QueryContext<DraftDocument> cxt = createQueryContext(parent, EN_DOC);
+        return cxt.apply(api::lookupDocument);
+    }
 
-	@Override
-	public CompletableFuture<QueryContext<String>> getEncryptedDocumentContentAsync(String draftId, String documentId) {
-		QueryContext<String> cxt = createQueryContext(EN_DOC);
-		return cxt
-			.setDraftId(draftId)
-			.setDocumentId(documentId)
-			.applyAsync(api::getEncryptedDocumentContent);
-	}
+    @Override
+    public CompletableFuture<QueryContext<DraftDocument>> updateDocumentAsync(String draftId, String documentId, DocumentContents documentContents) {
+        QueryContext<DraftDocument> cxt = createQueryContext(EN_DOC);
+        return cxt
+                .setDraftId(draftId)
+                .setDocumentId(documentId)
+                .setDocumentContents(documentContents)
+                .applyAsync(api::updateDocument);
+    }
 
-	@Override
-	public QueryContext<String> getEncryptedDocumentContent(QueryContext<?> parent) {
-		QueryContext<String> cxt = createQueryContext(parent, EN_DOC);
-		return cxt.apply(api::getEncryptedDocumentContent);
-	}
+    @Override
+    public QueryContext<DraftDocument> updateDocument(QueryContext<?> parent) {
+        QueryContext<DraftDocument> cxt = createQueryContext(parent, EN_DOC);
+        return cxt.apply(api::updateDocument);
+    }
 
-	@Override
-	public CompletableFuture<QueryContext<String>> getSignatureContentAsync(String draftId, String documentId) {
-		QueryContext<String> cxt = createQueryContext(EN_DOC);
-		return cxt
-			.setDraftId(draftId)
-			.setDocumentId(documentId)
-			.applyAsync(api::getSignatureContent);
-	}
+    @Override
+    public CompletableFuture<QueryContext<String>> printDocumentAsync(String draftId, String documentId) {
+        QueryContext<String> cxt = createQueryContext(EN_DOC);
+        return cxt
+                .setDraftId(draftId)
+                .setDocumentId(documentId)
+                .applyAsync(api::printDocument);
+    }
 
-	@Override
-	public QueryContext<String> getSignatureContent(QueryContext<?> parent) {
-		QueryContext<String> cxt = createQueryContext(parent, EN_DOC);
-		return cxt.apply(api::getSignatureContent);
-	}
+    @Override
+    public QueryContext<String> printDocument(QueryContext<?> parent) {
+        QueryContext<String> cxt = createQueryContext(parent, EN_DOC);
+        return cxt.apply(api::printDocument);
+    }
 
-	@Override
-	public CompletableFuture<QueryContext<Void>> updateSignatureAsync(String draftId, String documentId, byte[] content) {
-		QueryContext<Void> cxt = createQueryContext(EN_DOC);
-		return cxt
-			.setDraftId(draftId)
-			.setDocumentId(documentId)
-			.setContent(content)
-			.applyAsync(api::updateSignature);
-	}
+    @Override
+    public CompletableFuture<QueryContext<DraftDocument>> addDecryptedDocumentAsync(UUID draftId, DocumentContents documentContents) {
+        QueryContext<DraftDocument> cxt = createQueryContext(EN_DOC);
+        return cxt
+                .setDraftId(draftId)
+                .setDocumentContents(documentContents)
+                .applyAsync(api::addDecryptedDocument);
+    }
 
-	@Override
-	public QueryContext<Void> updateSignature(QueryContext<?> parent) {
-		QueryContext<Void> cxt = createQueryContext(parent, EN_DOC);
-		return cxt.apply(api::updateSignature);
-	}
+    @Override
+    public QueryContext<DraftDocument> addDecryptedDocument(QueryContext<?> parent) {
+        QueryContext<DraftDocument> cxt = createQueryContext(parent, EN_DOC);
+        return cxt.apply(api::addDecryptedDocument);
+    }
 
-	@Override
-	public CompletableFuture<QueryContext<Void>> createUSN1Async(String draftId, String documentId, UsnServiceContractInfo usn) {
-		QueryContext<Void> cxt = createQueryContext(EN_DOC);
-		return cxt
-			.setDraftId(draftId)
-			.setDocumentId(documentId)
-			.setUsnServiceContractInfo(usn)
-			.applyAsync(api::createUSN1);
-	}
+    @Override
+    public CompletableFuture<QueryContext<String>> getDecryptedDocumentContentAsync(String draftId, String documentId) {
+        QueryContext<String> cxt = createQueryContext(EN_DOC);
+        return cxt
+                .setDraftId(draftId)
+                .setDocumentId(documentId)
+                .applyAsync(api::getDecryptedDocumentContent);
+    }
 
-	@Override
-	public QueryContext<Void> createUSN1(QueryContext<?> parent) {
-		QueryContext<Void> cxt = createQueryContext(parent, EN_DOC);
-		return cxt.apply(api::createUSN1);
-	}
+    @Override
+    public QueryContext<String> getDecryptedDocumentContent(QueryContext<?> parent) {
+        QueryContext<String> cxt = createQueryContext(parent, EN_DOC);
+        return cxt.apply(api::getDecryptedDocumentContent);
+    }
 
-	@Override
-	public CompletableFuture<QueryContext<Void>> createUSN2Async(String draftId, String documentId, UsnServiceContractInfoV2 usn) {
-		QueryContext<Void> cxt = createQueryContext(EN_DOC);
-		return cxt
-			.setDraftId(draftId)
-			.setDocumentId(documentId)
-			.setUsnServiceContractInfoV2(usn)
-			.applyAsync(api::createUSN2);
-	}
+    @Override
+    public CompletableFuture<QueryContext<Void>> updateDecryptedDocumentContentAsync(String draftId, String documentId, byte[] content) {
+        QueryContext<Void> cxt = createQueryContext(EN_DOC);
+        return cxt
+                .setDraftId(draftId)
+                .setDocumentId(documentId)
+                .setContent(content)
+                .applyAsync(api::updateDecryptedDocumentContent);
+    }
 
-	@Override
-	public QueryContext<Void> createUSN2(QueryContext<?> parent) {
-		QueryContext<Void> cxt = createQueryContext(parent, EN_DOC);
-		return cxt.apply(api::createUSN2);
-	}
+    @Override
+    public QueryContext<Void> updateDecryptedDocumentContent(QueryContext<?> parent) {
+        QueryContext<Void> cxt = createQueryContext(parent, EN_DOC);
+        return cxt.apply(api::updateDecryptedDocumentContent);
+    }
+
+    @Override
+    public CompletableFuture<QueryContext<String>> getEncryptedDocumentContentAsync(String draftId, String documentId) {
+        QueryContext<String> cxt = createQueryContext(EN_DOC);
+        return cxt
+                .setDraftId(draftId)
+                .setDocumentId(documentId)
+                .applyAsync(api::getEncryptedDocumentContent);
+    }
+
+    @Override
+    public QueryContext<String> getEncryptedDocumentContent(QueryContext<?> parent) {
+        QueryContext<String> cxt = createQueryContext(parent, EN_DOC);
+        return cxt.apply(api::getEncryptedDocumentContent);
+    }
+
+    @Override
+    public CompletableFuture<QueryContext<String>> getSignatureContentAsync(String draftId, String documentId) {
+        QueryContext<String> cxt = createQueryContext(EN_DOC);
+        return cxt
+                .setDraftId(draftId)
+                .setDocumentId(documentId)
+                .applyAsync(api::getSignatureContent);
+    }
+
+    @Override
+    public QueryContext<String> getSignatureContent(QueryContext<?> parent) {
+        QueryContext<String> cxt = createQueryContext(parent, EN_DOC);
+        return cxt.apply(api::getSignatureContent);
+    }
+
+    @Override
+    public CompletableFuture<QueryContext<Void>> updateSignatureAsync(String draftId, String documentId, byte[] content) {
+        QueryContext<Void> cxt = createQueryContext(EN_DOC);
+        return cxt
+                .setDraftId(draftId)
+                .setDocumentId(documentId)
+                .setContent(content)
+                .applyAsync(api::updateSignature);
+    }
+
+    @Override
+    public QueryContext<Void> updateSignature(QueryContext<?> parent) {
+        QueryContext<Void> cxt = createQueryContext(parent, EN_DOC);
+        return cxt.apply(api::updateSignature);
+    }
+
+    @Override
+    public CompletableFuture<QueryContext<Void>> createUSN1Async(String draftId, String documentId, UsnServiceContractInfo usn) {
+        QueryContext<Void> cxt = createQueryContext(EN_DOC);
+        return cxt
+                .setDraftId(draftId)
+                .setDocumentId(documentId)
+                .setUsnServiceContractInfo(usn)
+                .applyAsync(api::createUSN1);
+    }
+
+    @Override
+    public QueryContext<Void> createUSN1(QueryContext<?> parent) {
+        QueryContext<Void> cxt = createQueryContext(parent, EN_DOC);
+        return cxt.apply(api::createUSN1);
+    }
+
+    @Override
+    public CompletableFuture<QueryContext<Void>> createUSN2Async(String draftId, String documentId, UsnServiceContractInfoV2 usn) {
+        QueryContext<Void> cxt = createQueryContext(EN_DOC);
+        return cxt
+                .setDraftId(draftId)
+                .setDocumentId(documentId)
+                .setUsnServiceContractInfoV2(usn)
+                .applyAsync(api::createUSN2);
+    }
+
+    @Override
+    public QueryContext<Void> createUSN2(QueryContext<?> parent) {
+        QueryContext<Void> cxt = createQueryContext(parent, EN_DOC);
+        return cxt.apply(api::createUSN2);
+    }
 
 }

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/AccountsAdaptor.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/AccountsAdaptor.java
@@ -5,16 +5,10 @@
  */
 package ru.skbkontur.sdk.extern.service.transport.adaptors;
 
-import java.util.List;
-import java.util.stream.Collectors;
 import ru.skbkontur.sdk.extern.model.Account;
 import ru.skbkontur.sdk.extern.model.AccountList;
 import ru.skbkontur.sdk.extern.model.Link;
 import ru.skbkontur.sdk.extern.providers.ServiceError;
-import static ru.skbkontur.sdk.extern.service.transport.adaptors.QueryContext.ACCOUNT;
-import static ru.skbkontur.sdk.extern.service.transport.adaptors.QueryContext.ACCOUNT_LIST;
-import static ru.skbkontur.sdk.extern.service.transport.adaptors.QueryContext.LINKS;
-import static ru.skbkontur.sdk.extern.service.transport.adaptors.QueryContext.OBJECT;
 import ru.skbkontur.sdk.extern.service.transport.adaptors.dto.AccountDto;
 import ru.skbkontur.sdk.extern.service.transport.adaptors.dto.AccountListDto;
 import ru.skbkontur.sdk.extern.service.transport.adaptors.dto.CreateAccountRequestDto;
@@ -23,116 +17,120 @@ import ru.skbkontur.sdk.extern.service.transport.invoker.ApiClient;
 import ru.skbkontur.sdk.extern.service.transport.swagger.api.AccountsApi;
 import ru.skbkontur.sdk.extern.service.transport.swagger.invoker.ApiException;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static ru.skbkontur.sdk.extern.service.transport.adaptors.QueryContext.ACCOUNT;
+import static ru.skbkontur.sdk.extern.service.transport.adaptors.QueryContext.ACCOUNT_LIST;
+import static ru.skbkontur.sdk.extern.service.transport.adaptors.QueryContext.LINKS;
+import static ru.skbkontur.sdk.extern.service.transport.adaptors.QueryContext.OBJECT;
+
+
 /**
- *
  * @author AlexS
  */
 public class AccountsAdaptor extends BaseAdaptor {
 
-	private AccountsApi api;
-	
-	public AccountsAdaptor(AccountsApi accountsApi) {
-		this.api = accountsApi;
-	}
-	
-	public AccountsAdaptor() {
-		this(new AccountsApi());
-	}
-		
-	@Override
-	public ApiClient getApiClient() {
-		return (ApiClient) api.getApiClient();
-	}
+    private AccountsApi api;
 
-	@Override
-	public void setApiClient(ApiClient apiClient) {
-		api.setApiClient(apiClient);
-	}
-	
-	public QueryContext<List<Link>> acquireBaseUri(QueryContext<List<Link>> cxt) {
-		try {
-			if (cxt.isFail())	return cxt;
+    public AccountsAdaptor(AccountsApi accountsApi) {
+        this.api = accountsApi;
+    }
 
-			LinkDto linkDto = new LinkDto();
-			
-			return cxt.setResult(
-				transport(cxt)
-					.rootIndex()
-					.stream()
-					.map(linkDto::fromDto)
-					.collect(Collectors.toList())
-				, 
-				LINKS
-			);
-		}
-		catch (ApiException x) {
-			return cxt.setServiceError(new ServiceErrorImpl(ServiceError.ErrorCode.server, x.getMessage(), x.getCode(), x.getResponseHeaders(), x.getResponseBody()));
-		}
-	}
+    public AccountsAdaptor() {
+        this(new AccountsApi());
+    }
 
-	public QueryContext<AccountList> acquireAccounts(QueryContext<AccountList> cxt) {
-		try {
-			if (cxt.isFail())	return cxt;
+    @Override
+    public ApiClient getApiClient() {
+        return (ApiClient) api.getApiClient();
+    }
 
-			AccountListDto accountListDto = new AccountListDto();
-			
-			return cxt.setResult(
-				accountListDto
-					.fromDto(
-						transport(cxt)
-							.accountsGetAll()
-					)
-				,
-				ACCOUNT_LIST
-			);
-		}
-		catch (ApiException x) {
-			return cxt.setServiceError(new ServiceErrorImpl(ServiceError.ErrorCode.server, x.getMessage(), x.getCode(), x.getResponseHeaders(), x.getResponseBody()));
-		}
-	}
-	
-	public QueryContext<Object> createAccount(QueryContext<Object> cxt) {
-		try {
-			if (cxt.isFail())	return cxt;
-			
-			CreateAccountRequestDto createAccountRequestDto = new CreateAccountRequestDto();
-			
-			return cxt.setResult(
-				transport(cxt).accountsCreate(
-					createAccountRequestDto
-						.toDto(cxt.getCreateAccountRequest())
-				)
-				, 
-				OBJECT
-			);
-		}
-		catch (ApiException x) {
-			return cxt.setServiceError(new ServiceErrorImpl(ServiceError.ErrorCode.server, x.getMessage(), x.getCode(), x.getResponseHeaders(), x.getResponseBody()));
-		}
-	}
+    @Override
+    public void setApiClient(ApiClient apiClient) {
+        api.setApiClient(apiClient);
+    }
 
-	public QueryContext<Account> getAccount(QueryContext<Account> cxt) {
-		try {
-			if (cxt.isFail())	return cxt;
+    public QueryContext<List<Link>> acquireBaseUri(QueryContext<List<Link>> cxt) {
+        try {
+            if (cxt.isFail()) return cxt;
 
-			AccountDto accountDto = new AccountDto();
-			
-			return cxt.setResult(
-				accountDto
-					.fromDto(
-						transport(cxt).accountsGet(cxt.getAccountId())
-					)
-				,
-				ACCOUNT
-			);
-		}
-		catch (ApiException x) {
-			return cxt.setServiceError(new ServiceErrorImpl(ServiceError.ErrorCode.server, x.getMessage(), x.getCode(), x.getResponseHeaders(), x.getResponseBody()));
-		}
-	}
-	
-	private AccountsApi transport(QueryContext<?> cxt) {
-		super.prepareTransport(cxt);
-		return api;
-	}
+            LinkDto linkDto = new LinkDto();
+
+            return cxt.setResult(
+                    transport(cxt)
+                            .rootIndex()
+                            .stream()
+                            .map(linkDto::fromDto)
+                            .collect(Collectors.toList())
+                    ,
+                    LINKS
+            );
+        } catch (ApiException x) {
+            return cxt.setServiceError(new ServiceErrorImpl(ServiceError.ErrorCode.server, x.getMessage(), x.getCode(), x.getResponseHeaders(), x.getResponseBody()));
+        }
+    }
+
+    public QueryContext<AccountList> acquireAccounts(QueryContext<AccountList> cxt) {
+        try {
+            if (cxt.isFail()) return cxt;
+
+            AccountListDto accountListDto = new AccountListDto();
+
+            return cxt.setResult(
+                    accountListDto
+                            .fromDto(
+                                    transport(cxt)
+                                            .accountsGetAll()
+                            )
+                    ,
+                    ACCOUNT_LIST
+            );
+        } catch (ApiException x) {
+            return cxt.setServiceError(new ServiceErrorImpl(ServiceError.ErrorCode.server, x.getMessage(), x.getCode(), x.getResponseHeaders(), x.getResponseBody()));
+        }
+    }
+
+    public QueryContext<Object> createAccount(QueryContext<Object> cxt) {
+        try {
+            if (cxt.isFail()) return cxt;
+
+            CreateAccountRequestDto createAccountRequestDto = new CreateAccountRequestDto();
+
+            return cxt.setResult(
+                    transport(cxt).accountsCreate(
+                            createAccountRequestDto
+                                    .toDto(cxt.getCreateAccountRequest())
+                    )
+                    ,
+                    OBJECT
+            );
+        } catch (ApiException x) {
+            return cxt.setServiceError(new ServiceErrorImpl(ServiceError.ErrorCode.server, x.getMessage(), x.getCode(), x.getResponseHeaders(), x.getResponseBody()));
+        }
+    }
+
+    public QueryContext<Account> getAccount(QueryContext<Account> cxt) {
+        try {
+            if (cxt.isFail()) return cxt;
+
+            AccountDto accountDto = new AccountDto();
+
+            return cxt.setResult(
+                    accountDto
+                            .fromDto(
+                                    transport(cxt).accountsGet(cxt.getAccountId())
+                            )
+                    ,
+                    ACCOUNT
+            );
+        } catch (ApiException x) {
+            return cxt.setServiceError(new ServiceErrorImpl(ServiceError.ErrorCode.server, x.getMessage(), x.getCode(), x.getResponseHeaders(), x.getResponseBody()));
+        }
+    }
+
+    private AccountsApi transport(QueryContext<?> cxt) {
+        super.prepareTransport(cxt);
+        return api;
+    }
 }

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/AccountsAdaptor.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/AccountsAdaptor.java
@@ -1,8 +1,27 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * MIT License
+ *
+ * Copyright (c) 2018 SKB Kontur
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  */
+
 package ru.skbkontur.sdk.extern.service.transport.adaptors;
 
 import ru.skbkontur.sdk.extern.model.Account;

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/ApiClientAware.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/ApiClientAware.java
@@ -1,8 +1,27 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * MIT License
+ *
+ * Copyright (c) 2018 SKB Kontur
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  */
+
 package ru.skbkontur.sdk.extern.service.transport.adaptors;
 
 import ru.skbkontur.sdk.extern.service.transport.invoker.ApiClient;

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/ApiClientAware.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/ApiClientAware.java
@@ -7,11 +7,13 @@ package ru.skbkontur.sdk.extern.service.transport.adaptors;
 
 import ru.skbkontur.sdk.extern.service.transport.invoker.ApiClient;
 
+
 /**
- *
  * @author AlexS
  */
 public interface ApiClientAware {
-	ApiClient getApiClient();
-	void setApiClient(ApiClient apiClient);
+
+    ApiClient getApiClient();
+
+    void setApiClient(ApiClient apiClient);
 }

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/ApiExceptionDto.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/ApiExceptionDto.java
@@ -7,19 +7,19 @@ package ru.skbkontur.sdk.extern.service.transport.adaptors;
 
 import ru.skbkontur.sdk.extern.service.transport.invoker.ApiException;
 
+
 /**
- *
  * @author alexs
  */
 public class ApiExceptionDto {
 
-	public ApiException fromDto(ru.skbkontur.sdk.extern.service.transport.swagger.invoker.ApiException dto) {
-		return new ApiException(dto.getCode(), dto.getMessage(), dto.getResponseHeaders(), dto.getResponseBody());
-	}
-	
-	public ru.skbkontur.sdk.extern.service.transport.swagger.invoker.ApiException toDto(ApiException x) {
-		return new ru.skbkontur.sdk.extern.service.transport.swagger.invoker.ApiException(
-			x.getCode(), x.getMessage(), x.getResponseHeaders(), x.getResponseBody()
-		);
-	}
+    public ApiException fromDto(ru.skbkontur.sdk.extern.service.transport.swagger.invoker.ApiException dto) {
+        return new ApiException(dto.getCode(), dto.getMessage(), dto.getResponseHeaders(), dto.getResponseBody());
+    }
+
+    public ru.skbkontur.sdk.extern.service.transport.swagger.invoker.ApiException toDto(ApiException x) {
+        return new ru.skbkontur.sdk.extern.service.transport.swagger.invoker.ApiException(
+                x.getCode(), x.getMessage(), x.getResponseHeaders(), x.getResponseBody()
+        );
+    }
 }

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/ApiExceptionDto.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/ApiExceptionDto.java
@@ -1,8 +1,27 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * MIT License
+ *
+ * Copyright (c) 2018 SKB Kontur
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  */
+
 package ru.skbkontur.sdk.extern.service.transport.adaptors;
 
 import ru.skbkontur.sdk.extern.service.transport.invoker.ApiException;

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/BaseAdaptor.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/BaseAdaptor.java
@@ -6,41 +6,42 @@
 package ru.skbkontur.sdk.extern.service.transport.adaptors;
 
 import com.google.gson.Gson;
-import java.util.HashMap;
-import java.util.Map;
 import ru.skbkontur.sdk.extern.service.transport.invoker.ApiClient;
 import ru.skbkontur.sdk.extern.service.transport.invoker.ApiException;
 import ru.skbkontur.sdk.extern.service.transport.invoker.ApiResponse;
 
+import java.util.HashMap;
+import java.util.Map;
+
+
 /**
- *
  * @author AlexS
  */
 public abstract class BaseAdaptor implements ApiClientAware {
 
-	protected <T> T jsonToDTO(Map<?, ?> response, Class<T> t) {
-		Gson gson = new Gson();
-		String json = gson.toJson(response);
-		return gson.fromJson(json, t);
-	}
+    protected <T> T jsonToDTO(Map<?, ?> response, Class<T> t) {
+        Gson gson = new Gson();
+        String json = gson.toJson(response);
+        return gson.fromJson(json, t);
+    }
 
-	protected void prepareTransport(QueryContext<?> cxt) {
-		setApiClient(cxt.getApiClient());
-	}
+    protected void prepareTransport(QueryContext<?> cxt) {
+        setApiClient(cxt.getApiClient());
+    }
 
-	protected <T> T submitHttpRequest(String httpRequestUri, String httpMethod, Object body, Class<T> dtoClass) throws ApiException {
-		ApiClient apiClient = getApiClient();
-		
-		apiClient.setBasePath("");
-		
-		Map<String, String> localQueryParams = new HashMap<>();
+    protected <T> T submitHttpRequest(String httpRequestUri, String httpMethod, Object body, Class<T> dtoClass) throws ApiException {
+        ApiClient apiClient = getApiClient();
 
-		Map<String, String> localHeaderParams = new HashMap<>();
+        apiClient.setBasePath("");
 
-		Map<String, Object> localVarFormParams = new HashMap<>();
+        Map<String, String> localQueryParams = new HashMap<>();
 
-		ApiResponse<T> response = apiClient.submitHttpRequest(httpRequestUri, httpMethod, localQueryParams, body, localHeaderParams, localVarFormParams, dtoClass);
+        Map<String, String> localHeaderParams = new HashMap<>();
 
-		return response.getData();
-	}
+        Map<String, Object> localVarFormParams = new HashMap<>();
+
+        ApiResponse<T> response = apiClient.submitHttpRequest(httpRequestUri, httpMethod, localQueryParams, body, localHeaderParams, localVarFormParams, dtoClass);
+
+        return response.getData();
+    }
 }

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/BaseAdaptor.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/BaseAdaptor.java
@@ -1,8 +1,27 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * MIT License
+ *
+ * Copyright (c) 2018 SKB Kontur
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  */
+
 package ru.skbkontur.sdk.extern.service.transport.adaptors;
 
 import com.google.gson.Gson;

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/CertificatesAdaptor.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/CertificatesAdaptor.java
@@ -1,8 +1,27 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * MIT License
+ *
+ * Copyright (c) 2018 SKB Kontur
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  */
+
 package ru.skbkontur.sdk.extern.service.transport.adaptors;
 
 import ru.skbkontur.sdk.extern.model.CertificateList;

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/CertificatesAdaptor.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/CertificatesAdaptor.java
@@ -7,58 +7,58 @@ package ru.skbkontur.sdk.extern.service.transport.adaptors;
 
 import ru.skbkontur.sdk.extern.model.CertificateList;
 import ru.skbkontur.sdk.extern.providers.ServiceError;
-import static ru.skbkontur.sdk.extern.service.transport.adaptors.QueryContext.CERTIFICATE_LIST;
 import ru.skbkontur.sdk.extern.service.transport.adaptors.dto.CertificateListDto;
 import ru.skbkontur.sdk.extern.service.transport.invoker.ApiClient;
 import ru.skbkontur.sdk.extern.service.transport.swagger.api.CertificatesApi;
 import ru.skbkontur.sdk.extern.service.transport.swagger.invoker.ApiException;
 
+import static ru.skbkontur.sdk.extern.service.transport.adaptors.QueryContext.CERTIFICATE_LIST;
+
+
 /**
- *
  * @author alexs
  */
 public class CertificatesAdaptor extends BaseAdaptor {
 
-	private CertificatesApi api;
-	
-	public CertificatesAdaptor(CertificatesApi certificatesApi) {
-		this.api = certificatesApi;
-	}
-	
-	public CertificatesAdaptor() {
-		this(new CertificatesApi());
-	}
-		
-	@Override
-	public ApiClient getApiClient() {
-		return (ApiClient) api.getApiClient();
-	}
+    private CertificatesApi api;
 
-	@Override
-	public void setApiClient(ApiClient apiClient) {
-		api.setApiClient(apiClient);
-	}
-	
-	public QueryContext<CertificateList> getCertificates(QueryContext<CertificateList> cxt) {
-		try {
-			if (cxt.isFail())	return cxt;
+    public CertificatesAdaptor(CertificatesApi certificatesApi) {
+        this.api = certificatesApi;
+    }
 
-			return cxt.setResult(
-				new CertificateListDto()
-					.fromDto(
-						transport(cxt)
-							.certificatesGetCertificatesAsync(cxt.getAccountProvider().accountId())
-					),
-				CERTIFICATE_LIST
-			);
-		}
-		catch (ApiException x) {
-			return cxt.setServiceError(new ServiceErrorImpl(ServiceError.ErrorCode.server, x.getMessage(), x.getCode(), x.getResponseHeaders(), x.getResponseBody()));
-		}
-	}
+    public CertificatesAdaptor() {
+        this(new CertificatesApi());
+    }
 
-	private CertificatesApi transport(QueryContext<?> cxt) {
-		super.prepareTransport(cxt);
-		return api;
-	}
+    @Override
+    public ApiClient getApiClient() {
+        return (ApiClient) api.getApiClient();
+    }
+
+    @Override
+    public void setApiClient(ApiClient apiClient) {
+        api.setApiClient(apiClient);
+    }
+
+    public QueryContext<CertificateList> getCertificates(QueryContext<CertificateList> cxt) {
+        try {
+            if (cxt.isFail()) return cxt;
+
+            return cxt.setResult(
+                    new CertificateListDto()
+                            .fromDto(
+                                    transport(cxt)
+                                            .certificatesGetCertificatesAsync(cxt.getAccountProvider().accountId())
+                            ),
+                    CERTIFICATE_LIST
+            );
+        } catch (ApiException x) {
+            return cxt.setServiceError(new ServiceErrorImpl(ServiceError.ErrorCode.server, x.getMessage(), x.getCode(), x.getResponseHeaders(), x.getResponseBody()));
+        }
+    }
+
+    private CertificatesApi transport(QueryContext<?> cxt) {
+        super.prepareTransport(cxt);
+        return api;
+    }
 }

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/DocflowsAdaptor.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/DocflowsAdaptor.java
@@ -5,11 +5,6 @@
  */
 package ru.skbkontur.sdk.extern.service.transport.adaptors;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
 import ru.skbkontur.sdk.extern.model.Docflow;
 import ru.skbkontur.sdk.extern.model.DocflowPage;
 import ru.skbkontur.sdk.extern.model.Document;
@@ -18,540 +13,520 @@ import ru.skbkontur.sdk.extern.model.DocumentToSend;
 import ru.skbkontur.sdk.extern.model.Link;
 import ru.skbkontur.sdk.extern.model.Signature;
 import ru.skbkontur.sdk.extern.providers.ServiceError;
-import static ru.skbkontur.sdk.extern.service.transport.adaptors.QueryContext.CONTENT;
-import static ru.skbkontur.sdk.extern.service.transport.adaptors.QueryContext.CONTENT_STRING;
-import static ru.skbkontur.sdk.extern.service.transport.adaptors.QueryContext.DOCFLOW;
-import static ru.skbkontur.sdk.extern.service.transport.adaptors.QueryContext.DOCFLOW_PAGE;
-import static ru.skbkontur.sdk.extern.service.transport.adaptors.QueryContext.DOCUMENT;
-import static ru.skbkontur.sdk.extern.service.transport.adaptors.QueryContext.DOCUMENTS;
-import static ru.skbkontur.sdk.extern.service.transport.adaptors.QueryContext.DOCUMENT_DESCRIPTION;
-import static ru.skbkontur.sdk.extern.service.transport.adaptors.QueryContext.DOCUMENT_TO_SEND;
-import static ru.skbkontur.sdk.extern.service.transport.adaptors.QueryContext.SIGNATURE;
-import static ru.skbkontur.sdk.extern.service.transport.adaptors.QueryContext.SIGNATURES;
 import ru.skbkontur.sdk.extern.service.transport.adaptors.dto.DocflowDto;
+import ru.skbkontur.sdk.extern.service.transport.adaptors.dto.DocflowPageDto;
 import ru.skbkontur.sdk.extern.service.transport.adaptors.dto.DocumentDescriptionDto;
 import ru.skbkontur.sdk.extern.service.transport.adaptors.dto.DocumentDto;
 import ru.skbkontur.sdk.extern.service.transport.adaptors.dto.DocumentToSendDto;
 import ru.skbkontur.sdk.extern.service.transport.adaptors.dto.SignatureDto;
-import ru.skbkontur.sdk.extern.service.transport.swagger.api.DocflowsApi;
 import ru.skbkontur.sdk.extern.service.transport.invoker.ApiClient;
+import ru.skbkontur.sdk.extern.service.transport.swagger.api.DocflowsApi;
 import ru.skbkontur.sdk.extern.service.transport.swagger.invoker.ApiException;
-import static ru.skbkontur.sdk.extern.service.transport.adaptors.QueryContext.DOCUMENT_TO_SENDS;
-import ru.skbkontur.sdk.extern.service.transport.adaptors.dto.DocflowPageDto;
 import ru.skbkontur.sdk.extern.service.transport.swagger.model.GenerateReplyDocumentRequestData;
 import ru.skbkontur.sdk.extern.service.transport.swagger.model.PrintDocumentData;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static ru.skbkontur.sdk.extern.service.transport.adaptors.QueryContext.*;
+
+
 /**
- *
  * @author AlexS
  */
 public class DocflowsAdaptor extends BaseAdaptor {
 
-	private final DocflowsApi api;
+    private final DocflowsApi api;
 
-	public DocflowsAdaptor() {
-		this(new DocflowsApi());
-	}
+    public DocflowsAdaptor() {
+        this(new DocflowsApi());
+    }
 
-	public DocflowsAdaptor(DocflowsApi api) {
-		this.api = api;
-	}
+    public DocflowsAdaptor(DocflowsApi api) {
+        this.api = api;
+    }
 
-	@Override
-	public ApiClient getApiClient() {
-		return (ApiClient) api.getApiClient();
-	}
+    @Override
+    public ApiClient getApiClient() {
+        return (ApiClient) api.getApiClient();
+    }
 
-	@Override
-	public void setApiClient(ApiClient apiClient) {
-		api.setApiClient(apiClient);
-	}
+    @Override
+    public void setApiClient(ApiClient apiClient) {
+        api.setApiClient(apiClient);
+    }
 
-	/**
-	 * Get docflow page
-	 *
-	 * GET /v1/{accountId}/docflows
-	 *
-	 * @param cxt QueryContext&lt;Docflow&gt;
-	 *
-	 * @return QueryContext&lt;Docflow&gt;
-	 */
-	public QueryContext<DocflowPage> getDocflows(QueryContext<DocflowPage> cxt) {
-		if (cxt.isFail()) {
-			return cxt;
-		}
-		
-		try {
-			return cxt.setResult(
-				new DocflowPageDto().fromDto(
-					transport(cxt)
-						.docflowsGetDocflowsAsync(
-							cxt.getAccountProvider().accountId(),
-							cxt.getFinished(),
-							cxt.getIncoming(),
-							cxt.getSkip(),
-							cxt.getTake(),
-							cxt.getInnKpp(),
-							cxt.getUpdatedFrom(),
-							cxt.getUpdatedTo(),
-							cxt.getCreatedFrom(),
-							cxt.getCreatedTo(),
-							cxt.getType())
-						),
-				DOCFLOW_PAGE
-			);
-		}
-		catch (ApiException x) {
-			return cxt.setServiceError(new ServiceErrorImpl(ServiceError.ErrorCode.server, x.getMessage(), x.getCode(), x.getResponseHeaders(), x.getResponseBody()));
-		}
-	}
-	/**
-	 * Allow API user to get Docflow object
-	 *
-	 * GET /v1/{accountId}/docflows/{docflowId}
-	 *
-	 * @param cxt QueryContext&lt;Docflow&gt;
-	 * @return QueryContext&lt;Docflow&gt;
-	 */
-	public QueryContext<Docflow> lookupDocflow(QueryContext<Docflow> cxt) {
-		try {
-			if (cxt.isFail()) {
-				return cxt;
-			}
+    /**
+     * Get docflow page
+     * <p>
+     * GET /v1/{accountId}/docflows
+     *
+     * @param cxt QueryContext&lt;Docflow&gt;
+     * @return QueryContext&lt;Docflow&gt;
+     */
+    public QueryContext<DocflowPage> getDocflows(QueryContext<DocflowPage> cxt) {
+        if (cxt.isFail()) {
+            return cxt;
+        }
 
-			return cxt.setResult(
-				new DocflowDto().fromDto(
-					transport(cxt)
-						.docflowsGetDocflowAsync(
-							cxt.getAccountProvider().accountId(),
-							cxt.getDocflowId()
-						)
-				),
-				DOCFLOW
-			).setDocflowId(cxt.getDocflow().getId());
-		}
-		catch (ApiException x) {
-			return cxt.setServiceError(new ServiceErrorImpl(ServiceError.ErrorCode.server, x.getMessage(), x.getCode(), x.getResponseHeaders(), x.getResponseBody()));
-		}
-	}
+        try {
+            return cxt.setResult(
+                    new DocflowPageDto().fromDto(
+                            transport(cxt)
+                                    .docflowsGetDocflowsAsync(
+                                            cxt.getAccountProvider().accountId(),
+                                            cxt.getFinished(),
+                                            cxt.getIncoming(),
+                                            cxt.getSkip(),
+                                            cxt.getTake(),
+                                            cxt.getInnKpp(),
+                                            cxt.getUpdatedFrom(),
+                                            cxt.getUpdatedTo(),
+                                            cxt.getCreatedFrom(),
+                                            cxt.getCreatedTo(),
+                                            cxt.getType())
+                    ),
+                    DOCFLOW_PAGE
+            );
+        } catch (ApiException x) {
+            return cxt.setServiceError(new ServiceErrorImpl(ServiceError.ErrorCode.server, x.getMessage(), x.getCode(), x.getResponseHeaders(), x.getResponseBody()));
+        }
+    }
 
-	/**
-	 * Allow API user to get all document from docflow
-	 *
-	 * GET /v1/{accountId}/docflows/{docflowId}/documents
-	 *
-	 * @param cxt QueryContext&lt;List&lt;Document&gt;&gt; context
-	 * @return QueryContext&lt;List&lt;Document&gt;&gt; context
-	 */
-	public QueryContext<List<Document>> getDocuments(QueryContext<List<Document>> cxt) {
-		try {
-			if (cxt.isFail()) {
-				return cxt;
-			}
+    /**
+     * Allow API user to get Docflow object
+     * <p>
+     * GET /v1/{accountId}/docflows/{docflowId}
+     *
+     * @param cxt QueryContext&lt;Docflow&gt;
+     * @return QueryContext&lt;Docflow&gt;
+     */
+    public QueryContext<Docflow> lookupDocflow(QueryContext<Docflow> cxt) {
+        try {
+            if (cxt.isFail()) {
+                return cxt;
+            }
 
-			DocumentDto documentDto = new DocumentDto();
+            return cxt.setResult(
+                    new DocflowDto().fromDto(
+                            transport(cxt)
+                                    .docflowsGetDocflowAsync(
+                                            cxt.getAccountProvider().accountId(),
+                                            cxt.getDocflowId()
+                                    )
+                    ),
+                    DOCFLOW
+            ).setDocflowId(cxt.getDocflow().getId());
+        } catch (ApiException x) {
+            return cxt.setServiceError(new ServiceErrorImpl(ServiceError.ErrorCode.server, x.getMessage(), x.getCode(), x.getResponseHeaders(), x.getResponseBody()));
+        }
+    }
 
-			return cxt.setResult(
-				transport(cxt)
-					.docflowsGetDocumentsAsync(
-						cxt.getAccountProvider().accountId(),
-						cxt.getDocflowId()
-					)
-					.stream()
-					.map(documentDto::fromDto)
-					.collect(Collectors.toList()),
-				DOCUMENTS
-			);
-		}
-		catch (ApiException x) {
-			return cxt.setServiceError(new ServiceErrorImpl(ServiceError.ErrorCode.server, x.getMessage(), x.getCode(), x.getResponseHeaders(), x.getResponseBody()));
-		}
-	}
+    /**
+     * Allow API user to get all document from docflow
+     * <p>
+     * GET /v1/{accountId}/docflows/{docflowId}/documents
+     *
+     * @param cxt QueryContext&lt;List&lt;Document&gt;&gt; context
+     * @return QueryContext&lt;List&lt;Document&gt;&gt; context
+     */
+    public QueryContext<List<Document>> getDocuments(QueryContext<List<Document>> cxt) {
+        try {
+            if (cxt.isFail()) {
+                return cxt;
+            }
 
-	/**
-	 * Allow API user to get discrete document from docflow
-	 *
-	 * GET /v1/{accountId}/docflows/{docflowId}/documents/{documentId}
-	 *
-	 * @param cxt QueryContext&lt;List&lt;Document&gt;&gt; context
-	 * @return QueryContext&lt;List&lt;Document&gt;&gt; context
-	 */
-	public QueryContext<Document> lookupDocument(QueryContext<Document> cxt) {
-		try {
-			if (cxt.isFail()) {
-				return cxt;
-			}
+            DocumentDto documentDto = new DocumentDto();
 
-			return cxt.setResult(
-				new DocumentDto().fromDto(
-					transport(cxt)
-						.docflowsGetDocumentAsync(
-							cxt.getAccountProvider().accountId(),
-							cxt.getDocflowId(),
-							cxt.getDocumentId()
-						)
-				),
-				DOCUMENT
-			)
-				.setDocumentId(cxt.getDocument().getId());
-		}
-		catch (ApiException x) {
-			return cxt.setServiceError(new ServiceErrorImpl(ServiceError.ErrorCode.server, x.getMessage(), x.getCode(), x.getResponseHeaders(), x.getResponseBody()));
-		}
-	}
+            return cxt.setResult(
+                    transport(cxt)
+                            .docflowsGetDocumentsAsync(
+                                    cxt.getAccountProvider().accountId(),
+                                    cxt.getDocflowId()
+                            )
+                            .stream()
+                            .map(documentDto::fromDto)
+                            .collect(Collectors.toList()),
+                    DOCUMENTS
+            );
+        } catch (ApiException x) {
+            return cxt.setServiceError(new ServiceErrorImpl(ServiceError.ErrorCode.server, x.getMessage(), x.getCode(), x.getResponseHeaders(), x.getResponseBody()));
+        }
+    }
 
-	/**
-	 * Allow API user to get discrete document description from docflow
-	 *
-	 * GET /v1/{accountId}/docflows/{docflowId}/documents/{documentId}/description
-	 *
-	 * @param cxt QueryContext&lt;DocumentDescription&gt; context
-	 * @return QueryContext&lt;DocumentDescription&gt; context
-	 */
-	public QueryContext<DocumentDescription> lookupDescription(QueryContext<DocumentDescription> cxt) {
-		try {
-			if (cxt.isFail()) {
-				return cxt;
-			}
+    /**
+     * Allow API user to get discrete document from docflow
+     * <p>
+     * GET /v1/{accountId}/docflows/{docflowId}/documents/{documentId}
+     *
+     * @param cxt QueryContext&lt;List&lt;Document&gt;&gt; context
+     * @return QueryContext&lt;List&lt;Document&gt;&gt; context
+     */
+    public QueryContext<Document> lookupDocument(QueryContext<Document> cxt) {
+        try {
+            if (cxt.isFail()) {
+                return cxt;
+            }
 
-			return cxt.setResult(
-				new DocumentDescriptionDto().fromDto(
-					transport(cxt)
-						.docflowsGetDocumentDescriptionAsync(
-							cxt.getAccountProvider().accountId(),
-							cxt.getDocflowId(),
-							cxt.getDocumentId()
-						)
-				),
-				DOCUMENT_DESCRIPTION
-			);
-		}
-		catch (ApiException x) {
-			return cxt.setServiceError(new ServiceErrorImpl(ServiceError.ErrorCode.server, x.getMessage(), x.getCode(), x.getResponseHeaders(), x.getResponseBody()));
-		}
-	}
+            return cxt.setResult(
+                    new DocumentDto().fromDto(
+                            transport(cxt)
+                                    .docflowsGetDocumentAsync(
+                                            cxt.getAccountProvider().accountId(),
+                                            cxt.getDocflowId(),
+                                            cxt.getDocumentId()
+                                    )
+                    ),
+                    DOCUMENT
+            )
+                    .setDocumentId(cxt.getDocument().getId());
+        } catch (ApiException x) {
+            return cxt.setServiceError(new ServiceErrorImpl(ServiceError.ErrorCode.server, x.getMessage(), x.getCode(), x.getResponseHeaders(), x.getResponseBody()));
+        }
+    }
 
-	/**
-	 * Allow API user to get discrete encrypted document content from docflow
-	 *
-	 * GET /v1/{accountId}/docflows/{docflowId}/documents/{documentId}/content/encrypted
-	 *
-	 * @param cxt QueryContext&lt;byte[]&gt; context
-	 * @return QueryContext&lt;byte[]&gt; context
-	 */
-	public QueryContext<byte[]> getEncryptedContent(QueryContext<byte[]> cxt) {
-		try {
-			if (cxt.isFail()) {
-				return cxt;
-			}
+    /**
+     * Allow API user to get discrete document description from docflow
+     * <p>
+     * GET /v1/{accountId}/docflows/{docflowId}/documents/{documentId}/description
+     *
+     * @param cxt QueryContext&lt;DocumentDescription&gt; context
+     * @return QueryContext&lt;DocumentDescription&gt; context
+     */
+    public QueryContext<DocumentDescription> lookupDescription(QueryContext<DocumentDescription> cxt) {
+        try {
+            if (cxt.isFail()) {
+                return cxt;
+            }
 
-			return cxt.setResult(
-				transport(cxt)
-					.docflowsGetEncryptedDocumentContentAsync(
-						cxt.getAccountProvider().accountId(),
-						cxt.getDocflowId(),
-						cxt.getDocumentId()
-					),
-				CONTENT
-			);
-		}
-		catch (ApiException x) {
-			return cxt.setServiceError(new ServiceErrorImpl(ServiceError.ErrorCode.server, x.getMessage(), x.getCode(), x.getResponseHeaders(), x.getResponseBody()));
-		}
-	}
+            return cxt.setResult(
+                    new DocumentDescriptionDto().fromDto(
+                            transport(cxt)
+                                    .docflowsGetDocumentDescriptionAsync(
+                                            cxt.getAccountProvider().accountId(),
+                                            cxt.getDocflowId(),
+                                            cxt.getDocumentId()
+                                    )
+                    ),
+                    DOCUMENT_DESCRIPTION
+            );
+        } catch (ApiException x) {
+            return cxt.setServiceError(new ServiceErrorImpl(ServiceError.ErrorCode.server, x.getMessage(), x.getCode(), x.getResponseHeaders(), x.getResponseBody()));
+        }
+    }
 
-	/**
-	 * Allow API user to get discrete decrypted document content from docflow
-	 *
-	 * GET /v1/{accountId}/docflows/{docflowId}/documents/{documentId}/content/decrypted
-	 *
-	 * @param cxt QueryContext&lt;byte[]&gt; context
-	 * @return QueryContext&lt;byte[]&gt; context
-	 */
-	public QueryContext<byte[]> getDecryptedContent(QueryContext<byte[]> cxt) {
-		try {
-			if (cxt.isFail()) {
-				return cxt;
-			}
+    /**
+     * Allow API user to get discrete encrypted document content from docflow
+     * <p>
+     * GET /v1/{accountId}/docflows/{docflowId}/documents/{documentId}/content/encrypted
+     *
+     * @param cxt QueryContext&lt;byte[]&gt; context
+     * @return QueryContext&lt;byte[]&gt; context
+     */
+    public QueryContext<byte[]> getEncryptedContent(QueryContext<byte[]> cxt) {
+        try {
+            if (cxt.isFail()) {
+                return cxt;
+            }
 
-			return cxt.setResult(
-				transport(cxt)
-					.docflowsGetDecryptedDocumentContentAsync(
-						cxt.getAccountProvider().accountId(),
-						cxt.getDocflowId(),
-						cxt.getDocumentId()
-					),
-				CONTENT
-			);
-		}
-		catch (ApiException x) {
-			return cxt.setServiceError(new ServiceErrorImpl(ServiceError.ErrorCode.server, x.getMessage(), x.getCode(), x.getResponseHeaders(), x.getResponseBody()));
-		}
-	}
+            return cxt.setResult(
+                    transport(cxt)
+                            .docflowsGetEncryptedDocumentContentAsync(
+                                    cxt.getAccountProvider().accountId(),
+                                    cxt.getDocflowId(),
+                                    cxt.getDocumentId()
+                            ),
+                    CONTENT
+            );
+        } catch (ApiException x) {
+            return cxt.setServiceError(new ServiceErrorImpl(ServiceError.ErrorCode.server, x.getMessage(), x.getCode(), x.getResponseHeaders(), x.getResponseBody()));
+        }
+    }
 
-	/**
-	 * Allow API user to get discrete document signatures from docflow
-	 *
-	 * GET /v1/{accountId}/docflows/{docflowId}/documents/{documentId}/signatures
-	 *
-	 * @param cxt QueryContext&lt;List&lt;Signature&gt;&gt; context
-	 * @return QueryContext&lt;List&lt;Signature&gt;&gt; context
-	 */
-	public QueryContext<List<Signature>> getSignatures(QueryContext<List<Signature>> cxt) {
-		try {
-			if (cxt.isFail()) {
-				return cxt;
-			}
+    /**
+     * Allow API user to get discrete decrypted document content from docflow
+     * <p>
+     * GET /v1/{accountId}/docflows/{docflowId}/documents/{documentId}/content/decrypted
+     *
+     * @param cxt QueryContext&lt;byte[]&gt; context
+     * @return QueryContext&lt;byte[]&gt; context
+     */
+    public QueryContext<byte[]> getDecryptedContent(QueryContext<byte[]> cxt) {
+        try {
+            if (cxt.isFail()) {
+                return cxt;
+            }
 
-			SignatureDto signatureDto = new SignatureDto();
+            return cxt.setResult(
+                    transport(cxt)
+                            .docflowsGetDecryptedDocumentContentAsync(
+                                    cxt.getAccountProvider().accountId(),
+                                    cxt.getDocflowId(),
+                                    cxt.getDocumentId()
+                            ),
+                    CONTENT
+            );
+        } catch (ApiException x) {
+            return cxt.setServiceError(new ServiceErrorImpl(ServiceError.ErrorCode.server, x.getMessage(), x.getCode(), x.getResponseHeaders(), x.getResponseBody()));
+        }
+    }
 
-			return cxt.setResult(
-				transport(cxt)
-					.docflowsGetDocumentSignaturesAsync(
-						cxt.getAccountProvider().accountId(),
-						cxt.getDocflowId(),
-						cxt.getDocumentId()
-					)
-					.stream()
-					.map(signatureDto::fromDto)
-					.collect(Collectors.toList()),
-				SIGNATURES
-			);
-		}
-		catch (ApiException x) {
-			return cxt.setServiceError(new ServiceErrorImpl(ServiceError.ErrorCode.server, x.getMessage(), x.getCode(), x.getResponseHeaders(), x.getResponseBody()));
-		}
-	}
+    /**
+     * Allow API user to get discrete document signatures from docflow
+     * <p>
+     * GET /v1/{accountId}/docflows/{docflowId}/documents/{documentId}/signatures
+     *
+     * @param cxt QueryContext&lt;List&lt;Signature&gt;&gt; context
+     * @return QueryContext&lt;List&lt;Signature&gt;&gt; context
+     */
+    public QueryContext<List<Signature>> getSignatures(QueryContext<List<Signature>> cxt) {
+        try {
+            if (cxt.isFail()) {
+                return cxt;
+            }
 
-	/**
-	 * Allow API user to get discrete document single signature from docflow
-	 *
-	 * GET /v1/{accountId}/docflows/{docflowId}/documents/{documentId}/signatures/{signatureId}
-	 *
-	 * @param cxt QueryContext&lt;Signature&gt; context
-	 * @return QueryContext&lt;Signature&gt; context
-	 */
-	public QueryContext<Signature> getSignature(QueryContext<Signature> cxt) {
-		try {
-			if (cxt.isFail()) {
-				return cxt;
-			}
+            SignatureDto signatureDto = new SignatureDto();
 
-			return cxt.setResult(
-				new SignatureDto()
-					.fromDto(
-						transport(cxt)
-							.docflowsGetDocumentSignatureAsync(
-								cxt.getAccountProvider().accountId(),
-								cxt.getDocflowId(),
-								cxt.getDocumentId(),
-								cxt.getSignatureId()
-							)
-					),
-				SIGNATURE
-			);
-		}
-		catch (ApiException x) {
-			return cxt.setServiceError(new ServiceErrorImpl(ServiceError.ErrorCode.server, x.getMessage(), x.getCode(), x.getResponseHeaders(), x.getResponseBody()));
-		}
-	}
+            return cxt.setResult(
+                    transport(cxt)
+                            .docflowsGetDocumentSignaturesAsync(
+                                    cxt.getAccountProvider().accountId(),
+                                    cxt.getDocflowId(),
+                                    cxt.getDocumentId()
+                            )
+                            .stream()
+                            .map(signatureDto::fromDto)
+                            .collect(Collectors.toList()),
+                    SIGNATURES
+            );
+        } catch (ApiException x) {
+            return cxt.setServiceError(new ServiceErrorImpl(ServiceError.ErrorCode.server, x.getMessage(), x.getCode(), x.getResponseHeaders(), x.getResponseBody()));
+        }
+    }
 
-	/**
-	 * Allow API user to get discrete document signature single content from docflow
-	 *
-	 * GET /v1/{accountId}/docflows/{docflowId}/documents/{documentId}/signatures/{signatureId}/content
-	 *
-	 * @param cxt QueryContext&lt;byte[]gt; context
-	 * @return QueryContext&lt;byte[]&gt; context
-	 */
-	public QueryContext<byte[]> getSignatureContent(QueryContext<byte[]> cxt) {
-		try {
-			if (cxt.isFail()) {
-				return cxt;
-			}
+    /**
+     * Allow API user to get discrete document single signature from docflow
+     * <p>
+     * GET /v1/{accountId}/docflows/{docflowId}/documents/{documentId}/signatures/{signatureId}
+     *
+     * @param cxt QueryContext&lt;Signature&gt; context
+     * @return QueryContext&lt;Signature&gt; context
+     */
+    public QueryContext<Signature> getSignature(QueryContext<Signature> cxt) {
+        try {
+            if (cxt.isFail()) {
+                return cxt;
+            }
 
-			return cxt.setResult(
-				transport(cxt)
-					.docflowsGetDocumentSignatureContentAsync(
-						cxt.getAccountProvider().accountId(),
-						cxt.getDocflowId(),
-						cxt.getDocumentId(),
-						cxt.getSignatureId()
-					),
-				CONTENT
-			);
-		}
-		catch (ApiException x) {
-			return cxt.setServiceError(new ServiceErrorImpl(ServiceError.ErrorCode.server, x.getMessage(), x.getCode(), x.getResponseHeaders(), x.getResponseBody()));
-		}
-	}
+            return cxt.setResult(
+                    new SignatureDto()
+                            .fromDto(
+                                    transport(cxt)
+                                            .docflowsGetDocumentSignatureAsync(
+                                                    cxt.getAccountProvider().accountId(),
+                                                    cxt.getDocflowId(),
+                                                    cxt.getDocumentId(),
+                                                    cxt.getSignatureId()
+                                            )
+                            ),
+                    SIGNATURE
+            );
+        } catch (ApiException x) {
+            return cxt.setServiceError(new ServiceErrorImpl(ServiceError.ErrorCode.server, x.getMessage(), x.getCode(), x.getResponseHeaders(), x.getResponseBody()));
+        }
+    }
 
-	/**
-	 * Allow API user to create Reply document for specified workflow
-	 *
-	 * POST /v1/{accountId}/docflows/{docflowId}/documents/{documentId}/reply/{documentType}/generate
-	 *
-	 * @param cxt QueryContext&lt;DocumentToSend&gt; context
-	 * 
-	 * @return QueryContext&lt;DocumentToSend&gt; context
-	 */
-	public QueryContext<DocumentToSend> generateDocumentTypeReply(QueryContext<DocumentToSend> cxt) {
-		try {
-			if (cxt.isFail()) {
-				return cxt;
-			}
+    /**
+     * Allow API user to get discrete document signature single content from docflow
+     * <p>
+     * GET /v1/{accountId}/docflows/{docflowId}/documents/{documentId}/signatures/{signatureId}/content
+     *
+     * @param cxt QueryContext&lt;byte[]gt; context
+     * @return QueryContext&lt;byte[]&gt; context
+     */
+    public QueryContext<byte[]> getSignatureContent(QueryContext<byte[]> cxt) {
+        try {
+            if (cxt.isFail()) {
+                return cxt;
+            }
 
-			return cxt.setResult(
-				new DocumentToSendDto()
-					.fromDto(
-						transport(cxt)
-							.docflowsGenerateReplyDocumentAsync(
-								cxt.getAccountProvider().accountId(),
-								cxt.getDocflowId(),
-								cxt.getDocumentType(),
-								cxt.getDocumentId(),
-								new GenerateReplyDocumentRequestData().certificateBase64(cxt.getContentString())
-							)
-					),
-				DOCUMENT_TO_SEND
-			);
-		}
-		catch (ApiException x) {
-			return cxt.setServiceError(new ApiExceptionDto().fromDto(x));
-		}
-	}
+            return cxt.setResult(
+                    transport(cxt)
+                            .docflowsGetDocumentSignatureContentAsync(
+                                    cxt.getAccountProvider().accountId(),
+                                    cxt.getDocflowId(),
+                                    cxt.getDocumentId(),
+                                    cxt.getSignatureId()
+                            ),
+                    CONTENT
+            );
+        } catch (ApiException x) {
+            return cxt.setServiceError(new ServiceErrorImpl(ServiceError.ErrorCode.server, x.getMessage(), x.getCode(), x.getResponseHeaders(), x.getResponseBody()));
+        }
+    }
 
-	/**
-	 * Allow API user to send Reply document for specified workflow
-	 *
-	 * POST /v1/{accountId}/docflows/{docflowId}/documents/{documentId}/reply/{documentType}
-	 *
-	 * @param cxt QueryContext&lt;Signature&gt; context
-	 * @return QueryContext&lt;Signature&gt; context
-	 */
-	public QueryContext<Docflow> addDocumentTypeReply(QueryContext<Docflow> cxt) {
-		try {
-			if (cxt.isFail()) {
-				return cxt;
-			}
+    /**
+     * Allow API user to create Reply document for specified workflow
+     * <p>
+     * POST /v1/{accountId}/docflows/{docflowId}/documents/{documentId}/reply/{documentType}/generate
+     *
+     * @param cxt QueryContext&lt;DocumentToSend&gt; context
+     * @return QueryContext&lt;DocumentToSend&gt; context
+     */
+    public QueryContext<DocumentToSend> generateDocumentTypeReply(QueryContext<DocumentToSend> cxt) {
+        try {
+            if (cxt.isFail()) {
+                return cxt;
+            }
 
-			return cxt.setResult(
-				new DocflowDto()
-					.fromDto(
-						transport(cxt)
-							.docflowsSendReplyDocumentAsync(
-								cxt.getAccountProvider().accountId(),
-								cxt.getDocflowId(),
-								cxt.getDocumentType(),
-								cxt.getDocumentId(),
-								new DocumentToSendDto().toDto(cxt.getDocumentToSend())
-							)
-					),
-				DOCFLOW
-			).setDocflowId(cxt.getDocflow().getId());
-		}
-		catch (ApiException x) {
-			return cxt.setServiceError(new ServiceErrorImpl(ServiceError.ErrorCode.server, x.getMessage(), x.getCode(), x.getResponseHeaders(), x.getResponseBody()));
-		}
-	}
+            return cxt.setResult(
+                    new DocumentToSendDto()
+                            .fromDto(
+                                    transport(cxt)
+                                            .docflowsGenerateReplyDocumentAsync(
+                                                    cxt.getAccountProvider().accountId(),
+                                                    cxt.getDocflowId(),
+                                                    cxt.getDocumentType(),
+                                                    cxt.getDocumentId(),
+                                                    new GenerateReplyDocumentRequestData().certificateBase64(cxt.getContentString())
+                                            )
+                            ),
+                    DOCUMENT_TO_SEND
+            );
+        } catch (ApiException x) {
+            return cxt.setServiceError(new ApiExceptionDto().fromDto(x));
+        }
+    }
 
-	public QueryContext<List<DocumentToSend>> generateReplies(QueryContext<List<DocumentToSend>> cxt) {
-		try {
-			if (cxt.isFail()) {
-				return cxt;
-			}
+    /**
+     * Allow API user to send Reply document for specified workflow
+     * <p>
+     * POST /v1/{accountId}/docflows/{docflowId}/documents/{documentId}/reply/{documentType}
+     *
+     * @param cxt QueryContext&lt;Signature&gt; context
+     * @return QueryContext&lt;Signature&gt; context
+     */
+    public QueryContext<Docflow> addDocumentTypeReply(QueryContext<Docflow> cxt) {
+        try {
+            if (cxt.isFail()) {
+                return cxt;
+            }
 
-			Docflow docflow = cxt.getDocflow();
-			if (docflow.getLinks() != null && !docflow.getLinks().isEmpty()) {
-				String x509Base64 = cxt.getCertificate();
-				if (x509Base64 == null) {
-					return cxt.setServiceError("A signer certificate is absent in the context.");
-				}
-				prepareTransport(cxt);
-				List<DocumentToSend> replies = new ArrayList<>();
-				for (Link l : docflow.getLinks()) {
-					if (l.getRel().equals("reply")) {
-						DocumentToSend documentToSend 
-							= new DocumentToSendDto()
-								.fromDto(
-									(Map) submitHttpRequest(
-										l.getHref(),
-										"POST", 
-										new GenerateReplyDocumentRequestData().certificateBase64(x509Base64), 
-										Object.class
-									)
-								);
-						replies.add(documentToSend);
-					}
-				}
-				
-				return cxt.setResult(replies, DOCUMENT_TO_SENDS);
-			}
-			else {
-				return cxt.setResult(Collections.emptyList(), DOCUMENT_TO_SENDS);
-			}
-		}
-		catch (ru.skbkontur.sdk.extern.service.transport.invoker.ApiException x) {
-			return cxt.setServiceError(new ServiceErrorImpl(ServiceError.ErrorCode.server, x.getMessage(), x.getCode(), x.getResponseHeaders(), x.getResponseBody()));
-		}
-	}
+            return cxt.setResult(
+                    new DocflowDto()
+                            .fromDto(
+                                    transport(cxt)
+                                            .docflowsSendReplyDocumentAsync(
+                                                    cxt.getAccountProvider().accountId(),
+                                                    cxt.getDocflowId(),
+                                                    cxt.getDocumentType(),
+                                                    cxt.getDocumentId(),
+                                                    new DocumentToSendDto().toDto(cxt.getDocumentToSend())
+                                            )
+                            ),
+                    DOCFLOW
+            ).setDocflowId(cxt.getDocflow().getId());
+        } catch (ApiException x) {
+            return cxt.setServiceError(new ServiceErrorImpl(ServiceError.ErrorCode.server, x.getMessage(), x.getCode(), x.getResponseHeaders(), x.getResponseBody()));
+        }
+    }
 
-	public QueryContext<Docflow> sendReply(QueryContext<Docflow> cxt) {
-		try {
-			if (cxt.isFail()) {
-				return cxt;
-			}
+    public QueryContext<List<DocumentToSend>> generateReplies(QueryContext<List<DocumentToSend>> cxt) {
+        try {
+            if (cxt.isFail()) {
+                return cxt;
+            }
 
-			DocumentToSend documentToSend = cxt.getDocumentToSend();
-			if (documentToSend == null) {
-				return cxt.setServiceError(new ServiceErrorImpl(ServiceError.ErrorCode.business, "Reply is absent in the context.", 0, null, null));
-			}
+            Docflow docflow = cxt.getDocflow();
+            if (docflow.getLinks() != null && !docflow.getLinks().isEmpty()) {
+                String x509Base64 = cxt.getCertificate();
+                if (x509Base64 == null) {
+                    return cxt.setServiceError("A signer certificate is absent in the context.");
+                }
+                prepareTransport(cxt);
+                List<DocumentToSend> replies = new ArrayList<>();
+                for (Link l : docflow.getLinks()) {
+                    if (l.getRel().equals("reply")) {
+                        DocumentToSend documentToSend
+                                = new DocumentToSendDto()
+                                .fromDto(
+                                        (Map) submitHttpRequest(
+                                                l.getHref(),
+                                                "POST",
+                                                new GenerateReplyDocumentRequestData().certificateBase64(x509Base64),
+                                                Object.class
+                                        )
+                                );
+                        replies.add(documentToSend);
+                    }
+                }
 
-			Link self = documentToSend.getLinks().stream().filter(l -> l.getRel().equals("self")).findAny().orElse(null);
-			if (self == null) {
-				return cxt.setServiceError(new ServiceErrorImpl(ServiceError.ErrorCode.business, "The reply does not contain a self reference.", 0, null, null));
-			}
+                return cxt.setResult(replies, DOCUMENT_TO_SENDS);
+            } else {
+                return cxt.setResult(Collections.emptyList(), DOCUMENT_TO_SENDS);
+            }
+        } catch (ru.skbkontur.sdk.extern.service.transport.invoker.ApiException x) {
+            return cxt.setServiceError(new ServiceErrorImpl(ServiceError.ErrorCode.server, x.getMessage(), x.getCode(), x.getResponseHeaders(), x.getResponseBody()));
+        }
+    }
 
-			prepareTransport(cxt);
+    public QueryContext<Docflow> sendReply(QueryContext<Docflow> cxt) {
+        try {
+            if (cxt.isFail()) {
+                return cxt;
+            }
 
-			DocumentToSendDto documentToSendDto = new DocumentToSendDto();
-			DocflowDto docflowDto = new DocflowDto();
+            DocumentToSend documentToSend = cxt.getDocumentToSend();
+            if (documentToSend == null) {
+                return cxt.setServiceError(new ServiceErrorImpl(ServiceError.ErrorCode.business, "Reply is absent in the context.", 0, null, null));
+            }
 
-			String httpRequest = self.getHref().toLowerCase().replaceAll("/generate", "/send");
-			
-			Docflow docflow = docflowDto.fromDto(submitHttpRequest(httpRequest, "POST", documentToSendDto.toDto(documentToSend), ru.skbkontur.sdk.extern.service.transport.swagger.model.Docflow.class));
+            Link self = documentToSend.getLinks().stream().filter(l -> l.getRel().equals("self")).findAny().orElse(null);
+            if (self == null) {
+                return cxt.setServiceError(new ServiceErrorImpl(ServiceError.ErrorCode.business, "The reply does not contain a self reference.", 0, null, null));
+            }
 
-			return cxt.setResult(docflow, DOCFLOW);
-		}
-		catch (ru.skbkontur.sdk.extern.service.transport.invoker.ApiException x) {
-			return cxt.setServiceError(x);
-		}
-	}
+            prepareTransport(cxt);
 
-	public QueryContext<String> print(QueryContext<String> cxt) {
-		try {
-			if (cxt.isFail()) {
-				return cxt;
-			}
-			
-			return cxt.setResult(
-				transport(cxt)
-					.docflowsGetDocumentPrintAsyncWithHttpInfo(
-						cxt.getAccountProvider().accountId(),
-						cxt.getDocflowId(),
-						cxt.getDocumentId(),
-						new PrintDocumentData().content(cxt.getContentString())
-					).getData(),
-					CONTENT_STRING
-				);
-		}
-		catch (ApiException x) {
-			return cxt.setServiceError(new ApiExceptionDto().fromDto(x));
-		}
-	}
-	
-	private DocflowsApi transport(QueryContext<?> cxt) {
-		prepareTransport(cxt);
-		return api;
-	}
+            DocumentToSendDto documentToSendDto = new DocumentToSendDto();
+            DocflowDto docflowDto = new DocflowDto();
+
+            String httpRequest = self.getHref().toLowerCase().replaceAll("/generate", "/send");
+
+            Docflow docflow = docflowDto.fromDto(submitHttpRequest(httpRequest, "POST", documentToSendDto.toDto(documentToSend), ru.skbkontur.sdk.extern.service.transport.swagger.model.Docflow.class));
+
+            return cxt.setResult(docflow, DOCFLOW);
+        } catch (ru.skbkontur.sdk.extern.service.transport.invoker.ApiException x) {
+            return cxt.setServiceError(x);
+        }
+    }
+
+    public QueryContext<String> print(QueryContext<String> cxt) {
+        try {
+            if (cxt.isFail()) {
+                return cxt;
+            }
+
+            return cxt.setResult(
+                    transport(cxt)
+                            .docflowsGetDocumentPrintAsyncWithHttpInfo(
+                                    cxt.getAccountProvider().accountId(),
+                                    cxt.getDocflowId(),
+                                    cxt.getDocumentId(),
+                                    new PrintDocumentData().content(cxt.getContentString())
+                            ).getData(),
+                    CONTENT_STRING
+            );
+        } catch (ApiException x) {
+            return cxt.setServiceError(new ApiExceptionDto().fromDto(x));
+        }
+    }
+
+    private DocflowsApi transport(QueryContext<?> cxt) {
+        prepareTransport(cxt);
+        return api;
+    }
 }

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/DocflowsAdaptor.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/DocflowsAdaptor.java
@@ -1,8 +1,27 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * MIT License
+ *
+ * Copyright (c) 2018 SKB Kontur
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  */
+
 package ru.skbkontur.sdk.extern.service.transport.adaptors;
 
 import ru.skbkontur.sdk.extern.model.Docflow;

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/DraftsAdaptor.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/DraftsAdaptor.java
@@ -5,612 +5,577 @@
  */
 package ru.skbkontur.sdk.extern.service.transport.adaptors;
 
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
-import java.util.stream.Collectors;
 import ru.skbkontur.sdk.extern.model.Docflow;
 import ru.skbkontur.sdk.extern.model.DraftDocument;
-import static ru.skbkontur.sdk.extern.service.transport.adaptors.QueryContext.DRAFT;
-import static ru.skbkontur.sdk.extern.service.transport.adaptors.QueryContext.DRAFT_ID;
-import static ru.skbkontur.sdk.extern.service.transport.adaptors.QueryContext.DRAFT_META;
-import static ru.skbkontur.sdk.extern.service.transport.adaptors.QueryContext.MAP;
-import static ru.skbkontur.sdk.extern.service.transport.adaptors.QueryContext.NOTHING;
-import static ru.skbkontur.sdk.extern.service.transport.adaptors.QueryContext.PREPARE_RESULT;
 import ru.skbkontur.sdk.extern.service.transport.adaptors.dto.DocflowDto;
 import ru.skbkontur.sdk.extern.service.transport.adaptors.dto.DocumentContentsDto;
 import ru.skbkontur.sdk.extern.service.transport.adaptors.dto.DraftDocumentDto;
 import ru.skbkontur.sdk.extern.service.transport.adaptors.dto.DraftDto;
 import ru.skbkontur.sdk.extern.service.transport.adaptors.dto.DraftMetaDto;
 import ru.skbkontur.sdk.extern.service.transport.adaptors.dto.PrepareResultDto;
-import ru.skbkontur.sdk.extern.service.transport.swagger.api.DraftsApi;
-import ru.skbkontur.sdk.extern.service.transport.invoker.ApiClient;
-import ru.skbkontur.sdk.extern.service.transport.swagger.invoker.ApiException;
-import static ru.skbkontur.sdk.extern.service.transport.adaptors.QueryContext.CONTENT_STRING;
-import static ru.skbkontur.sdk.extern.service.transport.adaptors.QueryContext.DOCFLOWS;
-import static ru.skbkontur.sdk.extern.service.transport.adaptors.QueryContext.DRAFT_DOCUMENT;
 import ru.skbkontur.sdk.extern.service.transport.adaptors.dto.UsnServiceContractInfoDto;
 import ru.skbkontur.sdk.extern.service.transport.adaptors.dto.UsnServiceContractInfoV2Dto;
+import ru.skbkontur.sdk.extern.service.transport.invoker.ApiClient;
+import ru.skbkontur.sdk.extern.service.transport.swagger.api.DraftsApi;
+import ru.skbkontur.sdk.extern.service.transport.swagger.invoker.ApiException;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import static ru.skbkontur.sdk.extern.service.transport.adaptors.QueryContext.*;
+
 
 /**
- *
  * @author AlexS
  */
 public class DraftsAdaptor extends BaseAdaptor {
 
-	private final DraftsApi api;
+    private final DraftsApi api;
 
-	public DraftsAdaptor() {
-		this(new DraftsApi());
-	}
-	
-	public DraftsAdaptor(DraftsApi api) {
-		this.api = api;
-	}
+    public DraftsAdaptor() {
+        this(new DraftsApi());
+    }
 
-	@Override
-	public ApiClient getApiClient() {
-		return (ApiClient) api.getApiClient();
-	}
+    public DraftsAdaptor(DraftsApi api) {
+        this.api = api;
+    }
 
-	@Override
-	public void setApiClient(ApiClient apiClient) {
-		api.setApiClient(apiClient);
-	}
+    @Override
+    public ApiClient getApiClient() {
+        return (ApiClient) api.getApiClient();
+    }
 
-	/**
-	 * Create new a draft
-	 *
-	 * POST /v1/{billingAccountId}/drafts
-	 *
-	 * @param cxt a context
-	 * @return QueryContext &lt;UUID&gt;
-	 */
-	public QueryContext<UUID> createDraft(QueryContext<UUID> cxt) {
-		try {
-			if (cxt.isFail())	return cxt;
-			
-			UUID draftId =
-				transport(cxt)
-					.draftsCreate(
-						cxt.getAccountProvider().accountId(), 
-						new DraftMetaDto().toDto(cxt.getDraftMeta())
-					).getId();
-			
-			return cxt.setResult(draftId,DRAFT_ID);
-		}
-		catch (ApiException x) {
-			return cxt.setServiceError(new ApiExceptionDto().fromDto(x));
-		}
-	}
+    @Override
+    public void setApiClient(ApiClient apiClient) {
+        api.setApiClient(apiClient);
+    }
 
-	/**
-	 * lookup a draft by an identifier
-	 *
-	 * GET /v1/{accountId}/drafts/{draftId}
-	 *
-	 * @param cxt a context
-	 * @return Draft
-	 */
-	public QueryContext<ru.skbkontur.sdk.extern.model.Draft> lookup(QueryContext<ru.skbkontur.sdk.extern.model.Draft> cxt) {
-		try {
-			if (cxt.isFail())	return cxt;
-			
-			return cxt.setResult(
-				new DraftDto().fromDto(
-					transport(cxt)
-						.draftsGetDraft(
-							cxt.getAccountProvider().accountId(), 
-							cxt.getDraftId()
-						) 
-					),
-				DRAFT
-			);
-		}
-		catch (ApiException x) {
-			return cxt.setServiceError(new ApiExceptionDto().fromDto(x));
-		}
-	}
+    /**
+     * Create new a draft
+     * <p>
+     * POST /v1/{billingAccountId}/drafts
+     *
+     * @param cxt a context
+     * @return QueryContext &lt;UUID&gt;
+     */
+    public QueryContext<UUID> createDraft(QueryContext<UUID> cxt) {
+        try {
+            if (cxt.isFail()) return cxt;
 
-	/**
-	 * Delete a draft
-	 *
-	 * DELETE /v1/{accountId}/drafts/{draftId}
-	 *
-	 * @param cxt a context
-	 * @return QueryContext&lt;Void&gt;
-	 */
-	public QueryContext<Void> delete(QueryContext<Void> cxt) {
-		try {
-			if (cxt.isFail())	return cxt;
-			
-			transport(cxt).draftsDeleteDraft(cxt.getAccountProvider().accountId(), cxt.getDraftId());
-			
-			return cxt.setResult(null,NOTHING);
-		}
-		catch (ApiException x) {
-			return cxt.setServiceError(new ApiExceptionDto().fromDto(x));
-		}
-	}
+            UUID draftId =
+                    transport(cxt)
+                            .draftsCreate(
+                                    cxt.getAccountProvider().accountId(),
+                                    new DraftMetaDto().toDto(cxt.getDraftMeta())
+                            ).getId();
 
-	/**
-	 * lookup a draft meta by an identifier
-	 *
-	 * GET /v1/{accountId}/drafts/{draftId}/meta
-	 *
-	 * @param cxt a context
-	 * @return DraftMeta
-	 */
-	public QueryContext<ru.skbkontur.sdk.extern.model.DraftMeta> lookupDraftMeta(QueryContext<ru.skbkontur.sdk.extern.model.DraftMeta> cxt) {
-		try {
-			if (cxt.isFail())	return cxt;
-			
-			return cxt.setResult(
-				new DraftMetaDto().fromDto(
-					transport(cxt).draftsGetMeta(
-						cxt.getAccountProvider().accountId(), 
-						cxt.getDraftId()
-					)
-				),
-				DRAFT_META
-			);
-		}
-		catch (ApiException x) {
-			return cxt.setServiceError(new ApiExceptionDto().fromDto(x));
-		}
-	}
+            return cxt.setResult(draftId, DRAFT_ID);
+        } catch (ApiException x) {
+            return cxt.setServiceError(new ApiExceptionDto().fromDto(x));
+        }
+    }
 
-	/**
-	 * update a draft meta
-	 *
-	 * PUT /v1/{accountId}/drafts/{draftId}/meta
-	 *
-	 * @param cxt a context
-	 * @return DraftMeta
-	 */
-	public QueryContext<ru.skbkontur.sdk.extern.model.DraftMeta> updateDraftMeta(QueryContext<ru.skbkontur.sdk.extern.model.DraftMeta> cxt) {
-		try {
-			if (cxt.isFail())	return cxt;
-			
-			return cxt.setResult(
-				new DraftMetaDto().fromDto(
-					transport(cxt).draftsUpdateDraftMeta(
-						cxt.getAccountProvider().accountId(), 
-						cxt.getDraftId(),
-						new DraftMetaDto().toDto(cxt.getDraftMeta())
-					)
-				),
-				DRAFT_META
-			);
-		}
-		catch (ApiException x) {
-			return cxt.setServiceError(new ApiExceptionDto().fromDto(x));
-		}
-	}
+    /**
+     * lookup a draft by an identifier
+     * <p>
+     * GET /v1/{accountId}/drafts/{draftId}
+     *
+     * @param cxt a context
+     * @return Draft
+     */
+    public QueryContext<ru.skbkontur.sdk.extern.model.Draft> lookup(QueryContext<ru.skbkontur.sdk.extern.model.Draft> cxt) {
+        try {
+            if (cxt.isFail()) return cxt;
 
-	/**
-	 * Operate CHECK
-	 *
-	 * POST /v1/{accountId}/drafts/{draftId}/check
-	 *
-	 * @param cxt a context
-	 * @return Map&lt;String,Object&gt;
-	 */
-	public QueryContext<Map<String, Object>> check(QueryContext<Map<String, Object>> cxt) {
-		try {
-			if (cxt.isFail())	return cxt;
-			
-			return cxt.setResult(
-				(Map)transport(cxt).draftsCheck(
-					cxt.getAccountProvider().accountId(), 
-					cxt.getDraftId()
-				),
-				MAP
-			);
-		}
-		catch (ApiException x) {
-			return cxt.setServiceError(new ApiExceptionDto().fromDto(x));
-		}
-	}
+            return cxt.setResult(
+                    new DraftDto().fromDto(
+                            transport(cxt)
+                                    .draftsGetDraft(
+                                            cxt.getAccountProvider().accountId(),
+                                            cxt.getDraftId()
+                                    )
+                    ),
+                    DRAFT
+            );
+        } catch (ApiException x) {
+            return cxt.setServiceError(new ApiExceptionDto().fromDto(x));
+        }
+    }
 
-	/**
-	 * Operate PREPARE
-	 *
-	 * POST /v1/{accountId}/drafts/{draftId}/prepare
-	 *
-	 * @param cxt a context
-	 * 
-	 * @return PrepareResult;
-	 */
-	public QueryContext<ru.skbkontur.sdk.extern.model.PrepareResult> prepare(QueryContext<ru.skbkontur.sdk.extern.model.PrepareResult> cxt) {
-		try {
-			if (cxt.isFail())	return cxt;
-			
-			return cxt.setResult(
-				new PrepareResultDto().fromDto(
-					transport(cxt).draftsPrepare(
-						cxt.getAccountProvider().accountId(), 
-						cxt.getDraftId()
-					)
-				),
-				PREPARE_RESULT
-			);
-			
-		}
-		catch (ApiException x) {
-			return cxt.setServiceError(new ApiExceptionDto().fromDto(x));
-		}
-	}
+    /**
+     * Delete a draft
+     * <p>
+     * DELETE /v1/{accountId}/drafts/{draftId}
+     *
+     * @param cxt a context
+     * @return QueryContext&lt;Void&gt;
+     */
+    public QueryContext<Void> delete(QueryContext<Void> cxt) {
+        try {
+            if (cxt.isFail()) return cxt;
 
-	/**
-	 * Send the draft
-	 *
-	 * POST /v1/{accountId}/drafts/drafts/{draftId}/send
-	 *
-	 * @param cxt a context
-	 * 
-	 * @return List&lt;Docflow&gt;
-	 */
-	public QueryContext<List<Docflow>> send(QueryContext<List<Docflow>> cxt) {
-		try {
-			if (cxt.isFail())	return cxt;
-			
-			DocflowDto docflowDto = new DocflowDto();
-			
-			return cxt.setResult(
-				transport(cxt).draftsSend(
-					cxt.getAccountProvider().accountId(), 
-					cxt.getDraftId(), 
-					cxt.getDeffered(), 
-					cxt.getForce()
-				)
-				.stream()
-					.map(docflowDto::fromDto)
-					.collect(Collectors.toList())
-				,DOCFLOWS
-			);
-		}
-		catch (ApiException x) {
-			return cxt.setServiceError(new ApiExceptionDto().fromDto(x));
-		}
-	}
+            transport(cxt).draftsDeleteDraft(cxt.getAccountProvider().accountId(), cxt.getDraftId());
 
-	/**
-	 * DELETE /v1/{accountId}/drafts/{draftId}/documents/{documentId}
-	 *
-	 * Delete a document from the draft
-	 *
-	 * @param cxt a context (draftId, documentId)
-	 * @return QueryContext&lt;Void&gt;
-	 */
-	public QueryContext<Void> deleteDocument(QueryContext<Void> cxt) {
-		try {
-			if (cxt.isFail())	return cxt;
-			
-			transport(cxt).draftDocumentsDeleteDocument(cxt.getAccountProvider().accountId(), cxt.getDraftId(), cxt.getDocumentId());
-			
-			return cxt.setResult(null, NOTHING);
-		}
-		catch (ApiException x) {
-			return cxt.setServiceError(new ApiExceptionDto().fromDto(x));
-		}
-	}
+            return cxt.setResult(null, NOTHING);
+        } catch (ApiException x) {
+            return cxt.setServiceError(new ApiExceptionDto().fromDto(x));
+        }
+    }
 
-	/**
-	 * GET /v1/{accountId}/drafts/{draftId}/documents/{documentId}
-	 *
-	 * lookup a document from the draft
-	 *
-	 * @param cxt a context (draftId,documentId)
-	 * 
-	 * @return DraftDocument
-	 */
-	public QueryContext<DraftDocument> lookupDocument(QueryContext<DraftDocument> cxt) {
-		try {
-			if (cxt.isFail())	return cxt;
-			
-			return cxt.setResult(new DraftDocumentDto().fromDto(
-					transport(cxt).draftDocumentsGetDocumentAsync(
-						cxt.getAccountProvider().accountId(), 
-						cxt.getDraftId(), 
-						cxt.getDocumentId()
-					)
-				),
-				DRAFT_DOCUMENT
-			).setDocumentId(cxt.getDraftDocument().getId());
-		}
-		catch (ApiException x) {
-			return cxt.setServiceError(new ApiExceptionDto().fromDto(x));
-		}
-	}
+    /**
+     * lookup a draft meta by an identifier
+     * <p>
+     * GET /v1/{accountId}/drafts/{draftId}/meta
+     *
+     * @param cxt a context
+     * @return DraftMeta
+     */
+    public QueryContext<ru.skbkontur.sdk.extern.model.DraftMeta> lookupDraftMeta(QueryContext<ru.skbkontur.sdk.extern.model.DraftMeta> cxt) {
+        try {
+            if (cxt.isFail()) return cxt;
 
-	/**
-	 * PUT /v1/{billingAccountId}/drafts/{draftId}/documents/{documentId}
-	 *
-	 * Update a draft document Update the document
-	 *
-	 * @param cxt a context (required: draftId,documentId,DocumentContents)
-	 * 
-	 * @return DraftDocument
-	 */
-	public QueryContext<DraftDocument> updateDocument(QueryContext<DraftDocument> cxt) {
-		try {
-			if (cxt.isFail())	return cxt;
-			
-			DocumentContentsDto documentContentsDto = new DocumentContentsDto();
-			
-			return cxt.setResult(new DraftDocumentDto()
-					.fromDto(transport(cxt)
-						.draftDocumentsPutDocument(
-							cxt.getAccountProvider().accountId(), 
-							cxt.getDraftId(),
-							cxt.getDocumentId(), 
-							documentContentsDto.toDto(cxt.getDocumentContents())
-						)
-					),
-				DRAFT_DOCUMENT
-			).setDocumentId(cxt.getDraftDocument().getId());
-		}
-		catch (ApiException x) {
-			return cxt.setServiceError(new ApiExceptionDto().fromDto(x));
-		}
-	}
+            return cxt.setResult(
+                    new DraftMetaDto().fromDto(
+                            transport(cxt).draftsGetMeta(
+                                    cxt.getAccountProvider().accountId(),
+                                    cxt.getDraftId()
+                            )
+                    ),
+                    DRAFT_META
+            );
+        } catch (ApiException x) {
+            return cxt.setServiceError(new ApiExceptionDto().fromDto(x));
+        }
+    }
 
-	/**
-	 * GET /v1/{accountId}/drafts/{draftId}/documents/{documentId}/print
-	 *
-	 * print a document from the draft
-	 *
-	 * @param cxt a context (draftId,documentId)
-	 * 
-	 * @return DraftDocument
-	 */
-	public QueryContext<String> printDocument(QueryContext<String> cxt) {
-		try {
-			if (cxt.isFail())	return cxt;
-			
-			return cxt.setResult(
-				transport(cxt)
-					.draftDocumentsGetDocumentPrintAsyncWithHttpInfo(
-						cxt.getAccountProvider().accountId(), 
-						cxt.getDraftId(), 
-						cxt.getDocumentId()
-					).getData(),
-				CONTENT_STRING
-			);
-		}
-		catch (ApiException x) {
-			return cxt.setServiceError(new ApiExceptionDto().fromDto(x));
-		}
-	}
+    /**
+     * update a draft meta
+     * <p>
+     * PUT /v1/{accountId}/drafts/{draftId}/meta
+     *
+     * @param cxt a context
+     * @return DraftMeta
+     */
+    public QueryContext<ru.skbkontur.sdk.extern.model.DraftMeta> updateDraftMeta(QueryContext<ru.skbkontur.sdk.extern.model.DraftMeta> cxt) {
+        try {
+            if (cxt.isFail()) return cxt;
 
-	/**
-	 * POST /v1/{accountId}/drafts/{draftId}/documents
-	 *
-	 * Add a new document to the draft
-	 *
-	 * @param cxt a context (draftId,documentContent,fileName)
-	 * 
-	 * @return DraftDocument
-	 */
-	public QueryContext<DraftDocument> addDecryptedDocument(QueryContext<DraftDocument> cxt) {
-		try {
-			if (cxt.isFail())	return cxt;
-			
-			DocumentContentsDto documentContentsDto = new DocumentContentsDto();
-			
-			return cxt
-				.setResult(
-					new DraftDocumentDto()
-						.fromDto(
-							transport(cxt)
-								.draftDocumentsAddDocument(
-									cxt.getAccountProvider().accountId(), 
-									cxt.getDraftId(),
-									documentContentsDto.toDto(cxt.getDocumentContents())
-								)
-						),
-					DRAFT_DOCUMENT
-				)
-				.setDocumentId(cxt.getDraftDocument().getId());
-		}
-		catch (ApiException x) {
-			return cxt.setServiceError(new ApiExceptionDto().fromDto(x));
-		}
-	}
+            return cxt.setResult(
+                    new DraftMetaDto().fromDto(
+                            transport(cxt).draftsUpdateDraftMeta(
+                                    cxt.getAccountProvider().accountId(),
+                                    cxt.getDraftId(),
+                                    new DraftMetaDto().toDto(cxt.getDraftMeta())
+                            )
+                    ),
+                    DRAFT_META
+            );
+        } catch (ApiException x) {
+            return cxt.setServiceError(new ApiExceptionDto().fromDto(x));
+        }
+    }
 
-	/**
-	 * GET /v1/{accountId}/drafts/{draftId}/documents/{documentId}/content/decrypted
-	 *
-	 * Get a decrypted document content
-	 *
-	 * @param cxt a context (required: draftId,documentId)
-	 * 
-	 * @return String
-	 */
-	public QueryContext<String> getDecryptedDocumentContent(QueryContext<String> cxt) {
-		try {
-			if (cxt.isFail())	return cxt;
-			
-			return cxt.setResult(transport(cxt)
-					.draftDocumentsGetDocumentContent(
-						cxt.getAccountProvider().accountId(), 
-						cxt.getDraftId(),
-						cxt.getDocumentId()
-					),
-				CONTENT_STRING
-			);
-		}
-		catch (ApiException x) {
-			return cxt.setServiceError(new ApiExceptionDto().fromDto(x));
-		}
-	}
+    /**
+     * Operate CHECK
+     * <p>
+     * POST /v1/{accountId}/drafts/{draftId}/check
+     *
+     * @param cxt a context
+     * @return Map&lt;String,Object&gt;
+     */
+    public QueryContext<Map<String, Object>> check(QueryContext<Map<String, Object>> cxt) {
+        try {
+            if (cxt.isFail()) return cxt;
 
-	/**
-	 * PUT /v1/{accountId}/drafts/{draftId}/documents/{documentId}/content/decrypted
-	 *
-	 * Get a decrypted document content
-	 *
-	 * @param cxt a context (required: draftId,documentId)
-	 * @return QueryContext&lt;Void&gt;
-	 */
-	public QueryContext<Void> updateDecryptedDocumentContent(QueryContext<Void> cxt) {
-		try {
-			if (cxt.isFail())	return cxt;
-			
-			transport(cxt)
-				.draftDocumentsPutDocumentContent(
-					cxt.getAccountProvider().accountId(), 
-					cxt.getDraftId(),
-					cxt.getDocumentId(),
-					cxt.getContent()
-				);
-			
-			return cxt.setResult(null, NOTHING);
-		}
-		catch (ApiException x) {
-			return cxt.setServiceError(new ApiExceptionDto().fromDto(x));
-		}
-	}
+            return cxt.setResult(
+                    (Map) transport(cxt).draftsCheck(
+                            cxt.getAccountProvider().accountId(),
+                            cxt.getDraftId()
+                    ),
+                    MAP
+            );
+        } catch (ApiException x) {
+            return cxt.setServiceError(new ApiExceptionDto().fromDto(x));
+        }
+    }
 
-	/**
-	 * GET /v1/{accountId}/drafts/{draftId}/documents/{documentId}/content/encrypted
-	 *
-	 * Get a ecrypted document content
-	 *
-	 * @param cxt a context (required: draftId,documentId)
-	 * @return String
-	 */
-	public QueryContext<String> getEncryptedDocumentContent(QueryContext<String> cxt) {
-		try {
-			if (cxt.isFail())	return cxt;
-			
-			return cxt.setResult(transport(cxt)
-					.draftDocumentsGetDocumentContent(
-						cxt.getAccountProvider().accountId(), 
-						cxt.getDraftId(),
-						cxt.getDocumentId()
-					),
-				CONTENT_STRING
-			);
-		}
-		catch (ApiException x) {
-			return cxt.setServiceError(new ApiExceptionDto().fromDto(x));
-		}
-	}
+    /**
+     * Operate PREPARE
+     * <p>
+     * POST /v1/{accountId}/drafts/{draftId}/prepare
+     *
+     * @param cxt a context
+     * @return PrepareResult;
+     */
+    public QueryContext<ru.skbkontur.sdk.extern.model.PrepareResult> prepare(QueryContext<ru.skbkontur.sdk.extern.model.PrepareResult> cxt) {
+        try {
+            if (cxt.isFail()) return cxt;
 
-	/**
-	 * GET /v1/{accountId}/drafts/{draftId}/documents/{documentId}/signature
-	 *
-	 * Get a document signature
-	 *
-	 * @param cxt a context (required: draftId,documentId)
-	 * @return String
-	 */
-	public QueryContext<String> getSignatureContent(QueryContext<String> cxt) {
-		try {
-			if (cxt.isFail())	return cxt;
-			
-			return cxt.setResult(
-				transport(cxt)
-					.draftDocumentsGetSignatureContent(
-						cxt.getAccountProvider().accountId(), 
-						cxt.getDraftId(),
-						cxt.getDocumentId()
-					),
-				CONTENT_STRING
-			);
-		}
-		catch (ApiException x) {
-			return cxt.setServiceError(new ApiExceptionDto().fromDto(x));
-		}
-	}
+            return cxt.setResult(
+                    new PrepareResultDto().fromDto(
+                            transport(cxt).draftsPrepare(
+                                    cxt.getAccountProvider().accountId(),
+                                    cxt.getDraftId()
+                            )
+                    ),
+                    PREPARE_RESULT
+            );
 
-	/**
-	 * PUT /v1/{accountId}/drafts/{draftId}/documents/{documentId}/signature
-	 *
-	 * Update a document signature
-	 *
-	 * @param cxt a context (required: draftId,documentId)
-	 * @return QueryContext&lt;Void&gt;
-	 */
-	public QueryContext<Void> updateSignature(QueryContext<Void> cxt) {
-		try {
-			if (cxt.isFail())	return cxt;
-			
-			transport(cxt)
-				.draftDocumentsPutDocumentSignature(
-					cxt.getAccountProvider().accountId(), 
-					cxt.getDraftId(),
-					cxt.getDocumentId(),
-					cxt.getContent()
-				);
-			
-			return cxt.setResult(null, NOTHING);
-		}
-		catch (ApiException x) {
-			return cxt.setServiceError(new ApiExceptionDto().fromDto(x));
-		}
-	}
-	
-	/**
-	 * POST /v1/{accountId}/drafts/{draftId}/documents/{documentId}/content/format/USN/1
-	 *
-	 * Create an USN declaration, version 1
-	 *
-	 * @param cxt a context (required: draftId,documentId)
-	 * 
-	 * @return QueryContext&lt;Void&gt;
-	 */
-	public QueryContext<Void> createUSN1(QueryContext<Void> cxt) {
-		try {
-			if (cxt.isFail())	return cxt;
-			
-			transport(cxt)
-				.draftDocumentsBuildContentFromFormatWithHttpInfo(
-					cxt.getAccountProvider().accountId(), 
-					cxt.getDraftId(),
-					cxt.getDocumentId(),
-					new UsnServiceContractInfoDto().toDto(cxt.getUsnServiceContractInfo())
-				);
-			
-			return cxt.setResult(null, NOTHING);
-		}
-		catch (ApiException x) {
-			return cxt.setServiceError(new ApiExceptionDto().fromDto(x));
-		}
-	}
-	
-	/**
-	 * POST /v1/{accountId}/drafts/{draftId}/documents/{documentId}/content/format/USN/2
-	 *
-	 * Create an USN declaration, version 2
-	 *
-	 * @param cxt a context (required: draftId,documentId)
-	 * 
-	 * @return QueryContext&lt;Void&gt;
-	 */
-	public QueryContext<Void> createUSN2(QueryContext<Void> cxt) {
-		try {
-			if (cxt.isFail())	return cxt;
-			
-			transport(cxt)
-				.draftDocumentsBuildContentFromFormat_0WithHttpInfo(
-					cxt.getAccountProvider().accountId(), 
-					cxt.getDraftId(),
-					cxt.getDocumentId(),
-					new UsnServiceContractInfoV2Dto().toDto(cxt.getUsnServiceContractInfoV2())
-				);
-			
-			return cxt.setResult(null, NOTHING);
-		}
-		catch (ApiException x) {
-			return cxt.setServiceError(new ApiExceptionDto().fromDto(x));
-		}
-	}
-	
-	private DraftsApi transport(QueryContext<?> cxt) {
-		super.prepareTransport(cxt);
-		return api;
-	}
+        } catch (ApiException x) {
+            return cxt.setServiceError(new ApiExceptionDto().fromDto(x));
+        }
+    }
+
+    /**
+     * Send the draft
+     * <p>
+     * POST /v1/{accountId}/drafts/drafts/{draftId}/send
+     *
+     * @param cxt a context
+     * @return List&lt;Docflow&gt;
+     */
+    public QueryContext<List<Docflow>> send(QueryContext<List<Docflow>> cxt) {
+        try {
+            if (cxt.isFail()) return cxt;
+
+            DocflowDto docflowDto = new DocflowDto();
+
+            return cxt.setResult(
+                    transport(cxt).draftsSend(
+                            cxt.getAccountProvider().accountId(),
+                            cxt.getDraftId(),
+                            cxt.getDeffered(),
+                            cxt.getForce()
+                    )
+                            .stream()
+                            .map(docflowDto::fromDto)
+                            .collect(Collectors.toList())
+                    , DOCFLOWS
+            );
+        } catch (ApiException x) {
+            return cxt.setServiceError(new ApiExceptionDto().fromDto(x));
+        }
+    }
+
+    /**
+     * DELETE /v1/{accountId}/drafts/{draftId}/documents/{documentId}
+     * <p>
+     * Delete a document from the draft
+     *
+     * @param cxt a context (draftId, documentId)
+     * @return QueryContext&lt;Void&gt;
+     */
+    public QueryContext<Void> deleteDocument(QueryContext<Void> cxt) {
+        try {
+            if (cxt.isFail()) return cxt;
+
+            transport(cxt).draftDocumentsDeleteDocument(cxt.getAccountProvider().accountId(), cxt.getDraftId(), cxt.getDocumentId());
+
+            return cxt.setResult(null, NOTHING);
+        } catch (ApiException x) {
+            return cxt.setServiceError(new ApiExceptionDto().fromDto(x));
+        }
+    }
+
+    /**
+     * GET /v1/{accountId}/drafts/{draftId}/documents/{documentId}
+     * <p>
+     * lookup a document from the draft
+     *
+     * @param cxt a context (draftId,documentId)
+     * @return DraftDocument
+     */
+    public QueryContext<DraftDocument> lookupDocument(QueryContext<DraftDocument> cxt) {
+        try {
+            if (cxt.isFail()) return cxt;
+
+            return cxt.setResult(new DraftDocumentDto().fromDto(
+                    transport(cxt).draftDocumentsGetDocumentAsync(
+                            cxt.getAccountProvider().accountId(),
+                            cxt.getDraftId(),
+                            cxt.getDocumentId()
+                    )
+                    ),
+                    DRAFT_DOCUMENT
+            ).setDocumentId(cxt.getDraftDocument().getId());
+        } catch (ApiException x) {
+            return cxt.setServiceError(new ApiExceptionDto().fromDto(x));
+        }
+    }
+
+    /**
+     * PUT /v1/{billingAccountId}/drafts/{draftId}/documents/{documentId}
+     * <p>
+     * Update a draft document Update the document
+     *
+     * @param cxt a context (required: draftId,documentId,DocumentContents)
+     * @return DraftDocument
+     */
+    public QueryContext<DraftDocument> updateDocument(QueryContext<DraftDocument> cxt) {
+        try {
+            if (cxt.isFail()) return cxt;
+
+            DocumentContentsDto documentContentsDto = new DocumentContentsDto();
+
+            return cxt.setResult(new DraftDocumentDto()
+                            .fromDto(transport(cxt)
+                                    .draftDocumentsPutDocument(
+                                            cxt.getAccountProvider().accountId(),
+                                            cxt.getDraftId(),
+                                            cxt.getDocumentId(),
+                                            documentContentsDto.toDto(cxt.getDocumentContents())
+                                    )
+                            ),
+                    DRAFT_DOCUMENT
+            ).setDocumentId(cxt.getDraftDocument().getId());
+        } catch (ApiException x) {
+            return cxt.setServiceError(new ApiExceptionDto().fromDto(x));
+        }
+    }
+
+    /**
+     * GET /v1/{accountId}/drafts/{draftId}/documents/{documentId}/print
+     * <p>
+     * print a document from the draft
+     *
+     * @param cxt a context (draftId,documentId)
+     * @return DraftDocument
+     */
+    public QueryContext<String> printDocument(QueryContext<String> cxt) {
+        try {
+            if (cxt.isFail()) return cxt;
+
+            return cxt.setResult(
+                    transport(cxt)
+                            .draftDocumentsGetDocumentPrintAsyncWithHttpInfo(
+                                    cxt.getAccountProvider().accountId(),
+                                    cxt.getDraftId(),
+                                    cxt.getDocumentId()
+                            ).getData(),
+                    CONTENT_STRING
+            );
+        } catch (ApiException x) {
+            return cxt.setServiceError(new ApiExceptionDto().fromDto(x));
+        }
+    }
+
+    /**
+     * POST /v1/{accountId}/drafts/{draftId}/documents
+     * <p>
+     * Add a new document to the draft
+     *
+     * @param cxt a context (draftId,documentContent,fileName)
+     * @return DraftDocument
+     */
+    public QueryContext<DraftDocument> addDecryptedDocument(QueryContext<DraftDocument> cxt) {
+        try {
+            if (cxt.isFail()) return cxt;
+
+            DocumentContentsDto documentContentsDto = new DocumentContentsDto();
+
+            return cxt
+                    .setResult(
+                            new DraftDocumentDto()
+                                    .fromDto(
+                                            transport(cxt)
+                                                    .draftDocumentsAddDocument(
+                                                            cxt.getAccountProvider().accountId(),
+                                                            cxt.getDraftId(),
+                                                            documentContentsDto.toDto(cxt.getDocumentContents())
+                                                    )
+                                    ),
+                            DRAFT_DOCUMENT
+                    )
+                    .setDocumentId(cxt.getDraftDocument().getId());
+        } catch (ApiException x) {
+            return cxt.setServiceError(new ApiExceptionDto().fromDto(x));
+        }
+    }
+
+    /**
+     * GET /v1/{accountId}/drafts/{draftId}/documents/{documentId}/content/decrypted
+     * <p>
+     * Get a decrypted document content
+     *
+     * @param cxt a context (required: draftId,documentId)
+     * @return String
+     */
+    public QueryContext<String> getDecryptedDocumentContent(QueryContext<String> cxt) {
+        try {
+            if (cxt.isFail()) return cxt;
+
+            return cxt.setResult(transport(cxt)
+                            .draftDocumentsGetDocumentContent(
+                                    cxt.getAccountProvider().accountId(),
+                                    cxt.getDraftId(),
+                                    cxt.getDocumentId()
+                            ),
+                    CONTENT_STRING
+            );
+        } catch (ApiException x) {
+            return cxt.setServiceError(new ApiExceptionDto().fromDto(x));
+        }
+    }
+
+    /**
+     * PUT /v1/{accountId}/drafts/{draftId}/documents/{documentId}/content/decrypted
+     * <p>
+     * Get a decrypted document content
+     *
+     * @param cxt a context (required: draftId,documentId)
+     * @return QueryContext&lt;Void&gt;
+     */
+    public QueryContext<Void> updateDecryptedDocumentContent(QueryContext<Void> cxt) {
+        try {
+            if (cxt.isFail()) return cxt;
+
+            transport(cxt)
+                    .draftDocumentsPutDocumentContent(
+                            cxt.getAccountProvider().accountId(),
+                            cxt.getDraftId(),
+                            cxt.getDocumentId(),
+                            cxt.getContent()
+                    );
+
+            return cxt.setResult(null, NOTHING);
+        } catch (ApiException x) {
+            return cxt.setServiceError(new ApiExceptionDto().fromDto(x));
+        }
+    }
+
+    /**
+     * GET /v1/{accountId}/drafts/{draftId}/documents/{documentId}/content/encrypted
+     * <p>
+     * Get a ecrypted document content
+     *
+     * @param cxt a context (required: draftId,documentId)
+     * @return String
+     */
+    public QueryContext<String> getEncryptedDocumentContent(QueryContext<String> cxt) {
+        try {
+            if (cxt.isFail()) return cxt;
+
+            return cxt.setResult(transport(cxt)
+                            .draftDocumentsGetDocumentContent(
+                                    cxt.getAccountProvider().accountId(),
+                                    cxt.getDraftId(),
+                                    cxt.getDocumentId()
+                            ),
+                    CONTENT_STRING
+            );
+        } catch (ApiException x) {
+            return cxt.setServiceError(new ApiExceptionDto().fromDto(x));
+        }
+    }
+
+    /**
+     * GET /v1/{accountId}/drafts/{draftId}/documents/{documentId}/signature
+     * <p>
+     * Get a document signature
+     *
+     * @param cxt a context (required: draftId,documentId)
+     * @return String
+     */
+    public QueryContext<String> getSignatureContent(QueryContext<String> cxt) {
+        try {
+            if (cxt.isFail()) return cxt;
+
+            return cxt.setResult(
+                    transport(cxt)
+                            .draftDocumentsGetSignatureContent(
+                                    cxt.getAccountProvider().accountId(),
+                                    cxt.getDraftId(),
+                                    cxt.getDocumentId()
+                            ),
+                    CONTENT_STRING
+            );
+        } catch (ApiException x) {
+            return cxt.setServiceError(new ApiExceptionDto().fromDto(x));
+        }
+    }
+
+    /**
+     * PUT /v1/{accountId}/drafts/{draftId}/documents/{documentId}/signature
+     * <p>
+     * Update a document signature
+     *
+     * @param cxt a context (required: draftId,documentId)
+     * @return QueryContext&lt;Void&gt;
+     */
+    public QueryContext<Void> updateSignature(QueryContext<Void> cxt) {
+        try {
+            if (cxt.isFail()) return cxt;
+
+            transport(cxt)
+                    .draftDocumentsPutDocumentSignature(
+                            cxt.getAccountProvider().accountId(),
+                            cxt.getDraftId(),
+                            cxt.getDocumentId(),
+                            cxt.getContent()
+                    );
+
+            return cxt.setResult(null, NOTHING);
+        } catch (ApiException x) {
+            return cxt.setServiceError(new ApiExceptionDto().fromDto(x));
+        }
+    }
+
+    /**
+     * POST /v1/{accountId}/drafts/{draftId}/documents/{documentId}/content/format/USN/1
+     * <p>
+     * Create an USN declaration, version 1
+     *
+     * @param cxt a context (required: draftId,documentId)
+     * @return QueryContext&lt;Void&gt;
+     */
+    public QueryContext<Void> createUSN1(QueryContext<Void> cxt) {
+        try {
+            if (cxt.isFail()) return cxt;
+
+            transport(cxt)
+                    .draftDocumentsBuildContentFromFormatWithHttpInfo(
+                            cxt.getAccountProvider().accountId(),
+                            cxt.getDraftId(),
+                            cxt.getDocumentId(),
+                            new UsnServiceContractInfoDto().toDto(cxt.getUsnServiceContractInfo())
+                    );
+
+            return cxt.setResult(null, NOTHING);
+        } catch (ApiException x) {
+            return cxt.setServiceError(new ApiExceptionDto().fromDto(x));
+        }
+    }
+
+    /**
+     * POST /v1/{accountId}/drafts/{draftId}/documents/{documentId}/content/format/USN/2
+     * <p>
+     * Create an USN declaration, version 2
+     *
+     * @param cxt a context (required: draftId,documentId)
+     * @return QueryContext&lt;Void&gt;
+     */
+    public QueryContext<Void> createUSN2(QueryContext<Void> cxt) {
+        try {
+            if (cxt.isFail()) return cxt;
+
+            transport(cxt)
+                    .draftDocumentsBuildContentFromFormat_0WithHttpInfo(
+                            cxt.getAccountProvider().accountId(),
+                            cxt.getDraftId(),
+                            cxt.getDocumentId(),
+                            new UsnServiceContractInfoV2Dto().toDto(cxt.getUsnServiceContractInfoV2())
+                    );
+
+            return cxt.setResult(null, NOTHING);
+        } catch (ApiException x) {
+            return cxt.setServiceError(new ApiExceptionDto().fromDto(x));
+        }
+    }
+
+    private DraftsApi transport(QueryContext<?> cxt) {
+        super.prepareTransport(cxt);
+        return api;
+    }
 }

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/DraftsAdaptor.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/DraftsAdaptor.java
@@ -1,8 +1,27 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * MIT License
+ *
+ * Copyright (c) 2018 SKB Kontur
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  */
+
 package ru.skbkontur.sdk.extern.service.transport.adaptors;
 
 import ru.skbkontur.sdk.extern.model.Docflow;

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/Query.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/Query.java
@@ -1,8 +1,27 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * MIT License
+ *
+ * Copyright (c) 2018 SKB Kontur
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  */
+
 package ru.skbkontur.sdk.extern.service.transport.adaptors;
 
 /**

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/Query.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/Query.java
@@ -6,10 +6,10 @@
 package ru.skbkontur.sdk.extern.service.transport.adaptors;
 
 /**
- *
  * @author AlexS
  */
 @FunctionalInterface
 public interface Query<R> {
-	QueryContext<R> apply(QueryContext<R> context);
+
+    QueryContext<R> apply(QueryContext<R> context);
 }

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/QueryContext.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/QueryContext.java
@@ -1,8 +1,27 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * MIT License
+ *
+ * Copyright (c) 2018 SKB Kontur
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  */
+
 package ru.skbkontur.sdk.extern.service.transport.adaptors;
 
 import com.google.gson.GsonBuilder;
@@ -137,19 +156,6 @@ public class QueryContext<R> implements Serializable {
         return serviceError;
     }
 
-    public QueryContext<R> setServiceError(String message) {
-        return setServiceError(new ServiceErrorImpl(ServiceError.ErrorCode.business, message, 0, null, null));
-    }
-
-    public QueryContext<R> setServiceError(QueryContext<?> queryContext) {
-        this.result = null;
-        this.serviceError = queryContext.serviceError;
-        if (serviceError.getResponseCode() == HttpsURLConnection.HTTP_UNAUTHORIZED) {
-            set(SESSION_ID, null);
-        }
-        return this;
-    }
-
     public QueryContext<R> setServiceError(ServiceError serviceError) {
         this.result = null;
         this.serviceError = serviceError;
@@ -161,6 +167,19 @@ public class QueryContext<R> implements Serializable {
 
     public QueryContext<R> setServiceError(ApiException x) {
         return setServiceError(ErrorCode.server, x.getMessage(), x.getCode(), x.getResponseHeaders(), x.getResponseBody());
+    }
+
+    public QueryContext<R> setServiceError(String message) {
+        return setServiceError(new ServiceErrorImpl(ServiceError.ErrorCode.business, message, 0, null, null));
+    }
+
+    public QueryContext<R> setServiceError(QueryContext<?> queryContext) {
+        this.result = null;
+        this.serviceError = queryContext.serviceError;
+        if (serviceError.getResponseCode() == HttpsURLConnection.HTTP_UNAUTHORIZED) {
+            set(SESSION_ID, null);
+        }
+        return this;
     }
 
     public QueryContext<R> setServiceError(ServiceError.ErrorCode errorCode, String message, int code, Map<String, List<String>> responseHeaders, String responseBody) {

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/QueryContext.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/QueryContext.java
@@ -6,6 +6,25 @@
 package ru.skbkontur.sdk.extern.service.transport.adaptors;
 
 import com.google.gson.GsonBuilder;
+import org.joda.time.DateTime;
+import org.joda.time.LocalDate;
+import ru.skbkontur.sdk.extern.model.*;
+import ru.skbkontur.sdk.extern.providers.AccountProvider;
+import ru.skbkontur.sdk.extern.providers.ApiKeyProvider;
+import ru.skbkontur.sdk.extern.providers.AuthenticationProvider;
+import ru.skbkontur.sdk.extern.providers.ServiceError;
+import ru.skbkontur.sdk.extern.providers.ServiceError.ErrorCode;
+import ru.skbkontur.sdk.extern.service.transport.invoker.ApiClient;
+import ru.skbkontur.sdk.extern.service.transport.invoker.ApiException;
+import ru.skbkontur.sdk.extern.service.transport.invoker.DateAdapter;
+import ru.skbkontur.sdk.extern.service.transport.invoker.DateTimeTypeAdapter;
+import ru.skbkontur.sdk.extern.service.transport.invoker.DocumentToSendAdapter;
+import ru.skbkontur.sdk.extern.service.transport.invoker.LocalDateTypeAdapter;
+import ru.skbkontur.sdk.extern.service.transport.invoker.SignatureToSendAdapter;
+import ru.skbkontur.sdk.extern.service.transport.swagger.invoker.auth.ApiKeyAuth;
+import ru.skbkontur.sdk.extern.service.transport.swagger.invoker.auth.Authentication;
+
+import javax.net.ssl.HttpsURLConnection;
 import java.io.Serializable;
 import java.util.Date;
 import java.util.List;
@@ -13,728 +32,690 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
-import javax.net.ssl.HttpsURLConnection;
-import org.joda.time.DateTime;
-import org.joda.time.LocalDate;
-import ru.skbkontur.sdk.extern.model.Account;
-import ru.skbkontur.sdk.extern.model.AccountList;
-import ru.skbkontur.sdk.extern.model.CertificateList;
-import ru.skbkontur.sdk.extern.model.CreateAccountRequest;
-import ru.skbkontur.sdk.extern.model.Docflow;
-import ru.skbkontur.sdk.extern.model.Document;
-import ru.skbkontur.sdk.extern.model.DocumentContents;
-import ru.skbkontur.sdk.extern.model.DocumentDescription;
-import ru.skbkontur.sdk.extern.model.DocumentToSend;
-import ru.skbkontur.sdk.extern.model.DraftDocument;
-import ru.skbkontur.sdk.extern.providers.AccountProvider;
-import ru.skbkontur.sdk.extern.providers.ApiKeyProvider;
-import ru.skbkontur.sdk.extern.providers.AuthenticationProvider;
-import ru.skbkontur.sdk.extern.providers.ServiceError;
-import ru.skbkontur.sdk.extern.service.transport.invoker.ApiClient;
-import ru.skbkontur.sdk.extern.service.transport.invoker.DateAdapter;
-import ru.skbkontur.sdk.extern.service.transport.invoker.DateTimeTypeAdapter;
-import ru.skbkontur.sdk.extern.service.transport.invoker.LocalDateTypeAdapter;
-import ru.skbkontur.sdk.extern.service.transport.swagger.invoker.auth.ApiKeyAuth;
-import ru.skbkontur.sdk.extern.service.transport.swagger.invoker.auth.Authentication;
-import ru.skbkontur.sdk.extern.model.DraftMeta;
-import ru.skbkontur.sdk.extern.model.Link;
-import ru.skbkontur.sdk.extern.model.Signature;
-import ru.skbkontur.sdk.extern.model.UsnServiceContractInfo;
-import ru.skbkontur.sdk.extern.model.UsnServiceContractInfoV2;
-import ru.skbkontur.sdk.extern.providers.ServiceError.ErrorCode;
-import ru.skbkontur.sdk.extern.service.transport.invoker.ApiException;
-import ru.skbkontur.sdk.extern.service.transport.invoker.DocumentToSendAdapter;
-import ru.skbkontur.sdk.extern.service.transport.invoker.SignatureToSendAdapter;
+
 
 /**
- *
- * @author AlexS
- *
- * Api Query Context
  * @param <R> some return type
+ * @author AlexS
+ * <p>
+ * Api Query Context
  */
 public class QueryContext<R> implements Serializable {
 
-	private final Map<String, Object> params;
-
-	public static final String SESSION_ID = "sessionId";
-	public static final String ENTITY_NAME = "entityName";
-	public static final String ENTITY_ID = "entityId";
-	public static final String DRAFT_ID = "draftId";
-	public static final String DRAFT = "draft";
-	public static final String DOCUMENT_ID = "documentId";
-	public static final String DOCUMENT = "document";
-	public static final String DOCUMENTS = "documents";
-	public static final String DOCFLOW_ID = "docflowId";
-	public static final String DOCUMENT_TYPE = "documentType";
-	public static final String REPLY_ID = "replyId";
-	public static final String DOCUMENT_TO_SEND = "documentToSend";
-	public static final String DOCUMENT_TO_SENDS = "documentToSends";
-	public static final String DRAFT_META = "draftMeta";
-	public static final String DEFFERED = "deffered";
-	public static final String FORCE = "force";
-	public static final String CONTENT_BYTES = "contentBytes";
-	public static final String CONTENT_STRING = "contentString";
-	public static final String FILE_NAME = "fileName";
-	public static final String DOCUMENT_CONTENTS = "documentContents";
-	public static final String CONTENT = "content";
-	public static final String MAP = "map";
-	public static final String PREPARE_RESULT = "prepareResult";
-	public static final String DOCFLOW = "docflow";
-	public static final String DOCFLOWS = "docflows";
-	public static final String DRAFT_DOCUMENT = "draftDocument";
-	public static final String DOCUMENT_DESCRIPTION = "documentDescription";
-	public static final String SIGNATURE_ID = "signatureId";
-	public static final String SIGNATURES = "signatures";
-	public static final String SIGNATURE = "signature";
-	public static final String THUMBPRINT = "thumbprint";
-	public static final String LINKS = "links";
-	public static final String ACCOUNT_ID = "accountId";
-	public static final String ACCOUNT = "account";
-	public static final String ACCOUNT_LIST = "accountList";
-	public static final String DOCFLOW_PAGE = "docflowPage";
-	public static final String CREATE_ACCOUNT_REQUEST = "createAccountRequest";
-	public static final String FINISHED = "finished";
-	public static final String INCOMING = "incoming";
-	public static final String SKIP = "skip";
-	public static final String TAKE = "take";
-	public static final String INN_KPP = "innKpp";
-	public static final String UPDATED_FROM = "updatedFrom";
-	public static final String UPDATED_TO = "updatedTo";
-	public static final String CREATED_FROM = "createdFrom";
-	public static final String CREATED_TO = "createdTo";
-	public static final String TYPE = "type";
-	public static final String CERTIFICATE = "certificate";
-	public static final String CERTIFICATE_LIST = "certificateList";
-	public static final String USN_SERVICE_CONTRACT_INFO = "usnServiceContractInfo";
-	public static final String USN_SERVICE_CONTRACT_INFO_V2 = "usnServiceContractInfoV2";
-	public static final String NOTHING = "nothing";
-	public static final String OBJECT = "object";
-
-	private String result;
-
-	private ServiceError serviceError;
-
-	private ApiClient apiClient;
-
-	private AuthenticationProvider authenticationProvider;
-
-	private AccountProvider accountProvider;
-	
-	private ApiKeyProvider apiKeyProvider;
-	
-	public QueryContext() {
-		this.params = new ConcurrentHashMap<>();
-		this.serviceError = null;
-		this.result = null;
-	}
-
-	public QueryContext(String entityName) {
-		this();
-		this.setEntityName(entityName);
-	}
-	
-	public QueryContext(QueryContext<?> parent, String entityName) {
-		this.params = new ConcurrentHashMap<>();
-		this.params.putAll(parent.params);
-		this.serviceError = parent.getServiceError();
-		this.result = null;
-		this.setEntityName(entityName);
-	}
-	
-	public void setApiClient(ApiClient apiClient) {
-		this.apiClient = apiClient;
-	}
-	
-	public QueryContext<R> setResult(R result, String key) {
-		this.result = key;
-		this.serviceError = null;
-		return key.equals(NOTHING) ? this : set(key, result);
-	}
-
-	public ServiceError getServiceError() {
-		return serviceError;
-	}
-
-	public QueryContext<R> setServiceError(QueryContext<?> queryContext) {
-		this.result = null;
-		this.serviceError = queryContext.serviceError;
-		if (serviceError.getResponseCode() == HttpsURLConnection.HTTP_UNAUTHORIZED) {
-			set(SESSION_ID, null);
-		}
-		return this;
-	}
-
-	public QueryContext<R> setServiceError(ServiceError serviceError) {
-		this.result = null;
-		this.serviceError = serviceError;
-		if (serviceError.getResponseCode() == HttpsURLConnection.HTTP_UNAUTHORIZED) {
-			set(SESSION_ID, null);
-		}
-		return this;
-	}
-	
-	public QueryContext<R> setServiceError(ApiException x) {
-		return setServiceError(ErrorCode.server, x.getMessage(), x.getCode(), x.getResponseHeaders(), x.getResponseBody());
-	}
-
-	public QueryContext<R> setServiceError(ServiceError.ErrorCode errorCode, String message, int code, Map<String, List<String>> responseHeaders, String responseBody) {
-		return setServiceError(new ServiceErrorImpl(errorCode, message, code, responseHeaders, responseBody));
-	}
-	
-	public QueryContext<R> setServiceError(String message) {
-		return setServiceError(new ServiceErrorImpl(ServiceError.ErrorCode.business, message, 0, null, null));
-	}
-	
-	public QueryContext<R> setServiceError(String message, Throwable x) {
-		return setServiceError(new ServiceErrorImpl(ServiceError.ErrorCode.business, message, 0, null, null, x));
-	}
-	
-	public R get() {
-		if(result==null) {
-			return null;
-		}
-		return (R)get(result);
-	}
-
-	public boolean isSuccess() {
-		return serviceError == null;
-	}
-
-	public boolean isFail() {
-		return serviceError != null;
-	}
-
-	public QueryContext<R> setServiceBaseUri(String serviceBaseUri) {
-		this.apiClient.setBasePath(serviceBaseUri);
-		return this;
-	}
-
-	public QueryContext<R> setAuthenticationProvider(AuthenticationProvider authenticationProvider) {
-		this.authenticationProvider = authenticationProvider;
-		return this;
-	}
-
-	public AuthenticationProvider getAuthenticationProvider() {
-		return authenticationProvider;
-	}
-
-	public AccountProvider getAccountProvider() {
-		return accountProvider;
-	}
-
-	public QueryContext<R> setAccountProvider(AccountProvider accountProvider) {
-		this.accountProvider = accountProvider;
-		return this;
-	}
-
-	public ApiKeyProvider getApiKeyProvider() {
-		return apiKeyProvider;
-	}
-
-	public QueryContext<R> setApiKeyProvider(ApiKeyProvider apiKeyProvider) {
-		this.apiKeyProvider = apiKeyProvider;
-		return this;
-	}
-
-	public String getSessionId() {
-		return (String) params.get(SESSION_ID);
-	}
-
-	public QueryContext<R> setSessionId(QueryContext<?> queryContext) {
-		return set(SESSION_ID, UUID.fromString(queryContext.getSessionId()));
-	}
-
-	public QueryContext<R> setSessionId(String sessionId) {
-		return set(SESSION_ID, sessionId);
-	}
-
-	public String getEntityName() {
-		return (String) params.get(ENTITY_NAME);
-	}
-
-	public final QueryContext<R> setEntityName(String entityName) {
-		return set(ENTITY_NAME, entityName);
-	}
-
-	public UUID getDraftId() {
-		return (UUID) params.get(DRAFT_ID);
-	}
-
-	public QueryContext<R> setDraftId(UUID draftId) {
-		return set(DRAFT_ID, draftId);
-	}
-
-	public QueryContext<R> setDraftId(String draftId) {
-		return set(DRAFT_ID, UUID.fromString(draftId));
-	}
-
-	public Docflow getDocflow() {
-		return (Docflow) params.get(DOCFLOW);
-	}
-
-	public QueryContext<R> setDocflow(Docflow docflow) {
-		return set(DOCFLOW, docflow);
-	}
-
-	public List<Docflow> getDocflows() {
-		return (List<Docflow>) params.get(DOCFLOWS);
-	}
-
-	public QueryContext<R> setDocflow(List<Docflow> docflows) {
-		return set(DOCFLOWS, docflows);
-	}
-
-	public UUID getDocflowId() {
-		UUID docflowId = (UUID) params.get(DOCFLOW_ID);
-		if (docflowId == null) {
-			Docflow docflow = this.getDocflow();
-			if (docflow != null)
-				docflowId = docflow.getId();
-		}
-		return docflowId;
-	}
-
-	public QueryContext<R> setDocflowId(String docflowId) {
-		return set(DOCFLOW_ID, UUID.fromString(docflowId));
-	}
-	
-	public QueryContext<R> setDocflowId(UUID docflowId) {
-		return set(DOCFLOW_ID, docflowId);
-	}
-	
-	public UUID getDocumentId() {
-		return (UUID) params.get(DOCUMENT_ID);
-	}
-
-	public QueryContext<R> setDocumentId(String documentId) {
-		return set(DOCUMENT_ID, UUID.fromString(documentId));
-	}
-
-	public QueryContext<R> setDocumentId(UUID documentId) {
-		return set(DOCUMENT_ID, documentId);
-	}
-
-	public Document getDocument() {
-		return (Document) params.get(DOCUMENT);
-	}
-
-	public QueryContext<R> setDocument(Document document) {
-		return set(DOCUMENT, document);
-	}
-	
-	public List<Document> getDocuments() {
-		return (List<Document>) params.get(DOCUMENTS);
-	}
-
-	public QueryContext<R> setDocument(List<Document> documents) {
-		return set(DOCUMENTS, documents);
-	}
-	
-	public DocumentDescription getDocumentDescription() {
-		return (DocumentDescription) params.get(DOCUMENT_DESCRIPTION);
-	}
-
-	public QueryContext<R> setDocumentDescription(DocumentDescription documentDescription) {
-		return set(DOCUMENT_DESCRIPTION, documentDescription);
-	}
-	
-	public String getDocumentType() {
-		return (String) params.get(DOCUMENT_TYPE);
-	}
-
-	public QueryContext<R> setDocumentType(String documentType) {
-		return set(DOCUMENT_TYPE, documentType);
-	}
-
-	public UUID getReplyId() {
-		return (UUID) params.get(REPLY_ID);
-	}
-
-	public QueryContext<R> setReplyId(String replyId) {
-		return set(REPLY_ID, UUID.fromString(replyId));
-	}
-
-	public DocumentToSend getDocumentToSend() {
-		return (DocumentToSend) params.get(DOCUMENT_TO_SEND);
-	}
-
-	public QueryContext<R> setDocumentToSend(DocumentToSend documentToSend) {
-		return set(DOCUMENT_TO_SEND, documentToSend);
-	}
-
-	public DraftMeta getDraftMeta() {
-		return (DraftMeta) params.get(DRAFT_META);
-	}
-
-	public QueryContext<R> setDraftMeta(DraftMeta draftMeta) {
-		return set(DRAFT_META, draftMeta);
-	}
-
-	public boolean getDeffered() {
-		Object v = params.get(DEFFERED);
-		return v == null ? true : (boolean)v;
-	}
-
-	public QueryContext<R> setDeffered(boolean deffered) {
-		return set(DEFFERED, deffered);
-	}
-
-	public boolean getForce() {
-		Object v = params.get(FORCE);
-		return v == null ? true : (boolean) v;
-	}
-
-	public QueryContext<R> setForce(boolean force) {
-		return set(FORCE, force);
-	}
-
-	public byte[] getContentBytes() {
-		return (byte[]) params.get(CONTENT_BYTES);
-	}
-
-	public String getContentString() {
-		return (String) params.get(CONTENT_STRING);
-	}
-
-	public QueryContext<R> setContentBytes(byte[] documentContent) {
-		return set(CONTENT_BYTES, documentContent);
-	}
-
-	public QueryContext<R> setContentString(String documentContent) {
-		return set(CONTENT_STRING, documentContent);
-	}
-
-	public String getFileName() {
-		return (String) params.get(FILE_NAME);
-	}
-
-	public QueryContext<R> setFileName(String fileName) {
-		return set(FILE_NAME, fileName);
-	}
-
-	public DocumentContents getDocumentContents() {
-		return (DocumentContents) params.get(DOCUMENT_CONTENTS);
-	}
-
-	public QueryContext<R> setDocumentContents(DocumentContents documentContents) {
-		return set(DOCUMENT_CONTENTS, documentContents);
-	}
-
-	public byte[] getContent() {
-		return (byte[]) params.get(CONTENT);
-	}
-
-	public DraftDocument getDraftDocument() {
-		return (DraftDocument) params.get(DRAFT_DOCUMENT);
-	}
-
-	public QueryContext<R> setContent(byte[] content) {
-		return set(CONTENT, content);
-	}
-
-	public UUID getSignatureId() {
-		return (UUID) params.get(SIGNATURE_ID);
-	}
-	
-	public QueryContext<R> setSignatureId(String signatureId) {
-		return set(SIGNATURE_ID, UUID.fromString(signatureId));
-	}
-	
-	public QueryContext<R> setSignatureId(UUID signatureId) {
-		return set(SIGNATURE_ID, signatureId);
-	}
-	
-	public String getThumbprint() {
-		return (String) params.get(THUMBPRINT);
-	}
-	
-	public QueryContext<R> setThumbprint(String thumbprint) {
-		return set(THUMBPRINT, thumbprint);
-	}
-	
-	public List<Link> getLinks() {
-		return (List<Link>) params.get(LINKS);
-	}
-	
-	public QueryContext<R> setLinks(List<Link> links) {
-		return set(LINKS, links);
-	}
-	
-	public UUID getAccountId() {
-		return (UUID) params.get(ACCOUNT_ID);
-	}
-	
-	public QueryContext<R> setAccountId(UUID accountId) {
-		return set(ACCOUNT_ID, accountId);
-	}
-	
-	public QueryContext<R> setAccountId(String accountId) {
-		return set(ACCOUNT_ID, UUID.fromString(accountId));
-	}
-	
-	public Account getAccount() {
-		return (Account) params.get(ACCOUNT);
-	}
-	
-	public QueryContext<R> setAccount(Account account) {
-		return set(ACCOUNT, account);
-	}
-	
-	public AccountList getAccountList() {
-		return (AccountList) params.get(ACCOUNT_LIST);
-	}
-	
-	public QueryContext<R> setAccountList(AccountList accountList) {
-		return set(ACCOUNT_LIST, accountList);
-	}
-	
-	public CreateAccountRequest getCreateAccountRequest() {
-		return (CreateAccountRequest) params.get(CREATE_ACCOUNT_REQUEST);
-	}
-	
-	public QueryContext<R> setCreateAccountRequest(CreateAccountRequest createAccountRequest) {
-		return set(CREATE_ACCOUNT_REQUEST, createAccountRequest);
-	}
-	
-	public Signature getSignature() {
-		return (Signature) params.get(SIGNATURE);
-	}
-	
-	public QueryContext<R> setSignature(Signature signature) {
-		return set(SIGNATURE, signature);
-	}
-	
-	public List<Signature> getSignatures() {
-		return (List<Signature>) params.get(SIGNATURES);
-	}
-	
-	public QueryContext<R> setSignatures(List<Signature> signatures) {
-		return set(SIGNATURES, signatures);
-	}
-	
-	public List<DocumentToSend> getDocumentToSends() {
-		return (List<DocumentToSend>) params.get(DOCUMENT_TO_SENDS);
-	}
-	
-	public QueryContext<R> setDocumentToSends(List<DocumentToSend> replies) {
-		return set(DOCUMENT_TO_SENDS, replies);
-	}
-	
-	public boolean getFinished() { 
-		return (boolean)params.get(FINISHED); 
-	};
-	
-	public QueryContext<R>  setFinished(boolean finished) { 
-		return set(FINISHED, finished);
-	};
-	
-	public boolean getIncoming() { 
-		return (boolean)params.get(INCOMING); 
-	};
-	
-	public QueryContext<R>  setIncoming(boolean incoming) { 
-		return set(INCOMING, incoming);
-	};
-	
-	public long getSkip() { 
-		return (long)params.get(SKIP); 
-	};
-	
-	public QueryContext<R>  setSkip(long skip) { 
-		return set(SKIP, skip);
-	};
-	
-	public int getTake() { 
-		return (int)params.get(TAKE); 
-	};
-	
-	public QueryContext<R>  setTake(int take) { 
-		return set(TAKE, take);
-	};
-	
-	public String getInnKpp() { 
-		return (String)params.get(INN_KPP); 
-	};
-	
-	public QueryContext<R>  setInnKpp(String innKpp) { 
-		return set(INN_KPP, innKpp);
-	};
-	
-	public DateTime getUpdatedFrom() { 
-		return (DateTime)params.get(UPDATED_FROM); 
-	};
-	
-	public QueryContext<R>  setUpdatedFrom(DateTime updatedFrom) { 
-		return set(UPDATED_FROM, updatedFrom);
-	};
-	
-	public DateTime getUpdatedTo() { 
-		return (DateTime)params.get(UPDATED_TO); 
-	};
-	
-	public QueryContext<R>  setUpdatedTo(DateTime updatedTo) { 
-		return set(UPDATED_TO, updatedTo);
-	};
-
-	public DateTime getCreatedFrom() { 
-		return (DateTime)params.get(CREATED_FROM); 
-	};
-	
-	public QueryContext<R>  setCreatedFrom(DateTime createdFrom) { 
-		return set(CREATED_FROM, createdFrom);
-	};
-
-	public DateTime getCreatedTo() { 
-		return (DateTime)params.get(CREATED_TO); 
-	};
-	
-	public QueryContext<R>  setCreatedTo(DateTime createdTo) { 
-		return set(CREATED_TO, createdTo);
-	};
-	
-	public String getType() { 
-		return (String)params.get(TYPE); 
-	};
-	
-	public QueryContext<R> setType(String type) { 
-		return set(TYPE, type);
-	};
-	
-	public String getCertificate() { 
-		return (String)params.get(CERTIFICATE); 
-	};
-	
-	public QueryContext<R> setCertificate(String certificate) { 
-		return set(CERTIFICATE, certificate);
-	};
-	
-	public CertificateList getCertificateList() { 
-		return (CertificateList)params.get(CERTIFICATE_LIST); 
-	};
-	
-	public QueryContext<R> setCertificateList(CertificateList certificateList) { 
-		return set(CERTIFICATE_LIST, certificateList);
-	};
-	
-	public UsnServiceContractInfo getUsnServiceContractInfo() { 
-		return (UsnServiceContractInfo)params.get(USN_SERVICE_CONTRACT_INFO); 
-	};
-	
-	public QueryContext<R> setUsnServiceContractInfo(UsnServiceContractInfo usnServiceContractInfo) { 
-		return set(USN_SERVICE_CONTRACT_INFO, usnServiceContractInfo);
-	};
-	
-	public UsnServiceContractInfoV2 getUsnServiceContractInfoV2() { 
-		return (UsnServiceContractInfoV2)params.get(USN_SERVICE_CONTRACT_INFO_V2); 
-	};
-
-	public QueryContext<R> setUsnServiceContractInfoV2(UsnServiceContractInfoV2 usnServiceContractInfoV2) { 
-		return set(USN_SERVICE_CONTRACT_INFO_V2, usnServiceContractInfoV2);
-	};
-
-	public QueryContext<R> set(String name, Object val) {
-		if (val != null) params.put(name, val);	else params.remove(name);
-		
-		return this;
-	}
-
-	public <T> T get(String name) {
-		return (T)params.get(name);
-	}
-
-	public ApiClient getApiClient() {
-		return apiClient;
-	}
-
-	private void acceptApiKey(String apiKey) {
-		if (apiKey != null && !apiKey.isEmpty()) {
-			Authentication apiKeyAuth = apiClient.getAuthentication("apiKey");
-			if (apiKeyAuth != null) {
-				((ApiKeyAuth) apiKeyAuth).setApiKey(apiKey);
-			}
-		}
-	}
-
-	public void configureApiClient() {
-		apiClient.getJSON().setGson(new GsonBuilder()
-			.disableHtmlEscaping()
-			.registerTypeAdapter(Date.class, new DateAdapter(apiClient))
-			.registerTypeAdapter(DateTime.class, new DateTimeTypeAdapter())
-			.registerTypeAdapter(LocalDate.class, new LocalDateTypeAdapter())
-			.registerTypeAdapter(ru.skbkontur.sdk.extern.service.transport.swagger.model.SignatureToSend.class, new SignatureToSendAdapter())
-			.registerTypeAdapter(ru.skbkontur.sdk.extern.service.transport.swagger.model.DocumentToSend.class, new DocumentToSendAdapter())
-			.create());
-		// устанавливаем api-key
-		acceptApiKey(apiKeyProvider.getApiKey());
-		// устанавливаем таймаут соединения
-		apiClient.setConnectTimeout(60*1000);
-		// устанавливаем таймаут чтения
-		apiClient.setReadTimeout(60*1000);
-	}
-
-	public CompletableFuture<QueryContext<R>> applyAsync(Query<R> query) {
-		if (isFail()) return CompletableFuture.completedFuture(this);
-		
-		acquireSessionId();
-		
-		if (isSuccess()) {
-			return CompletableFuture.supplyAsync(()->query.apply(this));
-		}
-		else
-			return CompletableFuture.completedFuture(this);
-	}
-
-	public QueryContext<R> apply(Query<R> query) {
-		if (isFail()) return this;
-		
-		acquireSessionId();
-		
-		if (isSuccess()) {
-			QueryContext<R> r = query.apply(this);
-			if (r.isFail() && r.getServiceError().getErrorCode() == ErrorCode.server && r.getServiceError().getResponseCode() == HttpsURLConnection.HTTP_UNAUTHORIZED) {
-				if (authenticationProvider != null)
-					authenticationProvider.raiseUnauthenticated(r.getServiceError());
-			}
-			return r;
-		}
-		else
-			return this;
-	}
-	
-	public ServiceException failure() {
-		throw new ServiceException(getServiceError());
-	}
-	
-	private void acquireSessionId() {
-		String sessionId = getSessionId();
-		if (sessionId != null && !sessionId.isEmpty()) {
-			acceptAccessToken(sessionId);
-		}
-		else {
-			if (authenticationProvider != null) {
-				QueryContext<String> authQuery = authenticationProvider.sessionId();
-				if (authQuery.isFail()) {
-					setServiceError(authQuery);
-				}
-				else {
-					sessionId = setSessionId(authQuery.get()).getSessionId();
-					acceptAccessToken(sessionId);
-				}
-			}
-			else {
-				setServiceError(new ServiceErrorImpl(ServiceError.ErrorCode.unknownAuth));
-			}
-		}
-	}
-
-	private void acceptAccessToken(String sessionId) {
-		if (sessionId != null && !sessionId.isEmpty()) {
-			Authentication apiKeyAuth = apiClient.getAuthentication("auth.sid");
-			if (apiKeyAuth != null) {
-				((ApiKeyAuth) apiKeyAuth).setApiKey(sessionId);
-				((ApiKeyAuth) apiKeyAuth).setApiKeyPrefix(getAuthenticationProvider().authPrefix());
-			}
-		}
-	}
+    public static final String SESSION_ID = "sessionId";
+    public static final String ENTITY_NAME = "entityName";
+    public static final String ENTITY_ID = "entityId";
+    public static final String DRAFT_ID = "draftId";
+    public static final String DRAFT = "draft";
+    public static final String DOCUMENT_ID = "documentId";
+    public static final String DOCUMENT = "document";
+    public static final String DOCUMENTS = "documents";
+    public static final String DOCFLOW_ID = "docflowId";
+    public static final String DOCUMENT_TYPE = "documentType";
+    public static final String REPLY_ID = "replyId";
+    public static final String DOCUMENT_TO_SEND = "documentToSend";
+    public static final String DOCUMENT_TO_SENDS = "documentToSends";
+    public static final String DRAFT_META = "draftMeta";
+    public static final String DEFFERED = "deffered";
+    public static final String FORCE = "force";
+    public static final String CONTENT_BYTES = "contentBytes";
+    public static final String CONTENT_STRING = "contentString";
+    public static final String FILE_NAME = "fileName";
+    public static final String DOCUMENT_CONTENTS = "documentContents";
+    public static final String CONTENT = "content";
+    public static final String MAP = "map";
+    public static final String PREPARE_RESULT = "prepareResult";
+    public static final String DOCFLOW = "docflow";
+    public static final String DOCFLOWS = "docflows";
+    public static final String DRAFT_DOCUMENT = "draftDocument";
+    public static final String DOCUMENT_DESCRIPTION = "documentDescription";
+    public static final String SIGNATURE_ID = "signatureId";
+    public static final String SIGNATURES = "signatures";
+    public static final String SIGNATURE = "signature";
+    public static final String THUMBPRINT = "thumbprint";
+    public static final String LINKS = "links";
+    public static final String ACCOUNT_ID = "accountId";
+    public static final String ACCOUNT = "account";
+    public static final String ACCOUNT_LIST = "accountList";
+    public static final String DOCFLOW_PAGE = "docflowPage";
+    public static final String CREATE_ACCOUNT_REQUEST = "createAccountRequest";
+    public static final String FINISHED = "finished";
+    public static final String INCOMING = "incoming";
+    public static final String SKIP = "skip";
+    public static final String TAKE = "take";
+    public static final String INN_KPP = "innKpp";
+    public static final String UPDATED_FROM = "updatedFrom";
+    public static final String UPDATED_TO = "updatedTo";
+    public static final String CREATED_FROM = "createdFrom";
+    public static final String CREATED_TO = "createdTo";
+    public static final String TYPE = "type";
+    public static final String CERTIFICATE = "certificate";
+    public static final String CERTIFICATE_LIST = "certificateList";
+    public static final String USN_SERVICE_CONTRACT_INFO = "usnServiceContractInfo";
+    public static final String USN_SERVICE_CONTRACT_INFO_V2 = "usnServiceContractInfoV2";
+    public static final String NOTHING = "nothing";
+    public static final String OBJECT = "object";
+    private final Map<String, Object> params;
+    private String result;
+
+    private ServiceError serviceError;
+
+    private ApiClient apiClient;
+
+    private AuthenticationProvider authenticationProvider;
+
+    private AccountProvider accountProvider;
+
+    private ApiKeyProvider apiKeyProvider;
+
+    public QueryContext() {
+        this.params = new ConcurrentHashMap<>();
+        this.serviceError = null;
+        this.result = null;
+    }
+
+    public QueryContext(String entityName) {
+        this();
+        this.setEntityName(entityName);
+    }
+
+    public QueryContext(QueryContext<?> parent, String entityName) {
+        this.params = new ConcurrentHashMap<>();
+        this.params.putAll(parent.params);
+        this.serviceError = parent.getServiceError();
+        this.result = null;
+        this.setEntityName(entityName);
+    }
+
+    public QueryContext<R> setResult(R result, String key) {
+        this.result = key;
+        this.serviceError = null;
+        return key.equals(NOTHING) ? this : set(key, result);
+    }
+
+    public ServiceError getServiceError() {
+        return serviceError;
+    }
+
+    public QueryContext<R> setServiceError(String message) {
+        return setServiceError(new ServiceErrorImpl(ServiceError.ErrorCode.business, message, 0, null, null));
+    }
+
+    public QueryContext<R> setServiceError(QueryContext<?> queryContext) {
+        this.result = null;
+        this.serviceError = queryContext.serviceError;
+        if (serviceError.getResponseCode() == HttpsURLConnection.HTTP_UNAUTHORIZED) {
+            set(SESSION_ID, null);
+        }
+        return this;
+    }
+
+    public QueryContext<R> setServiceError(ServiceError serviceError) {
+        this.result = null;
+        this.serviceError = serviceError;
+        if (serviceError.getResponseCode() == HttpsURLConnection.HTTP_UNAUTHORIZED) {
+            set(SESSION_ID, null);
+        }
+        return this;
+    }
+
+    public QueryContext<R> setServiceError(ApiException x) {
+        return setServiceError(ErrorCode.server, x.getMessage(), x.getCode(), x.getResponseHeaders(), x.getResponseBody());
+    }
+
+    public QueryContext<R> setServiceError(ServiceError.ErrorCode errorCode, String message, int code, Map<String, List<String>> responseHeaders, String responseBody) {
+        return setServiceError(new ServiceErrorImpl(errorCode, message, code, responseHeaders, responseBody));
+    }
+
+    public QueryContext<R> setServiceError(String message, Throwable x) {
+        return setServiceError(new ServiceErrorImpl(ServiceError.ErrorCode.business, message, 0, null, null, x));
+    }
+
+    public R get() {
+        if (result == null) {
+            return null;
+        }
+        return (R) get(result);
+    }
+
+    public boolean isSuccess() {
+        return serviceError == null;
+    }
+
+    public boolean isFail() {
+        return serviceError != null;
+    }
+
+    public QueryContext<R> setServiceBaseUri(String serviceBaseUri) {
+        this.apiClient.setBasePath(serviceBaseUri);
+        return this;
+    }
+
+    public AuthenticationProvider getAuthenticationProvider() {
+        return authenticationProvider;
+    }
+
+    public QueryContext<R> setAuthenticationProvider(AuthenticationProvider authenticationProvider) {
+        this.authenticationProvider = authenticationProvider;
+        return this;
+    }
+
+    public AccountProvider getAccountProvider() {
+        return accountProvider;
+    }
+
+    public QueryContext<R> setAccountProvider(AccountProvider accountProvider) {
+        this.accountProvider = accountProvider;
+        return this;
+    }
+
+    public ApiKeyProvider getApiKeyProvider() {
+        return apiKeyProvider;
+    }
+
+    public QueryContext<R> setApiKeyProvider(ApiKeyProvider apiKeyProvider) {
+        this.apiKeyProvider = apiKeyProvider;
+        return this;
+    }
+
+    public String getSessionId() {
+        return (String) params.get(SESSION_ID);
+    }
+
+    public QueryContext<R> setSessionId(String sessionId) {
+        return set(SESSION_ID, sessionId);
+    }
+
+    public QueryContext<R> setSessionId(QueryContext<?> queryContext) {
+        return set(SESSION_ID, UUID.fromString(queryContext.getSessionId()));
+    }
+
+    public String getEntityName() {
+        return (String) params.get(ENTITY_NAME);
+    }
+
+    public final QueryContext<R> setEntityName(String entityName) {
+        return set(ENTITY_NAME, entityName);
+    }
+
+    public UUID getDraftId() {
+        return (UUID) params.get(DRAFT_ID);
+    }
+
+    public QueryContext<R> setDraftId(String draftId) {
+        return set(DRAFT_ID, UUID.fromString(draftId));
+    }
+
+    public QueryContext<R> setDraftId(UUID draftId) {
+        return set(DRAFT_ID, draftId);
+    }
+
+    public Docflow getDocflow() {
+        return (Docflow) params.get(DOCFLOW);
+    }
+
+    public QueryContext<R> setDocflow(List<Docflow> docflows) {
+        return set(DOCFLOWS, docflows);
+    }
+
+    public QueryContext<R> setDocflow(Docflow docflow) {
+        return set(DOCFLOW, docflow);
+    }
+
+    public List<Docflow> getDocflows() {
+        return (List<Docflow>) params.get(DOCFLOWS);
+    }
+
+    public UUID getDocflowId() {
+        UUID docflowId = (UUID) params.get(DOCFLOW_ID);
+        if (docflowId == null) {
+            Docflow docflow = this.getDocflow();
+            if (docflow != null)
+                docflowId = docflow.getId();
+        }
+        return docflowId;
+    }
+
+    public QueryContext<R> setDocflowId(UUID docflowId) {
+        return set(DOCFLOW_ID, docflowId);
+    }
+
+    public QueryContext<R> setDocflowId(String docflowId) {
+        return set(DOCFLOW_ID, UUID.fromString(docflowId));
+    }
+
+    public UUID getDocumentId() {
+        return (UUID) params.get(DOCUMENT_ID);
+    }
+
+    public QueryContext<R> setDocumentId(UUID documentId) {
+        return set(DOCUMENT_ID, documentId);
+    }
+
+    public QueryContext<R> setDocumentId(String documentId) {
+        return set(DOCUMENT_ID, UUID.fromString(documentId));
+    }
+
+    public Document getDocument() {
+        return (Document) params.get(DOCUMENT);
+    }
+
+    public QueryContext<R> setDocument(List<Document> documents) {
+        return set(DOCUMENTS, documents);
+    }
+
+    public QueryContext<R> setDocument(Document document) {
+        return set(DOCUMENT, document);
+    }
+
+    public List<Document> getDocuments() {
+        return (List<Document>) params.get(DOCUMENTS);
+    }
+
+    public DocumentDescription getDocumentDescription() {
+        return (DocumentDescription) params.get(DOCUMENT_DESCRIPTION);
+    }
+
+    public QueryContext<R> setDocumentDescription(DocumentDescription documentDescription) {
+        return set(DOCUMENT_DESCRIPTION, documentDescription);
+    }
+
+    public String getDocumentType() {
+        return (String) params.get(DOCUMENT_TYPE);
+    }
+
+    public QueryContext<R> setDocumentType(String documentType) {
+        return set(DOCUMENT_TYPE, documentType);
+    }
+
+    public UUID getReplyId() {
+        return (UUID) params.get(REPLY_ID);
+    }
+
+    public QueryContext<R> setReplyId(String replyId) {
+        return set(REPLY_ID, UUID.fromString(replyId));
+    }
+
+    public DocumentToSend getDocumentToSend() {
+        return (DocumentToSend) params.get(DOCUMENT_TO_SEND);
+    }
+
+    public QueryContext<R> setDocumentToSend(DocumentToSend documentToSend) {
+        return set(DOCUMENT_TO_SEND, documentToSend);
+    }
+
+    public DraftMeta getDraftMeta() {
+        return (DraftMeta) params.get(DRAFT_META);
+    }
+
+    public QueryContext<R> setDraftMeta(DraftMeta draftMeta) {
+        return set(DRAFT_META, draftMeta);
+    }
+
+    public boolean getDeffered() {
+        Object v = params.get(DEFFERED);
+        return v == null || (boolean) v;
+    }
+
+    public QueryContext<R> setDeffered(boolean deffered) {
+        return set(DEFFERED, deffered);
+    }
+
+    public boolean getForce() {
+        Object v = params.get(FORCE);
+        return v == null || (boolean) v;
+    }
+
+    public QueryContext<R> setForce(boolean force) {
+        return set(FORCE, force);
+    }
+
+    public byte[] getContentBytes() {
+        return (byte[]) params.get(CONTENT_BYTES);
+    }
+
+    public QueryContext<R> setContentBytes(byte[] documentContent) {
+        return set(CONTENT_BYTES, documentContent);
+    }
+
+    public String getContentString() {
+        return (String) params.get(CONTENT_STRING);
+    }
+
+    public QueryContext<R> setContentString(String documentContent) {
+        return set(CONTENT_STRING, documentContent);
+    }
+
+    public String getFileName() {
+        return (String) params.get(FILE_NAME);
+    }
+
+    public QueryContext<R> setFileName(String fileName) {
+        return set(FILE_NAME, fileName);
+    }
+
+    public DocumentContents getDocumentContents() {
+        return (DocumentContents) params.get(DOCUMENT_CONTENTS);
+    }
+
+    public QueryContext<R> setDocumentContents(DocumentContents documentContents) {
+        return set(DOCUMENT_CONTENTS, documentContents);
+    }
+
+    public byte[] getContent() {
+        return (byte[]) params.get(CONTENT);
+    }
+
+    public QueryContext<R> setContent(byte[] content) {
+        return set(CONTENT, content);
+    }
+
+    public DraftDocument getDraftDocument() {
+        return (DraftDocument) params.get(DRAFT_DOCUMENT);
+    }
+
+    public UUID getSignatureId() {
+        return (UUID) params.get(SIGNATURE_ID);
+    }
+
+    public QueryContext<R> setSignatureId(UUID signatureId) {
+        return set(SIGNATURE_ID, signatureId);
+    }
+
+    public QueryContext<R> setSignatureId(String signatureId) {
+        return set(SIGNATURE_ID, UUID.fromString(signatureId));
+    }
+
+    public String getThumbprint() {
+        return (String) params.get(THUMBPRINT);
+    }
+
+    public QueryContext<R> setThumbprint(String thumbprint) {
+        return set(THUMBPRINT, thumbprint);
+    }
+
+    public List<Link> getLinks() {
+        return (List<Link>) params.get(LINKS);
+    }
+
+    public QueryContext<R> setLinks(List<Link> links) {
+        return set(LINKS, links);
+    }
+
+    public UUID getAccountId() {
+        return (UUID) params.get(ACCOUNT_ID);
+    }
+
+    public QueryContext<R> setAccountId(String accountId) {
+        return set(ACCOUNT_ID, UUID.fromString(accountId));
+    }
+
+    public QueryContext<R> setAccountId(UUID accountId) {
+        return set(ACCOUNT_ID, accountId);
+    }
+
+    public Account getAccount() {
+        return (Account) params.get(ACCOUNT);
+    }
+
+    public QueryContext<R> setAccount(Account account) {
+        return set(ACCOUNT, account);
+    }
+
+    public AccountList getAccountList() {
+        return (AccountList) params.get(ACCOUNT_LIST);
+    }
+
+    public QueryContext<R> setAccountList(AccountList accountList) {
+        return set(ACCOUNT_LIST, accountList);
+    }
+
+    public CreateAccountRequest getCreateAccountRequest() {
+        return (CreateAccountRequest) params.get(CREATE_ACCOUNT_REQUEST);
+    }
+
+    public QueryContext<R> setCreateAccountRequest(CreateAccountRequest createAccountRequest) {
+        return set(CREATE_ACCOUNT_REQUEST, createAccountRequest);
+    }
+
+    public Signature getSignature() {
+        return (Signature) params.get(SIGNATURE);
+    }
+
+    public QueryContext<R> setSignature(Signature signature) {
+        return set(SIGNATURE, signature);
+    }
+
+    public List<Signature> getSignatures() {
+        return (List<Signature>) params.get(SIGNATURES);
+    }
+
+    public QueryContext<R> setSignatures(List<Signature> signatures) {
+        return set(SIGNATURES, signatures);
+    }
+
+    public List<DocumentToSend> getDocumentToSends() {
+        return (List<DocumentToSend>) params.get(DOCUMENT_TO_SENDS);
+    }
+
+    public QueryContext<R> setDocumentToSends(List<DocumentToSend> replies) {
+        return set(DOCUMENT_TO_SENDS, replies);
+    }
+
+    public boolean getFinished() {
+        return (boolean) params.get(FINISHED);
+    }
+
+    public QueryContext<R> setFinished(boolean finished) {
+        return set(FINISHED, finished);
+    }
+
+    public boolean getIncoming() {
+        return (boolean) params.get(INCOMING);
+    }
+
+    public QueryContext<R> setIncoming(boolean incoming) {
+        return set(INCOMING, incoming);
+    }
+
+    public long getSkip() {
+        return (long) params.get(SKIP);
+    }
+
+    public QueryContext<R> setSkip(long skip) {
+        return set(SKIP, skip);
+    }
+
+    public int getTake() {
+        return (int) params.get(TAKE);
+    }
+
+    public QueryContext<R> setTake(int take) {
+        return set(TAKE, take);
+    }
+
+    public String getInnKpp() {
+        return (String) params.get(INN_KPP);
+    }
+
+    public QueryContext<R> setInnKpp(String innKpp) {
+        return set(INN_KPP, innKpp);
+    }
+
+    public DateTime getUpdatedFrom() {
+        return (DateTime) params.get(UPDATED_FROM);
+    }
+
+    public QueryContext<R> setUpdatedFrom(DateTime updatedFrom) {
+        return set(UPDATED_FROM, updatedFrom);
+    }
+
+    public DateTime getUpdatedTo() {
+        return (DateTime) params.get(UPDATED_TO);
+    }
+
+    public QueryContext<R> setUpdatedTo(DateTime updatedTo) {
+        return set(UPDATED_TO, updatedTo);
+    }
+
+    public DateTime getCreatedFrom() {
+        return (DateTime) params.get(CREATED_FROM);
+    }
+
+    public QueryContext<R> setCreatedFrom(DateTime createdFrom) {
+        return set(CREATED_FROM, createdFrom);
+    }
+
+    public DateTime getCreatedTo() {
+        return (DateTime) params.get(CREATED_TO);
+    }
+
+    public QueryContext<R> setCreatedTo(DateTime createdTo) {
+        return set(CREATED_TO, createdTo);
+    }
+
+    public String getType() {
+        return (String) params.get(TYPE);
+    }
+
+    public QueryContext<R> setType(String type) {
+        return set(TYPE, type);
+    }
+
+    public String getCertificate() {
+        return (String) params.get(CERTIFICATE);
+    }
+
+    public QueryContext<R> setCertificate(String certificate) {
+        return set(CERTIFICATE, certificate);
+    }
+
+    public CertificateList getCertificateList() {
+        return (CertificateList) params.get(CERTIFICATE_LIST);
+    }
+
+    public QueryContext<R> setCertificateList(CertificateList certificateList) {
+        return set(CERTIFICATE_LIST, certificateList);
+    }
+
+    public UsnServiceContractInfo getUsnServiceContractInfo() {
+        return (UsnServiceContractInfo) params.get(USN_SERVICE_CONTRACT_INFO);
+    }
+
+    public QueryContext<R> setUsnServiceContractInfo(UsnServiceContractInfo usnServiceContractInfo) {
+        return set(USN_SERVICE_CONTRACT_INFO, usnServiceContractInfo);
+    }
+
+    public UsnServiceContractInfoV2 getUsnServiceContractInfoV2() {
+        return (UsnServiceContractInfoV2) params.get(USN_SERVICE_CONTRACT_INFO_V2);
+    }
+
+    public QueryContext<R> setUsnServiceContractInfoV2(UsnServiceContractInfoV2 usnServiceContractInfoV2) {
+        return set(USN_SERVICE_CONTRACT_INFO_V2, usnServiceContractInfoV2);
+    }
+
+    public QueryContext<R> set(String name, Object val) {
+        if (val != null) params.put(name, val);
+        else params.remove(name);
+
+        return this;
+    }
+
+    public <T> T get(String name) {
+        return (T) params.get(name);
+    }
+
+    public ApiClient getApiClient() {
+        return apiClient;
+    }
+
+    public void setApiClient(ApiClient apiClient) {
+        this.apiClient = apiClient;
+    }
+
+    private void acceptApiKey(String apiKey) {
+        if (apiKey != null && !apiKey.isEmpty()) {
+            Authentication apiKeyAuth = apiClient.getAuthentication("apiKey");
+            if (apiKeyAuth != null) {
+                ((ApiKeyAuth) apiKeyAuth).setApiKey(apiKey);
+            }
+        }
+    }
+
+    public void configureApiClient() {
+        apiClient.getJSON().setGson(new GsonBuilder()
+                .disableHtmlEscaping()
+                .registerTypeAdapter(Date.class, new DateAdapter(apiClient))
+                .registerTypeAdapter(DateTime.class, new DateTimeTypeAdapter())
+                .registerTypeAdapter(LocalDate.class, new LocalDateTypeAdapter())
+                .registerTypeAdapter(ru.skbkontur.sdk.extern.service.transport.swagger.model.SignatureToSend.class, new SignatureToSendAdapter())
+                .registerTypeAdapter(ru.skbkontur.sdk.extern.service.transport.swagger.model.DocumentToSend.class, new DocumentToSendAdapter())
+                .create());
+        // устанавливаем api-key
+        acceptApiKey(apiKeyProvider.getApiKey());
+        // устанавливаем таймаут соединения
+        apiClient.setConnectTimeout(60 * 1000);
+        // устанавливаем таймаут чтения
+        apiClient.setReadTimeout(60 * 1000);
+    }
+
+    public CompletableFuture<QueryContext<R>> applyAsync(Query<R> query) {
+        if (isFail()) return CompletableFuture.completedFuture(this);
+
+        acquireSessionId();
+
+        if (isSuccess()) {
+            return CompletableFuture.supplyAsync(() -> query.apply(this));
+        } else
+            return CompletableFuture.completedFuture(this);
+    }
+
+    public QueryContext<R> apply(Query<R> query) {
+        if (isFail()) return this;
+
+        acquireSessionId();
+
+        if (isSuccess()) {
+            QueryContext<R> r = query.apply(this);
+            if (r.isFail() && r.getServiceError().getErrorCode() == ErrorCode.server && r.getServiceError().getResponseCode() == HttpsURLConnection.HTTP_UNAUTHORIZED) {
+                if (authenticationProvider != null)
+                    authenticationProvider.raiseUnauthenticated(r.getServiceError());
+            }
+            return r;
+        } else
+            return this;
+    }
+
+    public ServiceException failure() {
+        throw new ServiceException(getServiceError());
+    }
+
+    private void acquireSessionId() {
+        String sessionId = getSessionId();
+        if (sessionId != null && !sessionId.isEmpty()) {
+            acceptAccessToken(sessionId);
+        } else {
+            if (authenticationProvider != null) {
+                QueryContext<String> authQuery = authenticationProvider.sessionId();
+                if (authQuery.isFail()) {
+                    setServiceError(authQuery);
+                } else {
+                    sessionId = setSessionId(authQuery.get()).getSessionId();
+                    acceptAccessToken(sessionId);
+                }
+            } else {
+                setServiceError(new ServiceErrorImpl(ServiceError.ErrorCode.unknownAuth));
+            }
+        }
+    }
+
+    private void acceptAccessToken(String sessionId) {
+        if (sessionId != null && !sessionId.isEmpty()) {
+            Authentication apiKeyAuth = apiClient.getAuthentication("auth.sid");
+            if (apiKeyAuth != null) {
+                ((ApiKeyAuth) apiKeyAuth).setApiKey(sessionId);
+                ((ApiKeyAuth) apiKeyAuth).setApiKeyPrefix(getAuthenticationProvider().authPrefix());
+            }
+        }
+    }
 }

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/ServiceErrorImpl.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/ServiceErrorImpl.java
@@ -1,8 +1,27 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * MIT License
+ *
+ * Copyright (c) 2018 SKB Kontur
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  */
+
 package ru.skbkontur.sdk.extern.service.transport.adaptors;
 
 import ru.skbkontur.sdk.extern.providers.ServiceError;

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/ServiceErrorImpl.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/ServiceErrorImpl.java
@@ -5,97 +5,98 @@
  */
 package ru.skbkontur.sdk.extern.service.transport.adaptors;
 
-import java.util.List;
-import java.util.Map;
 import ru.skbkontur.sdk.extern.providers.ServiceError;
 
+import java.util.List;
+import java.util.Map;
+
+
 /**
- *
  * @author AlexS
  */
 public class ServiceErrorImpl implements ServiceError {
 
-	private ErrorCode errorCode;
+    private ErrorCode errorCode;
 
-	private String message;
+    private String message;
 
-	private int responseCode;
+    private int responseCode;
 
-	private Map<String, List<String>> responseHeaders;
+    private Map<String, List<String>> responseHeaders;
 
-	private String responseBody = null;
-	
-	private Throwable cause;
+    private String responseBody = null;
 
-	public ServiceErrorImpl(ErrorCode errorCode, String message, int responseCode, Map<String, List<String>> responseHeaders, String responseBody, Throwable cause) {
-		this.errorCode = errorCode;
+    private Throwable cause;
 
-		this.message = message;
+    public ServiceErrorImpl(ErrorCode errorCode, String message, int responseCode, Map<String, List<String>> responseHeaders, String responseBody, Throwable cause) {
+        this.errorCode = errorCode;
 
-		this.responseCode = responseCode;
+        this.message = message;
 
-		this.responseHeaders = responseHeaders;
+        this.responseCode = responseCode;
 
-		this.responseBody = responseBody;
-		
-		this.cause = cause;
-	}
-	
-	public ServiceErrorImpl(ErrorCode errorCode, String message, int responseCode, Map<String, List<String>> responseHeaders, String responseBody) {
-		this(errorCode, message, responseCode, responseHeaders, responseBody, null);
-	}
-	
-	public ServiceErrorImpl(ErrorCode errorCode) {
-		this(errorCode, errorCode.message(), 0, null, null);
-	}
+        this.responseHeaders = responseHeaders;
 
-	public ServiceErrorImpl(ErrorCode errorCode, String message) {
-		this(errorCode, message, 0, null, null);
-	}
+        this.responseBody = responseBody;
 
-	public ServiceErrorImpl(String message, int responseCode, Map<String, List<String>> responseHeaders, String responseBody) {
-		this(ErrorCode.server, message, responseCode, responseHeaders, responseBody);
-	}
+        this.cause = cause;
+    }
 
-	@Override
-	public int getResponseCode() {
-		return responseCode;
-	}
+    public ServiceErrorImpl(ErrorCode errorCode, String message, int responseCode, Map<String, List<String>> responseHeaders, String responseBody) {
+        this(errorCode, message, responseCode, responseHeaders, responseBody, null);
+    }
 
-	@Override
-	public String getMessage() {
-		return message;
-	}
+    public ServiceErrorImpl(ErrorCode errorCode) {
+        this(errorCode, errorCode.message(), 0, null, null);
+    }
 
-	@Override
-	public String toString() {
-		final String EOL = "\r\n";
-		StringBuilder errorMsg = new StringBuilder("Message error: ").append(message == null ? errorCode.message() : message).append(EOL);
-		if (responseCode != 0) {
-			errorMsg.append("  Response code: ").append(responseCode).append(EOL);
-			if (responseHeaders!= null) {
-				errorMsg.append("  Headers:").append(EOL);
-				responseHeaders.keySet().forEach((k) -> {
-					List<String> values = responseHeaders.get(k);
-					if (values != null) {
-						StringBuilder headerLine = new StringBuilder("    ").append(k).append(": ");
-						values.forEach((v) -> {
-							headerLine.append(v).append("; ");
-						});
-						errorMsg.append(headerLine).append(EOL);
-					}
-				});
-			}
-			if (responseBody != null) {
-				String cleanText = responseBody.replaceAll("\n", " ").replaceAll("\r", "");
-				errorMsg.append("  Response body: ").append(cleanText).append(EOL);
-			}
-		}
-		return errorMsg.toString();
-	}
+    public ServiceErrorImpl(ErrorCode errorCode, String message) {
+        this(errorCode, message, 0, null, null);
+    }
 
-	@Override
-	public ErrorCode getErrorCode() {
-		return errorCode;
-	}
+    public ServiceErrorImpl(String message, int responseCode, Map<String, List<String>> responseHeaders, String responseBody) {
+        this(ErrorCode.server, message, responseCode, responseHeaders, responseBody);
+    }
+
+    @Override
+    public int getResponseCode() {
+        return responseCode;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+
+    @Override
+    public String toString() {
+        final String EOL = "\r\n";
+        StringBuilder errorMsg = new StringBuilder("Message error: ").append(message == null ? errorCode.message() : message).append(EOL);
+        if (responseCode != 0) {
+            errorMsg.append("  Response code: ").append(responseCode).append(EOL);
+            if (responseHeaders != null) {
+                errorMsg.append("  Headers:").append(EOL);
+                responseHeaders.keySet().forEach((k) -> {
+                    List<String> values = responseHeaders.get(k);
+                    if (values != null) {
+                        StringBuilder headerLine = new StringBuilder("    ").append(k).append(": ");
+                        values.forEach((v) -> {
+                            headerLine.append(v).append("; ");
+                        });
+                        errorMsg.append(headerLine).append(EOL);
+                    }
+                });
+            }
+            if (responseBody != null) {
+                String cleanText = responseBody.replaceAll("\n", " ").replaceAll("\r", "");
+                errorMsg.append("  Response body: ").append(cleanText).append(EOL);
+            }
+        }
+        return errorMsg.toString();
+    }
+
+    @Override
+    public ErrorCode getErrorCode() {
+        return errorCode;
+    }
 }

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/ServiceException.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/ServiceException.java
@@ -1,8 +1,27 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * MIT License
+ *
+ * Copyright (c) 2018 SKB Kontur
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  */
+
 package ru.skbkontur.sdk.extern.service.transport.adaptors;
 
 import ru.skbkontur.sdk.extern.providers.ServiceError;

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/ServiceException.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/ServiceException.java
@@ -7,12 +7,13 @@ package ru.skbkontur.sdk.extern.service.transport.adaptors;
 
 import ru.skbkontur.sdk.extern.providers.ServiceError;
 
+
 /**
- *
  * @author AlexS
  */
 public class ServiceException extends RuntimeException {
-	public ServiceException(ServiceError serviceError) {
-		super(serviceError.toString());
-	}
+
+    public ServiceException(ServiceError serviceError) {
+        super(serviceError.toString());
+    }
 }

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/dto/AccountDto.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/dto/AccountDto.java
@@ -5,58 +5,59 @@
  */
 package ru.skbkontur.sdk.extern.service.transport.adaptors.dto;
 
-import java.util.stream.Collectors;
 import ru.skbkontur.sdk.extern.model.Account;
 
+import java.util.stream.Collectors;
+
+
 /**
- *
  * @author AlexS
  */
 public class AccountDto {
-	
-	public Account fromDto(ru.skbkontur.sdk.extern.service.transport.swagger.model.Account dto) {
-		
-		if (dto == null) return null;
-		
-		Account account = new Account();
-		
-		account.setId(dto.getId());
-		account.setInn(dto.getInn());
-		account.setKpp(dto.getKpp());
-		if (dto.getLinks() != null && !dto.getLinks().isEmpty()) {
-			LinkDto linkDto = new LinkDto();
-			account.setLinks(
-				dto.getLinks()
-					.stream()
-						.map(linkDto::fromDto)
-						.collect(Collectors.toList())
-			);
-		}
-		account.setOrganizationName(dto.getOrganizationName());
-		
-		return account;
-	}
-	
-	public ru.skbkontur.sdk.extern.service.transport.swagger.model.Account toDto(Account account) {
 
-		if (account == null) return null;
-		
-		ru.skbkontur.sdk.extern.service.transport.swagger.model.Account dto = new ru.skbkontur.sdk.extern.service.transport.swagger.model.Account();
-		
-		dto.setId(account.getId());
-		dto.setInn(account.getInn());
-		dto.setKpp(account.getKpp());
-		if (account.getLinks() != null && !account.getLinks().isEmpty()) {
-			LinkDto linkDto = new LinkDto();
-			dto.setLinks(
-				account.getLinks()
-					.stream()
-						.map(linkDto::toDto)
-						.collect(Collectors.toList())
-			);
-		}
-		dto.setOrganizationName(account.getOrganizationName());
-		
-		return dto;
-	}
+    public Account fromDto(ru.skbkontur.sdk.extern.service.transport.swagger.model.Account dto) {
+
+        if (dto == null) return null;
+
+        Account account = new Account();
+
+        account.setId(dto.getId());
+        account.setInn(dto.getInn());
+        account.setKpp(dto.getKpp());
+        if (dto.getLinks() != null && !dto.getLinks().isEmpty()) {
+            LinkDto linkDto = new LinkDto();
+            account.setLinks(
+                    dto.getLinks()
+                            .stream()
+                            .map(linkDto::fromDto)
+                            .collect(Collectors.toList())
+            );
+        }
+        account.setOrganizationName(dto.getOrganizationName());
+
+        return account;
+    }
+
+    public ru.skbkontur.sdk.extern.service.transport.swagger.model.Account toDto(Account account) {
+
+        if (account == null) return null;
+
+        ru.skbkontur.sdk.extern.service.transport.swagger.model.Account dto = new ru.skbkontur.sdk.extern.service.transport.swagger.model.Account();
+
+        dto.setId(account.getId());
+        dto.setInn(account.getInn());
+        dto.setKpp(account.getKpp());
+        if (account.getLinks() != null && !account.getLinks().isEmpty()) {
+            LinkDto linkDto = new LinkDto();
+            dto.setLinks(
+                    account.getLinks()
+                            .stream()
+                            .map(linkDto::toDto)
+                            .collect(Collectors.toList())
+            );
+        }
+        dto.setOrganizationName(account.getOrganizationName());
+
+        return dto;
+    }
 }

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/dto/AccountDto.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/dto/AccountDto.java
@@ -1,8 +1,27 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * MIT License
+ *
+ * Copyright (c) 2018 SKB Kontur
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  */
+
 package ru.skbkontur.sdk.extern.service.transport.adaptors.dto;
 
 import ru.skbkontur.sdk.extern.model.Account;

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/dto/AccountListDto.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/dto/AccountListDto.java
@@ -5,46 +5,47 @@
  */
 package ru.skbkontur.sdk.extern.service.transport.adaptors.dto;
 
-import java.util.stream.Collectors;
 import ru.skbkontur.sdk.extern.model.AccountList;
 
+import java.util.stream.Collectors;
+
+
 /**
- *
  * @author AlexS
  */
 public class AccountListDto {
 
-	public AccountList fromDto(ru.skbkontur.sdk.extern.service.transport.swagger.model.AccountList dto) {
-		
-		if (dto == null) return null;
-		
-		AccountList accountList = new AccountList();
-		
-		if (dto.getAccounts() != null && !dto.getAccounts().isEmpty()) {
-			AccountDto accountDto = new AccountDto();
-			accountList.setAccounts(dto.getAccounts().stream().map(accountDto::fromDto).collect(Collectors.toList()));
-		}
-		accountList.setSkip(dto.getSkip());
-		accountList.setTake(dto.getTake());
-		accountList.setTotalCount(dto.getTotalCount());
-		
-		return accountList;
-	}
+    public AccountList fromDto(ru.skbkontur.sdk.extern.service.transport.swagger.model.AccountList dto) {
 
-	public ru.skbkontur.sdk.extern.service.transport.swagger.model.AccountList toDto(AccountList accountList) {
-		
-		if (accountList == null) return null;
-		
-		ru.skbkontur.sdk.extern.service.transport.swagger.model.AccountList dto = new ru.skbkontur.sdk.extern.service.transport.swagger.model.AccountList();
-		
-		if (accountList.getAccounts() != null && !accountList.getAccounts().isEmpty()) {
-			AccountDto accountDto = new AccountDto();
-			dto.setAccounts(accountList.getAccounts().stream().map(accountDto::toDto).collect(Collectors.toList()));
-		}
-		dto.setSkip(accountList.getSkip());
-		dto.setTake(accountList.getTake());
-		dto.setTotalCount(accountList.getTotalCount());
-		
-		return dto;
-	}
+        if (dto == null) return null;
+
+        AccountList accountList = new AccountList();
+
+        if (dto.getAccounts() != null && !dto.getAccounts().isEmpty()) {
+            AccountDto accountDto = new AccountDto();
+            accountList.setAccounts(dto.getAccounts().stream().map(accountDto::fromDto).collect(Collectors.toList()));
+        }
+        accountList.setSkip(dto.getSkip());
+        accountList.setTake(dto.getTake());
+        accountList.setTotalCount(dto.getTotalCount());
+
+        return accountList;
+    }
+
+    public ru.skbkontur.sdk.extern.service.transport.swagger.model.AccountList toDto(AccountList accountList) {
+
+        if (accountList == null) return null;
+
+        ru.skbkontur.sdk.extern.service.transport.swagger.model.AccountList dto = new ru.skbkontur.sdk.extern.service.transport.swagger.model.AccountList();
+
+        if (accountList.getAccounts() != null && !accountList.getAccounts().isEmpty()) {
+            AccountDto accountDto = new AccountDto();
+            dto.setAccounts(accountList.getAccounts().stream().map(accountDto::toDto).collect(Collectors.toList()));
+        }
+        dto.setSkip(accountList.getSkip());
+        dto.setTake(accountList.getTake());
+        dto.setTotalCount(accountList.getTotalCount());
+
+        return dto;
+    }
 }

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/dto/AccountListDto.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/dto/AccountListDto.java
@@ -1,8 +1,27 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * MIT License
+ *
+ * Copyright (c) 2018 SKB Kontur
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  */
+
 package ru.skbkontur.sdk.extern.service.transport.adaptors.dto;
 
 import ru.skbkontur.sdk.extern.model.AccountList;

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/dto/AdditionalClientInfoDto.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/dto/AdditionalClientInfoDto.java
@@ -1,8 +1,27 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * MIT License
+ *
+ * Copyright (c) 2018 SKB Kontur
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  */
+
 package ru.skbkontur.sdk.extern.service.transport.adaptors.dto;
 
 import ru.skbkontur.sdk.extern.model.AdditionalClientInfo;

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/dto/AdditionalClientInfoDto.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/dto/AdditionalClientInfoDto.java
@@ -7,45 +7,45 @@ package ru.skbkontur.sdk.extern.service.transport.adaptors.dto;
 
 import ru.skbkontur.sdk.extern.model.AdditionalClientInfo;
 
+
 /**
- *
  * @author alexs
  */
 public class AdditionalClientInfoDto {
 
-	public AdditionalClientInfo fromDto(ru.skbkontur.sdk.extern.service.transport.swagger.model.AdditionalClientInfo dto) {
-		
-		if (dto == null) return null;
-		
-		AdditionalClientInfo info = new AdditionalClientInfo();
-		
-		TaxpayerDto taxpayerDto = new TaxpayerDto();
-		
-		info.setSenderFullName(dto.getDocumentSender().getSenderFullName());
-		info.setSignerType(AdditionalClientInfo.SignerTypeEnum.fromValue(dto.getSignerType().getValue()));
-		info.setTaxpayer(taxpayerDto.fromDto(dto.getTaxpayer()));
-		
-		return info;
-	}
+    public AdditionalClientInfo fromDto(ru.skbkontur.sdk.extern.service.transport.swagger.model.AdditionalClientInfo dto) {
 
-	public ru.skbkontur.sdk.extern.service.transport.swagger.model.AdditionalClientInfo toDto(AdditionalClientInfo info) {
-		
-		if (info == null) return null;
-		
-		ru.skbkontur.sdk.extern.service.transport.swagger.model.AdditionalClientInfo dto 
-			= new ru.skbkontur.sdk.extern.service.transport.swagger.model.AdditionalClientInfo();
-		
-		TaxpayerDto taxpayerDto = new TaxpayerDto();
-		
-		ru.skbkontur.sdk.extern.service.transport.swagger.model.DocumentSender sender
-			= new ru.skbkontur.sdk.extern.service.transport.swagger.model.DocumentSender();
-		
-		sender.setSenderFullName(info.getSenderFullName());
-		
-		dto.setDocumentSender(sender);
-		dto.setSignerType(ru.skbkontur.sdk.extern.service.transport.swagger.model.AdditionalClientInfo.SignerTypeEnum.fromValue(info.getSignerType().getValue()));
-		dto.setTaxpayer(taxpayerDto.toDto(info.getTaxpayer()));
-		
-		return dto;
-	}
+        if (dto == null) return null;
+
+        AdditionalClientInfo info = new AdditionalClientInfo();
+
+        TaxpayerDto taxpayerDto = new TaxpayerDto();
+
+        info.setSenderFullName(dto.getDocumentSender().getSenderFullName());
+        info.setSignerType(AdditionalClientInfo.SignerTypeEnum.fromValue(dto.getSignerType().getValue()));
+        info.setTaxpayer(taxpayerDto.fromDto(dto.getTaxpayer()));
+
+        return info;
+    }
+
+    public ru.skbkontur.sdk.extern.service.transport.swagger.model.AdditionalClientInfo toDto(AdditionalClientInfo info) {
+
+        if (info == null) return null;
+
+        ru.skbkontur.sdk.extern.service.transport.swagger.model.AdditionalClientInfo dto
+                = new ru.skbkontur.sdk.extern.service.transport.swagger.model.AdditionalClientInfo();
+
+        TaxpayerDto taxpayerDto = new TaxpayerDto();
+
+        ru.skbkontur.sdk.extern.service.transport.swagger.model.DocumentSender sender
+                = new ru.skbkontur.sdk.extern.service.transport.swagger.model.DocumentSender();
+
+        sender.setSenderFullName(info.getSenderFullName());
+
+        dto.setDocumentSender(sender);
+        dto.setSignerType(ru.skbkontur.sdk.extern.service.transport.swagger.model.AdditionalClientInfo.SignerTypeEnum.fromValue(info.getSignerType().getValue()));
+        dto.setTaxpayer(taxpayerDto.toDto(info.getTaxpayer()));
+
+        return dto;
+    }
 }

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/dto/CertificateDto.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/dto/CertificateDto.java
@@ -7,43 +7,44 @@ package ru.skbkontur.sdk.extern.service.transport.adaptors.dto;
 
 import ru.skbkontur.sdk.extern.model.Certificate;
 
+
 /**
- *
  * @author alexs
  */
 public class CertificateDto {
-	public Certificate fromDto(ru.skbkontur.sdk.extern.service.transport.swagger.model.CertificateDto dto) {
-		
-		if (dto == null) return null;
-		
-		Certificate cert = new Certificate();
-		
-		cert.setContent(dto.getContent());
-		cert.setFio(dto.getFio());
-		cert.setInn(dto.getInn());
-		cert.setIsCloud(dto.getIsCloud());
-		cert.setIsQualified(dto.getIsQualified());
-		cert.setIsValid(dto.getIsValid());
-		cert.setKpp(dto.getKpp());
-		
-		return cert;
-	}
 
-	public ru.skbkontur.sdk.extern.service.transport.swagger.model.CertificateDto toDto(Certificate cert) {
+    public Certificate fromDto(ru.skbkontur.sdk.extern.service.transport.swagger.model.CertificateDto dto) {
 
-		if (cert == null) return null;
-		
-		ru.skbkontur.sdk.extern.service.transport.swagger.model.CertificateDto dto 
-			= new ru.skbkontur.sdk.extern.service.transport.swagger.model.CertificateDto();
-		
-		dto.setContent(cert.getContent());
-		dto.setFio(cert.getFio());
-		dto.setInn(cert.getInn());
-		dto.setIsCloud(cert.getIsCloud());
-		dto.setIsQualified(cert.getIsQualified());
-		dto.setIsValid(cert.getIsValid());
-		dto.setKpp(cert.getKpp());
-		
-		return dto;
-	}
+        if (dto == null) return null;
+
+        Certificate cert = new Certificate();
+
+        cert.setContent(dto.getContent());
+        cert.setFio(dto.getFio());
+        cert.setInn(dto.getInn());
+        cert.setIsCloud(dto.getIsCloud());
+        cert.setIsQualified(dto.getIsQualified());
+        cert.setIsValid(dto.getIsValid());
+        cert.setKpp(dto.getKpp());
+
+        return cert;
+    }
+
+    public ru.skbkontur.sdk.extern.service.transport.swagger.model.CertificateDto toDto(Certificate cert) {
+
+        if (cert == null) return null;
+
+        ru.skbkontur.sdk.extern.service.transport.swagger.model.CertificateDto dto
+                = new ru.skbkontur.sdk.extern.service.transport.swagger.model.CertificateDto();
+
+        dto.setContent(cert.getContent());
+        dto.setFio(cert.getFio());
+        dto.setInn(cert.getInn());
+        dto.setIsCloud(cert.getIsCloud());
+        dto.setIsQualified(cert.getIsQualified());
+        dto.setIsValid(cert.getIsValid());
+        dto.setKpp(cert.getKpp());
+
+        return dto;
+    }
 }

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/dto/CertificateDto.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/dto/CertificateDto.java
@@ -1,8 +1,27 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * MIT License
+ *
+ * Copyright (c) 2018 SKB Kontur
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  */
+
 package ru.skbkontur.sdk.extern.service.transport.adaptors.dto;
 
 import ru.skbkontur.sdk.extern.model.Certificate;

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/dto/CertificateListDto.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/dto/CertificateListDto.java
@@ -1,8 +1,27 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * MIT License
+ *
+ * Copyright (c) 2018 SKB Kontur
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  */
+
 package ru.skbkontur.sdk.extern.service.transport.adaptors.dto;
 
 import ru.skbkontur.sdk.extern.model.CertificateList;

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/dto/CertificateListDto.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/dto/CertificateListDto.java
@@ -5,45 +5,46 @@
  */
 package ru.skbkontur.sdk.extern.service.transport.adaptors.dto;
 
-import java.util.stream.Collectors;
 import ru.skbkontur.sdk.extern.model.CertificateList;
 
+import java.util.stream.Collectors;
+
+
 /**
- *
  * @author alexs
  */
 public class CertificateListDto {
-	
-	public CertificateList fromDto(ru.skbkontur.sdk.extern.service.transport.swagger.model.CertificateList dto) {
 
-		if (dto == null) return null;
-		
-		CertificateList certs = new CertificateList();
-		
-		CertificateDto certificateDto = new CertificateDto();
-		
-		certs.setCertificates(dto.getCertificates().stream().map(certificateDto::fromDto).collect(Collectors.toList()));
-		certs.setPageIndex(dto.getPageIndex());
-		certs.setPageSize(dto.getPageSize());
-		certs.setTotalCount(dto.getTotalCount());
-		
-		return certs;
-	}
+    public CertificateList fromDto(ru.skbkontur.sdk.extern.service.transport.swagger.model.CertificateList dto) {
 
-	public ru.skbkontur.sdk.extern.service.transport.swagger.model.CertificateList toDto(CertificateList certs) {
+        if (dto == null) return null;
 
-		if (certs == null) return null;
-		
-		ru.skbkontur.sdk.extern.service.transport.swagger.model.CertificateList dto 
-			= new ru.skbkontur.sdk.extern.service.transport.swagger.model.CertificateList();
-		
-		CertificateDto certificateDto = new CertificateDto();
-		
-		dto.setCertificates(certs.getCertificates().stream().map(certificateDto::toDto).collect(Collectors.toList()));
-		dto.setPageIndex(certs.getPageIndex());
-		dto.setPageSize(certs.getPageSize());
-		dto.setTotalCount(certs.getTotalCount());
-		
-		return dto;
-	}
+        CertificateList certs = new CertificateList();
+
+        CertificateDto certificateDto = new CertificateDto();
+
+        certs.setCertificates(dto.getCertificates().stream().map(certificateDto::fromDto).collect(Collectors.toList()));
+        certs.setPageIndex(dto.getPageIndex());
+        certs.setPageSize(dto.getPageSize());
+        certs.setTotalCount(dto.getTotalCount());
+
+        return certs;
+    }
+
+    public ru.skbkontur.sdk.extern.service.transport.swagger.model.CertificateList toDto(CertificateList certs) {
+
+        if (certs == null) return null;
+
+        ru.skbkontur.sdk.extern.service.transport.swagger.model.CertificateList dto
+                = new ru.skbkontur.sdk.extern.service.transport.swagger.model.CertificateList();
+
+        CertificateDto certificateDto = new CertificateDto();
+
+        dto.setCertificates(certs.getCertificates().stream().map(certificateDto::toDto).collect(Collectors.toList()));
+        dto.setPageIndex(certs.getPageIndex());
+        dto.setPageSize(certs.getPageSize());
+        dto.setTotalCount(certs.getTotalCount());
+
+        return dto;
+    }
 }

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/dto/CheckErrorDto.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/dto/CheckErrorDto.java
@@ -1,8 +1,27 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * MIT License
+ *
+ * Copyright (c) 2018 SKB Kontur
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  */
+
 package ru.skbkontur.sdk.extern.service.transport.adaptors.dto;
 
 /**

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/dto/CheckErrorDto.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/dto/CheckErrorDto.java
@@ -6,42 +6,41 @@
 package ru.skbkontur.sdk.extern.service.transport.adaptors.dto;
 
 /**
- *
  * @author AlexS
  */
 public class CheckErrorDto {
 
-	public CheckErrorDto() {
+    public CheckErrorDto() {
 
-	}
+    }
 
-	public ru.skbkontur.sdk.extern.model.CheckError fromDto(ru.skbkontur.sdk.extern.service.transport.swagger.model.CheckError dto) {
+    public ru.skbkontur.sdk.extern.model.CheckError fromDto(ru.skbkontur.sdk.extern.service.transport.swagger.model.CheckError dto) {
 
-		if (dto == null) return null;
+        if (dto == null) return null;
 
-		ru.skbkontur.sdk.extern.model.CheckError checkError = new ru.skbkontur.sdk.extern.model.CheckError();
-		checkError.setDescription(dto.getDescription());
-		checkError.setId(dto.getId());
-		checkError.setLevel(dto.getLevel());
-		checkError.setTags(dto.getTags());
-		checkError.setType(dto.getType());
+        ru.skbkontur.sdk.extern.model.CheckError checkError = new ru.skbkontur.sdk.extern.model.CheckError();
+        checkError.setDescription(dto.getDescription());
+        checkError.setId(dto.getId());
+        checkError.setLevel(dto.getLevel());
+        checkError.setTags(dto.getTags());
+        checkError.setType(dto.getType());
 
-		return checkError;
-	}
+        return checkError;
+    }
 
-	public ru.skbkontur.sdk.extern.service.transport.swagger.model.CheckError toDto(ru.skbkontur.sdk.extern.model.CheckError checkError) {
+    public ru.skbkontur.sdk.extern.service.transport.swagger.model.CheckError toDto(ru.skbkontur.sdk.extern.model.CheckError checkError) {
 
-		if (checkError == null)	return null;
+        if (checkError == null) return null;
 
-		ru.skbkontur.sdk.extern.service.transport.swagger.model.CheckError dto
-			= new ru.skbkontur.sdk.extern.service.transport.swagger.model.CheckError();
-		dto.setDescription(checkError.getDescription());
-		dto.setId(checkError.getId());
-		dto.setLevel(checkError.getLevel());
-		dto.setTags(checkError.getTags());
-		dto.setType(checkError.getType());
+        ru.skbkontur.sdk.extern.service.transport.swagger.model.CheckError dto
+                = new ru.skbkontur.sdk.extern.service.transport.swagger.model.CheckError();
+        dto.setDescription(checkError.getDescription());
+        dto.setId(checkError.getId());
+        dto.setLevel(checkError.getLevel());
+        dto.setTags(checkError.getTags());
+        dto.setType(checkError.getType());
 
-		return dto;
-	}
+        return dto;
+    }
 
 }

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/dto/CheckResultDataDto.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/dto/CheckResultDataDto.java
@@ -1,8 +1,27 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * MIT License
+ *
+ * Copyright (c) 2018 SKB Kontur
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  */
+
 package ru.skbkontur.sdk.extern.service.transport.adaptors.dto;
 
 import java.util.Map;

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/dto/CheckResultDataDto.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/dto/CheckResultDataDto.java
@@ -8,56 +8,56 @@ package ru.skbkontur.sdk.extern.service.transport.adaptors.dto;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+
 /**
- *
  * @author AlexS
  */
 public class CheckResultDataDto {
 
-	public ru.skbkontur.sdk.extern.model.CheckResultData fromDto(ru.skbkontur.sdk.extern.service.transport.swagger.model.CheckResultData dto) {
+    public ru.skbkontur.sdk.extern.model.CheckResultData fromDto(ru.skbkontur.sdk.extern.service.transport.swagger.model.CheckResultData dto) {
 
-		if (dto == null) return null;
+        if (dto == null) return null;
 
-		ru.skbkontur.sdk.extern.model.CheckResultData checkResultData
-			= new ru.skbkontur.sdk.extern.model.CheckResultData();
+        ru.skbkontur.sdk.extern.model.CheckResultData checkResultData
+                = new ru.skbkontur.sdk.extern.model.CheckResultData();
 
-		CheckErrorDto checkErrorDto = new CheckErrorDto();
+        CheckErrorDto checkErrorDto = new CheckErrorDto();
 
-		if (dto.getCommonErrors() != null) {
-			checkResultData.setCommonErrors(dto.getCommonErrors().stream().map(e -> checkErrorDto.fromDto(e)).collect(Collectors.toList()));
-		}
+        if (dto.getCommonErrors() != null) {
+            checkResultData.setCommonErrors(dto.getCommonErrors().stream().map(e -> checkErrorDto.fromDto(e)).collect(Collectors.toList()));
+        }
 
-		if (dto.getDocumentsErrors() != null) {
-			checkResultData.setDocumentsErrors(
-				dto.getDocumentsErrors().entrySet().stream().collect(
-					Collectors.toMap(Map.Entry::getKey, l -> l.getValue().stream().map(e -> checkErrorDto.fromDto(e)).collect(Collectors.toList()))
-				)
-			);
-		}
-		return checkResultData;
-	}
+        if (dto.getDocumentsErrors() != null) {
+            checkResultData.setDocumentsErrors(
+                    dto.getDocumentsErrors().entrySet().stream().collect(
+                            Collectors.toMap(Map.Entry::getKey, l -> l.getValue().stream().map(e -> checkErrorDto.fromDto(e)).collect(Collectors.toList()))
+                    )
+            );
+        }
+        return checkResultData;
+    }
 
-	public ru.skbkontur.sdk.extern.service.transport.swagger.model.CheckResultData toDto(ru.skbkontur.sdk.extern.model.CheckResultData checkResultData) {
+    public ru.skbkontur.sdk.extern.service.transport.swagger.model.CheckResultData toDto(ru.skbkontur.sdk.extern.model.CheckResultData checkResultData) {
 
-		if (checkResultData == null) return null;
+        if (checkResultData == null) return null;
 
-		ru.skbkontur.sdk.extern.service.transport.swagger.model.CheckResultData dto
-			= new ru.skbkontur.sdk.extern.service.transport.swagger.model.CheckResultData();
+        ru.skbkontur.sdk.extern.service.transport.swagger.model.CheckResultData dto
+                = new ru.skbkontur.sdk.extern.service.transport.swagger.model.CheckResultData();
 
-		CheckErrorDto checkErrorDto = new CheckErrorDto();
+        CheckErrorDto checkErrorDto = new CheckErrorDto();
 
-		if (checkResultData.getCommonErrors() != null) {
-			dto.setCommonErrors(checkResultData.getCommonErrors().stream().map(e -> checkErrorDto.toDto(e)).collect(Collectors.toList()));
-		}
+        if (checkResultData.getCommonErrors() != null) {
+            dto.setCommonErrors(checkResultData.getCommonErrors().stream().map(e -> checkErrorDto.toDto(e)).collect(Collectors.toList()));
+        }
 
-		if (checkResultData.getDocumentsErrors() != null) {
-			dto.setDocumentsErrors(
-				checkResultData.getDocumentsErrors().entrySet().stream().collect(
-					Collectors.toMap(Map.Entry::getKey, l -> l.getValue().stream().map(e -> checkErrorDto.toDto(e)).collect(Collectors.toList()))
-				)
-			);
-		}
+        if (checkResultData.getDocumentsErrors() != null) {
+            dto.setDocumentsErrors(
+                    checkResultData.getDocumentsErrors().entrySet().stream().collect(
+                            Collectors.toMap(Map.Entry::getKey, l -> l.getValue().stream().map(e -> checkErrorDto.toDto(e)).collect(Collectors.toList()))
+                    )
+            );
+        }
 
-		return dto;
-	}
+        return dto;
+    }
 }

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/dto/ContentDto.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/dto/ContentDto.java
@@ -6,34 +6,33 @@
 package ru.skbkontur.sdk.extern.service.transport.adaptors.dto;
 
 /**
- *
  * @author AlexS
  */
 public class ContentDto {
 
-	public ru.skbkontur.sdk.extern.model.Content fromDto(ru.skbkontur.sdk.extern.service.transport.swagger.model.Content dto) {
+    public ru.skbkontur.sdk.extern.model.Content fromDto(ru.skbkontur.sdk.extern.service.transport.swagger.model.Content dto) {
 
-		if (dto == null) return null;
+        if (dto == null) return null;
 
-		LinkDto linkDto = new LinkDto();
-		ru.skbkontur.sdk.extern.model.Content content = new ru.skbkontur.sdk.extern.model.Content();
-		content.setDecrypted(linkDto.fromDto(dto.getDecrypted()));
-		content.setEncrypted(linkDto.fromDto(dto.getEncrypted()));
+        LinkDto linkDto = new LinkDto();
+        ru.skbkontur.sdk.extern.model.Content content = new ru.skbkontur.sdk.extern.model.Content();
+        content.setDecrypted(linkDto.fromDto(dto.getDecrypted()));
+        content.setEncrypted(linkDto.fromDto(dto.getEncrypted()));
 
-		return content;
-	}
+        return content;
+    }
 
-	public ru.skbkontur.sdk.extern.service.transport.swagger.model.Content toDto(ru.skbkontur.sdk.extern.model.Content content) {
+    public ru.skbkontur.sdk.extern.service.transport.swagger.model.Content toDto(ru.skbkontur.sdk.extern.model.Content content) {
 
-		if (content == null) return null;
+        if (content == null) return null;
 
-		LinkDto linkDto = new LinkDto();
-		ru.skbkontur.sdk.extern.service.transport.swagger.model.Content dto
-			= new ru.skbkontur.sdk.extern.service.transport.swagger.model.Content();
-		dto.setDecrypted(linkDto.toDto(content.getDecrypted()));
-		dto.setEncrypted(linkDto.toDto(content.getEncrypted()));
+        LinkDto linkDto = new LinkDto();
+        ru.skbkontur.sdk.extern.service.transport.swagger.model.Content dto
+                = new ru.skbkontur.sdk.extern.service.transport.swagger.model.Content();
+        dto.setDecrypted(linkDto.toDto(content.getDecrypted()));
+        dto.setEncrypted(linkDto.toDto(content.getEncrypted()));
 
-		return dto;
-	}
+        return dto;
+    }
 
 }

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/dto/ContentDto.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/dto/ContentDto.java
@@ -1,8 +1,27 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * MIT License
+ *
+ * Copyright (c) 2018 SKB Kontur
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  */
+
 package ru.skbkontur.sdk.extern.service.transport.adaptors.dto;
 
 /**

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/dto/CreateAccountRequestDto.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/dto/CreateAccountRequestDto.java
@@ -1,8 +1,27 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * MIT License
+ *
+ * Copyright (c) 2018 SKB Kontur
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  */
+
 package ru.skbkontur.sdk.extern.service.transport.adaptors.dto;
 
 import ru.skbkontur.sdk.extern.model.CreateAccountRequest;

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/dto/CreateAccountRequestDto.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/dto/CreateAccountRequestDto.java
@@ -7,35 +7,35 @@ package ru.skbkontur.sdk.extern.service.transport.adaptors.dto;
 
 import ru.skbkontur.sdk.extern.model.CreateAccountRequest;
 
+
 /**
- *
  * @author AlexS
  */
 public class CreateAccountRequestDto {
-	
-	public CreateAccountRequest fromDto(ru.skbkontur.sdk.extern.service.transport.swagger.model.CreateAccountRequestDto dto) {
 
-		if (dto == null) return null;
+    public CreateAccountRequest fromDto(ru.skbkontur.sdk.extern.service.transport.swagger.model.CreateAccountRequestDto dto) {
 
-		CreateAccountRequest request = new CreateAccountRequest();
-		
-		request.setInn(dto.getInn());
-		request.setKpp(dto.getKpp());
-		request.setOrganizationName(dto.getOrganizationName());
-		
-		return request;
-	}
+        if (dto == null) return null;
 
-	public ru.skbkontur.sdk.extern.service.transport.swagger.model.CreateAccountRequestDto toDto(CreateAccountRequest request) {
+        CreateAccountRequest request = new CreateAccountRequest();
 
-		if (request == null) return null;
+        request.setInn(dto.getInn());
+        request.setKpp(dto.getKpp());
+        request.setOrganizationName(dto.getOrganizationName());
 
-		ru.skbkontur.sdk.extern.service.transport.swagger.model.CreateAccountRequestDto dto = new ru.skbkontur.sdk.extern.service.transport.swagger.model.CreateAccountRequestDto();
-		
-		dto.setInn(request.getInn());
-		dto.setKpp(request.getKpp());
-		dto.setOrganizationName(request.getOrganizationName());
-		
-		return dto;
-	}
+        return request;
+    }
+
+    public ru.skbkontur.sdk.extern.service.transport.swagger.model.CreateAccountRequestDto toDto(CreateAccountRequest request) {
+
+        if (request == null) return null;
+
+        ru.skbkontur.sdk.extern.service.transport.swagger.model.CreateAccountRequestDto dto = new ru.skbkontur.sdk.extern.service.transport.swagger.model.CreateAccountRequestDto();
+
+        dto.setInn(request.getInn());
+        dto.setKpp(request.getKpp());
+        dto.setOrganizationName(request.getOrganizationName());
+
+        return dto;
+    }
 }

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/dto/DocflowDto.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/dto/DocflowDto.java
@@ -1,8 +1,27 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * MIT License
+ *
+ * Copyright (c) 2018 SKB Kontur
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  */
+
 package ru.skbkontur.sdk.extern.service.transport.adaptors.dto;
 
 import java.util.stream.Collectors;

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/dto/DocflowDto.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/dto/DocflowDto.java
@@ -7,72 +7,72 @@ package ru.skbkontur.sdk.extern.service.transport.adaptors.dto;
 
 import java.util.stream.Collectors;
 
+
 /**
- *
  * @author AlexS
  */
 public class DocflowDto {
 
-	public ru.skbkontur.sdk.extern.model.Docflow fromDto(ru.skbkontur.sdk.extern.service.transport.swagger.model.Docflow dto) {
+    public ru.skbkontur.sdk.extern.model.Docflow fromDto(ru.skbkontur.sdk.extern.service.transport.swagger.model.Docflow dto) {
 
-		if (dto == null) return null;
+        if (dto == null) return null;
 
-		ru.skbkontur.sdk.extern.model.Docflow docflow = new ru.skbkontur.sdk.extern.model.Docflow();
+        ru.skbkontur.sdk.extern.model.Docflow docflow = new ru.skbkontur.sdk.extern.model.Docflow();
 
-		docflow.setDescription(new ru.skbkontur.sdk.extern.model.DocflowDescription());
+        docflow.setDescription(new ru.skbkontur.sdk.extern.model.DocflowDescription());
 
-		if (dto.getDocuments() != null) {
-			DocumentDto documentDto = new DocumentDto();
-			docflow.setDocuments(dto.getDocuments().stream().map(d -> documentDto.fromDto(d)).collect(Collectors.toList()));
-		}
+        if (dto.getDocuments() != null) {
+            DocumentDto documentDto = new DocumentDto();
+            docflow.setDocuments(dto.getDocuments().stream().map(d -> documentDto.fromDto(d)).collect(Collectors.toList()));
+        }
 
-		docflow.setId(dto.getId());
+        docflow.setId(dto.getId());
 
-		docflow.setLastChangeDate(dto.getLastChangeDate());
+        docflow.setLastChangeDate(dto.getLastChangeDate());
 
-		if (dto.getLinks() != null) {
-			LinkDto linkDto = new LinkDto();
-			docflow.setLinks(dto.getLinks().stream().map(l -> linkDto.fromDto(l)).collect(Collectors.toList()));
-		}
+        if (dto.getLinks() != null) {
+            LinkDto linkDto = new LinkDto();
+            docflow.setLinks(dto.getLinks().stream().map(l -> linkDto.fromDto(l)).collect(Collectors.toList()));
+        }
 
-		docflow.setSendDate(dto.getSendDate());
+        docflow.setSendDate(dto.getSendDate());
 
-		docflow.setStatus(dto.getStatus());
+        docflow.setStatus(dto.getStatus());
 
-		docflow.setType(dto.getType());
+        docflow.setType(dto.getType());
 
-		return docflow;
-	}
+        return docflow;
+    }
 
-	public ru.skbkontur.sdk.extern.service.transport.swagger.model.Docflow toDto(ru.skbkontur.sdk.extern.model.Docflow docflow) {
+    public ru.skbkontur.sdk.extern.service.transport.swagger.model.Docflow toDto(ru.skbkontur.sdk.extern.model.Docflow docflow) {
 
-		if (docflow == null) return null;
+        if (docflow == null) return null;
 
-		ru.skbkontur.sdk.extern.service.transport.swagger.model.Docflow dto
-			= new ru.skbkontur.sdk.extern.service.transport.swagger.model.Docflow();
+        ru.skbkontur.sdk.extern.service.transport.swagger.model.Docflow dto
+                = new ru.skbkontur.sdk.extern.service.transport.swagger.model.Docflow();
 
-		dto.setDescription(new ru.skbkontur.sdk.extern.service.transport.swagger.model.DocflowDescription());
+        dto.setDescription(new ru.skbkontur.sdk.extern.service.transport.swagger.model.DocflowDescription());
 
-		if (docflow.getDocuments() != null) {
-			DocumentDto documentDto = new DocumentDto();
-			dto.setDocuments(docflow.getDocuments().stream().map(d -> documentDto.toDto(d)).collect(Collectors.toList()));
-		}
+        if (docflow.getDocuments() != null) {
+            DocumentDto documentDto = new DocumentDto();
+            dto.setDocuments(docflow.getDocuments().stream().map(d -> documentDto.toDto(d)).collect(Collectors.toList()));
+        }
 
-		dto.setId(docflow.getId());
+        dto.setId(docflow.getId());
 
-		dto.setLastChangeDate(docflow.getLastChangeDate());
+        dto.setLastChangeDate(docflow.getLastChangeDate());
 
-		if (docflow.getLinks() != null) {
-			LinkDto linkDto = new LinkDto();
-			dto.setLinks(docflow.getLinks().stream().map(l -> linkDto.toDto(l)).collect(Collectors.toList()));
-		}
+        if (docflow.getLinks() != null) {
+            LinkDto linkDto = new LinkDto();
+            dto.setLinks(docflow.getLinks().stream().map(l -> linkDto.toDto(l)).collect(Collectors.toList()));
+        }
 
-		dto.setSendDate(docflow.getSendDate());
+        dto.setSendDate(docflow.getSendDate());
 
-		dto.setStatus(docflow.getStatus());
+        dto.setStatus(docflow.getStatus());
 
-		dto.setType(docflow.getType());
+        dto.setType(docflow.getType());
 
-		return dto;
-	}
+        return dto;
+    }
 }

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/dto/DocflowPageDto.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/dto/DocflowPageDto.java
@@ -5,45 +5,46 @@
  */
 package ru.skbkontur.sdk.extern.service.transport.adaptors.dto;
 
-import java.util.stream.Collectors;
 import ru.skbkontur.sdk.extern.model.DocflowPage;
 
+import java.util.stream.Collectors;
+
+
 /**
- *
  * @author alexs
  */
 public class DocflowPageDto {
-	
-	public DocflowPage fromDto(ru.skbkontur.sdk.extern.service.transport.swagger.model.DocflowPage dto) {
 
-		if (dto == null) return null;
-		
-		DocflowPage docflowPage = new DocflowPage();
-		
-		DocflowPageItemDto docflowPageItemDto = new DocflowPageItemDto();
-		
-		docflowPage.setDocflowsPageItem(dto.getDocflowsPageItem().stream().map(docflowPageItemDto::fromDto).collect(Collectors.toList()));
-		docflowPage.setSkip(dto.getSkip());
-		docflowPage.setTake(dto.getTake());
-		docflowPage.setTotalCount(dto.getTotalCount());
-		
-		return docflowPage;
-	}
-	
-	public ru.skbkontur.sdk.extern.service.transport.swagger.model.DocflowPage toDto(DocflowPage docflowPage) {
+    public DocflowPage fromDto(ru.skbkontur.sdk.extern.service.transport.swagger.model.DocflowPage dto) {
 
-		if (docflowPage == null) return null;
-		
-		ru.skbkontur.sdk.extern.service.transport.swagger.model.DocflowPage dto 
-			= new ru.skbkontur.sdk.extern.service.transport.swagger.model.DocflowPage();
-		
-		DocflowPageItemDto docflowPageItemDto = new DocflowPageItemDto();
-		
-		dto.setDocflowsPageItem(docflowPage.getDocflowsPageItem().stream().map(docflowPageItemDto::toDto).collect(Collectors.toList()));
-		dto.setSkip(docflowPage.getSkip());
-		dto.setTake(docflowPage.getTake());
-		dto.setTotalCount(docflowPage.getTotalCount());
-		
-		return dto;
-	}
+        if (dto == null) return null;
+
+        DocflowPage docflowPage = new DocflowPage();
+
+        DocflowPageItemDto docflowPageItemDto = new DocflowPageItemDto();
+
+        docflowPage.setDocflowsPageItem(dto.getDocflowsPageItem().stream().map(docflowPageItemDto::fromDto).collect(Collectors.toList()));
+        docflowPage.setSkip(dto.getSkip());
+        docflowPage.setTake(dto.getTake());
+        docflowPage.setTotalCount(dto.getTotalCount());
+
+        return docflowPage;
+    }
+
+    public ru.skbkontur.sdk.extern.service.transport.swagger.model.DocflowPage toDto(DocflowPage docflowPage) {
+
+        if (docflowPage == null) return null;
+
+        ru.skbkontur.sdk.extern.service.transport.swagger.model.DocflowPage dto
+                = new ru.skbkontur.sdk.extern.service.transport.swagger.model.DocflowPage();
+
+        DocflowPageItemDto docflowPageItemDto = new DocflowPageItemDto();
+
+        dto.setDocflowsPageItem(docflowPage.getDocflowsPageItem().stream().map(docflowPageItemDto::toDto).collect(Collectors.toList()));
+        dto.setSkip(docflowPage.getSkip());
+        dto.setTake(docflowPage.getTake());
+        dto.setTotalCount(docflowPage.getTotalCount());
+
+        return dto;
+    }
 }

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/dto/DocflowPageDto.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/dto/DocflowPageDto.java
@@ -1,8 +1,27 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * MIT License
+ *
+ * Copyright (c) 2018 SKB Kontur
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  */
+
 package ru.skbkontur.sdk.extern.service.transport.adaptors.dto;
 
 import ru.skbkontur.sdk.extern.model.DocflowPage;

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/dto/DocflowPageItemDto.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/dto/DocflowPageItemDto.java
@@ -1,8 +1,27 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * MIT License
+ *
+ * Copyright (c) 2018 SKB Kontur
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  */
+
 package ru.skbkontur.sdk.extern.service.transport.adaptors.dto;
 
 import ru.skbkontur.sdk.extern.model.DocflowPageItem;

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/dto/DocflowPageItemDto.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/dto/DocflowPageItemDto.java
@@ -5,49 +5,50 @@
  */
 package ru.skbkontur.sdk.extern.service.transport.adaptors.dto;
 
-import java.util.stream.Collectors;
 import ru.skbkontur.sdk.extern.model.DocflowPageItem;
 
+import java.util.stream.Collectors;
+
+
 /**
- *
  * @author alexs
  */
 public class DocflowPageItemDto {
-	
-	public DocflowPageItem fromDto(ru.skbkontur.sdk.extern.service.transport.swagger.model.DocflowPageItem dto) {
 
-		if (dto == null) return null;
-		
-		DocflowPageItem docflowPageItem = new DocflowPageItem();
-		
-		LinkDto linkDto = new LinkDto();
-		
-		docflowPageItem.setId(dto.getId());
-		docflowPageItem.setLastChangeDate(dto.getLastChangeDate());
-		docflowPageItem.setLinks(dto.getLinks().stream().map(linkDto::fromDto).collect(Collectors.toList()));
-		docflowPageItem.setSendDate(dto.getSendDate());
-		docflowPageItem.setStatus(dto.getStatus());
-		docflowPageItem.setType(dto.getType());
-		
-		return docflowPageItem;
-	}
-	
-	public ru.skbkontur.sdk.extern.service.transport.swagger.model.DocflowPageItem toDto(DocflowPageItem docflowPageItem) {
+    public DocflowPageItem fromDto(ru.skbkontur.sdk.extern.service.transport.swagger.model.DocflowPageItem dto) {
 
-		if (docflowPageItem == null) return null;
-		
-		ru.skbkontur.sdk.extern.service.transport.swagger.model.DocflowPageItem dto 
-			= new ru.skbkontur.sdk.extern.service.transport.swagger.model.DocflowPageItem();
-		
-		LinkDto linkDto = new LinkDto();
-		
-		dto.setId(docflowPageItem.getId());
-		dto.setLastChangeDate(docflowPageItem.getLastChangeDate());
-		dto.setLinks(docflowPageItem.getLinks().stream().map(linkDto::toDto).collect(Collectors.toList()));
-		dto.setSendDate(docflowPageItem.getSendDate());
-		dto.setStatus(docflowPageItem.getStatus());
-		dto.setType(docflowPageItem.getType());
-		
-		return dto;
-	}
+        if (dto == null) return null;
+
+        DocflowPageItem docflowPageItem = new DocflowPageItem();
+
+        LinkDto linkDto = new LinkDto();
+
+        docflowPageItem.setId(dto.getId());
+        docflowPageItem.setLastChangeDate(dto.getLastChangeDate());
+        docflowPageItem.setLinks(dto.getLinks().stream().map(linkDto::fromDto).collect(Collectors.toList()));
+        docflowPageItem.setSendDate(dto.getSendDate());
+        docflowPageItem.setStatus(dto.getStatus());
+        docflowPageItem.setType(dto.getType());
+
+        return docflowPageItem;
+    }
+
+    public ru.skbkontur.sdk.extern.service.transport.swagger.model.DocflowPageItem toDto(DocflowPageItem docflowPageItem) {
+
+        if (docflowPageItem == null) return null;
+
+        ru.skbkontur.sdk.extern.service.transport.swagger.model.DocflowPageItem dto
+                = new ru.skbkontur.sdk.extern.service.transport.swagger.model.DocflowPageItem();
+
+        LinkDto linkDto = new LinkDto();
+
+        dto.setId(docflowPageItem.getId());
+        dto.setLastChangeDate(docflowPageItem.getLastChangeDate());
+        dto.setLinks(docflowPageItem.getLinks().stream().map(linkDto::toDto).collect(Collectors.toList()));
+        dto.setSendDate(docflowPageItem.getSendDate());
+        dto.setStatus(docflowPageItem.getStatus());
+        dto.setType(docflowPageItem.getType());
+
+        return dto;
+    }
 }

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/dto/DocumentContentsDto.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/dto/DocumentContentsDto.java
@@ -1,8 +1,27 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * MIT License
+ *
+ * Copyright (c) 2018 SKB Kontur
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  */
+
 package ru.skbkontur.sdk.extern.service.transport.adaptors.dto;
 
 /**

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/dto/DocumentContentsDto.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/dto/DocumentContentsDto.java
@@ -6,43 +6,42 @@
 package ru.skbkontur.sdk.extern.service.transport.adaptors.dto;
 
 /**
- *
  * @author AlexS
  */
 public class DocumentContentsDto {
 
-	public ru.skbkontur.sdk.extern.model.DocumentContents fromDto(ru.skbkontur.sdk.extern.service.transport.swagger.model.DocumentContents dto) {
+    public ru.skbkontur.sdk.extern.model.DocumentContents fromDto(ru.skbkontur.sdk.extern.service.transport.swagger.model.DocumentContents dto) {
 
-		if (dto == null) return null;
+        if (dto == null) return null;
 
-		ru.skbkontur.sdk.extern.model.DocumentContents documentContents = new ru.skbkontur.sdk.extern.model.DocumentContents();
+        ru.skbkontur.sdk.extern.model.DocumentContents documentContents = new ru.skbkontur.sdk.extern.model.DocumentContents();
 
-		documentContents.setBase64Content(dto.getBase64Content());
+        documentContents.setBase64Content(dto.getBase64Content());
 
-		DocumentDescriptionDto documentDescriptionDto = new DocumentDescriptionDto();
+        DocumentDescriptionDto documentDescriptionDto = new DocumentDescriptionDto();
 
-		documentContents.setDocumentDescription(documentDescriptionDto.fromDto(dto.getDescription()));
+        documentContents.setDocumentDescription(documentDescriptionDto.fromDto(dto.getDescription()));
 
-		documentContents.setSignature(dto.getSignature());
+        documentContents.setSignature(dto.getSignature());
 
-		return documentContents;
-	}
+        return documentContents;
+    }
 
-	public ru.skbkontur.sdk.extern.service.transport.swagger.model.DocumentContents toDto(ru.skbkontur.sdk.extern.model.DocumentContents documentContents) {
+    public ru.skbkontur.sdk.extern.service.transport.swagger.model.DocumentContents toDto(ru.skbkontur.sdk.extern.model.DocumentContents documentContents) {
 
-		if (documentContents == null) return null;
+        if (documentContents == null) return null;
 
-		ru.skbkontur.sdk.extern.service.transport.swagger.model.DocumentContents dto
-			= new ru.skbkontur.sdk.extern.service.transport.swagger.model.DocumentContents();
+        ru.skbkontur.sdk.extern.service.transport.swagger.model.DocumentContents dto
+                = new ru.skbkontur.sdk.extern.service.transport.swagger.model.DocumentContents();
 
-		dto.setBase64Content(documentContents.getBase64Content());
+        dto.setBase64Content(documentContents.getBase64Content());
 
-		DocumentDescriptionDto documentDescriptionDto = new DocumentDescriptionDto();
+        DocumentDescriptionDto documentDescriptionDto = new DocumentDescriptionDto();
 
-		dto.setDescription(documentDescriptionDto.toDto(documentContents.getDocumentDescription()));
+        dto.setDescription(documentDescriptionDto.toDto(documentContents.getDocumentDescription()));
 
-		dto.setSignature(documentContents.getSignature());
+        dto.setSignature(documentContents.getSignature());
 
-		return dto;
-	}
+        return dto;
+    }
 }

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/dto/DocumentDescriptionDto.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/dto/DocumentDescriptionDto.java
@@ -1,8 +1,27 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * MIT License
+ *
+ * Copyright (c) 2018 SKB Kontur
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  */
+
 package ru.skbkontur.sdk.extern.service.transport.adaptors.dto;
 
 /**

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/dto/DocumentDescriptionDto.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/dto/DocumentDescriptionDto.java
@@ -6,33 +6,32 @@
 package ru.skbkontur.sdk.extern.service.transport.adaptors.dto;
 
 /**
- *
  * @author AlexS
  */
 public class DocumentDescriptionDto {
 
-	public ru.skbkontur.sdk.extern.model.DocumentDescription fromDto(ru.skbkontur.sdk.extern.service.transport.swagger.model.DocumentDescription dto) {
+    public ru.skbkontur.sdk.extern.model.DocumentDescription fromDto(ru.skbkontur.sdk.extern.service.transport.swagger.model.DocumentDescription dto) {
 
-		if (dto == null) return null;
+        if (dto == null) return null;
 
-		ru.skbkontur.sdk.extern.model.DocumentDescription documentDescription = new ru.skbkontur.sdk.extern.model.DocumentDescription();
-		documentDescription.setContentType(dto.getContentType());
-		documentDescription.setFilename(dto.getFilename());
-		documentDescription.setType(dto.getType());
+        ru.skbkontur.sdk.extern.model.DocumentDescription documentDescription = new ru.skbkontur.sdk.extern.model.DocumentDescription();
+        documentDescription.setContentType(dto.getContentType());
+        documentDescription.setFilename(dto.getFilename());
+        documentDescription.setType(dto.getType());
 
-		return documentDescription;
-	}
+        return documentDescription;
+    }
 
-	public ru.skbkontur.sdk.extern.service.transport.swagger.model.DocumentDescription toDto(ru.skbkontur.sdk.extern.model.DocumentDescription documentDescription) {
+    public ru.skbkontur.sdk.extern.service.transport.swagger.model.DocumentDescription toDto(ru.skbkontur.sdk.extern.model.DocumentDescription documentDescription) {
 
-		if (documentDescription == null) return null;
+        if (documentDescription == null) return null;
 
-		ru.skbkontur.sdk.extern.service.transport.swagger.model.DocumentDescription dto
-			= new ru.skbkontur.sdk.extern.service.transport.swagger.model.DocumentDescription();
-		dto.setContentType(documentDescription.getContentType());
-		dto.setFilename(documentDescription.getFilename());
-		dto.setType(documentDescription.getType());
+        ru.skbkontur.sdk.extern.service.transport.swagger.model.DocumentDescription dto
+                = new ru.skbkontur.sdk.extern.service.transport.swagger.model.DocumentDescription();
+        dto.setContentType(documentDescription.getContentType());
+        dto.setFilename(documentDescription.getFilename());
+        dto.setType(documentDescription.getType());
 
-		return dto;
-	}
+        return dto;
+    }
 }

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/dto/DocumentDto.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/dto/DocumentDto.java
@@ -7,50 +7,50 @@ package ru.skbkontur.sdk.extern.service.transport.adaptors.dto;
 
 import java.util.stream.Collectors;
 
+
 /**
- *
  * @author AlexS
  */
 public class DocumentDto {
 
-	public ru.skbkontur.sdk.extern.model.Document fromDto(ru.skbkontur.sdk.extern.service.transport.swagger.model.Document dto) {
+    public ru.skbkontur.sdk.extern.model.Document fromDto(ru.skbkontur.sdk.extern.service.transport.swagger.model.Document dto) {
 
-		if (dto == null) return null;
+        if (dto == null) return null;
 
-		ContentDto contentDto = new ContentDto();
-		DocumentDescriptionDto documentDescriptionDto = new DocumentDescriptionDto();
-		LinkDto linkDto = new LinkDto();
-		SignatureDto signatureDto = new SignatureDto();
-		ru.skbkontur.sdk.extern.model.Document document = new ru.skbkontur.sdk.extern.model.Document();
-		document.setContent(contentDto.fromDto(dto.getContent()));
-		document.setDescription(documentDescriptionDto.fromDto(dto.getDescription()));
-		document.setId(dto.getId());
-		if (dto.getLinks() != null) {
-			document.setLinks(dto.getLinks().stream().map(l -> linkDto.fromDto(l)).collect(Collectors.toList()));
-		}
-		document.setSignatures(dto.getSignatures().stream().map(s -> signatureDto.fromDto(s)).collect(Collectors.toList()));
+        ContentDto contentDto = new ContentDto();
+        DocumentDescriptionDto documentDescriptionDto = new DocumentDescriptionDto();
+        LinkDto linkDto = new LinkDto();
+        SignatureDto signatureDto = new SignatureDto();
+        ru.skbkontur.sdk.extern.model.Document document = new ru.skbkontur.sdk.extern.model.Document();
+        document.setContent(contentDto.fromDto(dto.getContent()));
+        document.setDescription(documentDescriptionDto.fromDto(dto.getDescription()));
+        document.setId(dto.getId());
+        if (dto.getLinks() != null) {
+            document.setLinks(dto.getLinks().stream().map(l -> linkDto.fromDto(l)).collect(Collectors.toList()));
+        }
+        document.setSignatures(dto.getSignatures().stream().map(s -> signatureDto.fromDto(s)).collect(Collectors.toList()));
 
-		return document;
-	}
+        return document;
+    }
 
-	public ru.skbkontur.sdk.extern.service.transport.swagger.model.Document toDto(ru.skbkontur.sdk.extern.model.Document document) {
+    public ru.skbkontur.sdk.extern.service.transport.swagger.model.Document toDto(ru.skbkontur.sdk.extern.model.Document document) {
 
-		if (document == null) return null;
+        if (document == null) return null;
 
-		ContentDto contentDto = new ContentDto();
-		DocumentDescriptionDto documentDescriptionDto = new DocumentDescriptionDto();
-		LinkDto linkDto = new LinkDto();
-		SignatureDto signatureDto = new SignatureDto();
-		ru.skbkontur.sdk.extern.service.transport.swagger.model.Document dto
-			= new ru.skbkontur.sdk.extern.service.transport.swagger.model.Document();
-		dto.setContent(contentDto.toDto(document.getContent()));
-		dto.setDescription(documentDescriptionDto.toDto(document.getDescription()));
-		dto.setId(document.getId());
-		if (document.getLinks() != null) {
-			dto.setLinks(document.getLinks().stream().map(l -> linkDto.toDto(l)).collect(Collectors.toList()));
-		}
-		dto.setSignatures(document.getSignatures().stream().map(s -> signatureDto.toDto(s)).collect(Collectors.toList()));
+        ContentDto contentDto = new ContentDto();
+        DocumentDescriptionDto documentDescriptionDto = new DocumentDescriptionDto();
+        LinkDto linkDto = new LinkDto();
+        SignatureDto signatureDto = new SignatureDto();
+        ru.skbkontur.sdk.extern.service.transport.swagger.model.Document dto
+                = new ru.skbkontur.sdk.extern.service.transport.swagger.model.Document();
+        dto.setContent(contentDto.toDto(document.getContent()));
+        dto.setDescription(documentDescriptionDto.toDto(document.getDescription()));
+        dto.setId(document.getId());
+        if (document.getLinks() != null) {
+            dto.setLinks(document.getLinks().stream().map(l -> linkDto.toDto(l)).collect(Collectors.toList()));
+        }
+        dto.setSignatures(document.getSignatures().stream().map(s -> signatureDto.toDto(s)).collect(Collectors.toList()));
 
-		return dto;
-	}
+        return dto;
+    }
 }

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/dto/DocumentDto.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/dto/DocumentDto.java
@@ -1,8 +1,27 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * MIT License
+ *
+ * Copyright (c) 2018 SKB Kontur
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  */
+
 package ru.skbkontur.sdk.extern.service.transport.adaptors.dto;
 
 import java.util.stream.Collectors;

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/dto/DocumentToSendDto.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/dto/DocumentToSendDto.java
@@ -9,79 +9,79 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+
 /**
- *
  * @author AlexS
  */
 public class DocumentToSendDto {
-	private static final java.util.Base64.Decoder base64Decoder = java.util.Base64.getDecoder();
 
-	public ru.skbkontur.sdk.extern.model.DocumentToSend fromDto(ru.skbkontur.sdk.extern.service.transport.swagger.model.DocumentToSend dto) {
+    private static final java.util.Base64.Decoder base64Decoder = java.util.Base64.getDecoder();
 
-		if (dto == null) return null;
+    public ru.skbkontur.sdk.extern.model.DocumentToSend fromDto(ru.skbkontur.sdk.extern.service.transport.swagger.model.DocumentToSend dto) {
 
-		
-		ru.skbkontur.sdk.extern.model.DocumentToSend documentToSend = new ru.skbkontur.sdk.extern.model.DocumentToSend();
-		
-		documentToSend.setContent(dto.getContent());
-		documentToSend.setFilename(dto.getFilename());
-		documentToSend.setId(dto.getId());
-		documentToSend.setSenderIp(dto.getSenderIp());
-		documentToSend.setSignature(new SignatureToSendDto().fromDto(dto.getSignature()));
-		if (dto.getLinks() != null) {
-			LinkDto linkDto = new LinkDto();
-			documentToSend.setLinks(dto.getLinks().stream().map(linkDto::fromDto).collect(Collectors.toList()));
-		}
-		
-		return documentToSend;
-	}
+        if (dto == null) return null;
 
-	public ru.skbkontur.sdk.extern.model.DocumentToSend fromDto(Map<String,Object> dto) {
-		if (dto == null)	return null;
-		
-		ru.skbkontur.sdk.extern.model.DocumentToSend documentToSend = new ru.skbkontur.sdk.extern.model.DocumentToSend();
-		
-		String base64 = (String)dto.get("content");
-		byte[] content = null;
-		if (base64 != null) {
-			try {
-				content = base64Decoder.decode(base64);
-			}
-			catch (Exception x) {
-			}
-		}
-			
-		
-		documentToSend.setContent(content);
-		documentToSend.setFilename((String)dto.get("filename"));
-		documentToSend.setId((String)dto.get("id"));
-		documentToSend.setSenderIp(null);
-		documentToSend.setSignature(new SignatureToSendDto().fromDto((Map)dto.get("signature")));
-		if (dto.get("links") != null) {
-			LinkDto linkDto = new LinkDto();
-			List<Map<String,Object>> links = (List<Map<String,Object>>)dto.get("links");
-			documentToSend.setLinks(links.stream().map(linkDto::fromDto).collect(Collectors.toList()));
-		}
-		
-		return documentToSend;
-	}
 
-	public ru.skbkontur.sdk.extern.service.transport.swagger.model.DocumentToSend toDto(ru.skbkontur.sdk.extern.model.DocumentToSend documentToSend) {
+        ru.skbkontur.sdk.extern.model.DocumentToSend documentToSend = new ru.skbkontur.sdk.extern.model.DocumentToSend();
 
-		if (documentToSend == null) return null;
+        documentToSend.setContent(dto.getContent());
+        documentToSend.setFilename(dto.getFilename());
+        documentToSend.setId(dto.getId());
+        documentToSend.setSenderIp(dto.getSenderIp());
+        documentToSend.setSignature(new SignatureToSendDto().fromDto(dto.getSignature()));
+        if (dto.getLinks() != null) {
+            LinkDto linkDto = new LinkDto();
+            documentToSend.setLinks(dto.getLinks().stream().map(linkDto::fromDto).collect(Collectors.toList()));
+        }
 
-		ru.skbkontur.sdk.extern.service.transport.swagger.model.DocumentToSend dto = new ru.skbkontur.sdk.extern.service.transport.swagger.model.DocumentToSend();
-		
-		dto.setContent(documentToSend.getContent());
-		dto.setFilename(documentToSend.getFilename());
-		dto.setId(documentToSend.getId());
-		dto.setSenderIp(documentToSend.getSenderIp());
-		dto.setSignature(new SignatureToSendDto().toDto(documentToSend.getSignature()));
-		if (documentToSend.getLinks() != null) {
-			LinkDto linkDto = new LinkDto();
-			dto.setLinks(documentToSend.getLinks().stream().map(linkDto::toDto).collect(Collectors.toList()));
-		}
-		
-		return dto;
-	}
+        return documentToSend;
+    }
+
+    public ru.skbkontur.sdk.extern.model.DocumentToSend fromDto(Map<String, Object> dto) {
+        if (dto == null) return null;
+
+        ru.skbkontur.sdk.extern.model.DocumentToSend documentToSend = new ru.skbkontur.sdk.extern.model.DocumentToSend();
+
+        String base64 = (String) dto.get("content");
+        byte[] content = null;
+        if (base64 != null) {
+            try {
+                content = base64Decoder.decode(base64);
+            } catch (Exception x) {
+            }
+        }
+
+
+        documentToSend.setContent(content);
+        documentToSend.setFilename((String) dto.get("filename"));
+        documentToSend.setId((String) dto.get("id"));
+        documentToSend.setSenderIp(null);
+        documentToSend.setSignature(new SignatureToSendDto().fromDto((Map) dto.get("signature")));
+        if (dto.get("links") != null) {
+            LinkDto linkDto = new LinkDto();
+            List<Map<String, Object>> links = (List<Map<String, Object>>) dto.get("links");
+            documentToSend.setLinks(links.stream().map(linkDto::fromDto).collect(Collectors.toList()));
+        }
+
+        return documentToSend;
+    }
+
+    public ru.skbkontur.sdk.extern.service.transport.swagger.model.DocumentToSend toDto(ru.skbkontur.sdk.extern.model.DocumentToSend documentToSend) {
+
+        if (documentToSend == null) return null;
+
+        ru.skbkontur.sdk.extern.service.transport.swagger.model.DocumentToSend dto = new ru.skbkontur.sdk.extern.service.transport.swagger.model.DocumentToSend();
+
+        dto.setContent(documentToSend.getContent());
+        dto.setFilename(documentToSend.getFilename());
+        dto.setId(documentToSend.getId());
+        dto.setSenderIp(documentToSend.getSenderIp());
+        dto.setSignature(new SignatureToSendDto().toDto(documentToSend.getSignature()));
+        if (documentToSend.getLinks() != null) {
+            LinkDto linkDto = new LinkDto();
+            dto.setLinks(documentToSend.getLinks().stream().map(linkDto::toDto).collect(Collectors.toList()));
+        }
+
+        return dto;
+    }
 }

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/dto/DocumentToSendDto.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/dto/DocumentToSendDto.java
@@ -1,8 +1,27 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * MIT License
+ *
+ * Copyright (c) 2018 SKB Kontur
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  */
+
 package ru.skbkontur.sdk.extern.service.transport.adaptors.dto;
 
 import java.util.List;

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/dto/DraftDocumentDto.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/dto/DraftDocumentDto.java
@@ -6,63 +6,62 @@
 package ru.skbkontur.sdk.extern.service.transport.adaptors.dto;
 
 /**
- *
  * @author AlexS
  */
 public class DraftDocumentDto {
 
-	public ru.skbkontur.sdk.extern.model.DraftDocument fromDto(ru.skbkontur.sdk.extern.service.transport.swagger.model.DraftDocument dto) {
+    public ru.skbkontur.sdk.extern.model.DraftDocument fromDto(ru.skbkontur.sdk.extern.service.transport.swagger.model.DraftDocument dto) {
 
-		if (dto == null) return null;
+        if (dto == null) return null;
 
-		ru.skbkontur.sdk.extern.model.DraftDocument draftDocument = new ru.skbkontur.sdk.extern.model.DraftDocument();
+        ru.skbkontur.sdk.extern.model.DraftDocument draftDocument = new ru.skbkontur.sdk.extern.model.DraftDocument();
 
-		LinkDto linkDto = new LinkDto();
+        LinkDto linkDto = new LinkDto();
 
-		if (dto.getDecryptedContentLink() != null) {
-			draftDocument.setDecryptedContentLink(linkDto.fromDto(dto.getDecryptedContentLink()));
-		}
+        if (dto.getDecryptedContentLink() != null) {
+            draftDocument.setDecryptedContentLink(linkDto.fromDto(dto.getDecryptedContentLink()));
+        }
 
-		if (dto.getEncryptedContentLink() != null) {
-			draftDocument.setEncryptedContentLink(linkDto.fromDto(dto.getEncryptedContentLink()));
-		}
+        if (dto.getEncryptedContentLink() != null) {
+            draftDocument.setEncryptedContentLink(linkDto.fromDto(dto.getEncryptedContentLink()));
+        }
 
-		draftDocument.setId(dto.getId());
+        draftDocument.setId(dto.getId());
 
-		DocumentDescriptionDto documentDescriptionDto = new DocumentDescriptionDto();
+        DocumentDescriptionDto documentDescriptionDto = new DocumentDescriptionDto();
 
-		draftDocument.setDocumentDescription(documentDescriptionDto.fromDto(dto.getDescription()));
+        draftDocument.setDocumentDescription(documentDescriptionDto.fromDto(dto.getDescription()));
 
-		draftDocument.setSignatureContentLink(linkDto.fromDto(dto.getSignatureContentLink()));
+        draftDocument.setSignatureContentLink(linkDto.fromDto(dto.getSignatureContentLink()));
 
-		return draftDocument;
-	}
+        return draftDocument;
+    }
 
-	public ru.skbkontur.sdk.extern.service.transport.swagger.model.DraftDocument toDto(ru.skbkontur.sdk.extern.model.DraftDocument draftDocument) {
+    public ru.skbkontur.sdk.extern.service.transport.swagger.model.DraftDocument toDto(ru.skbkontur.sdk.extern.model.DraftDocument draftDocument) {
 
-		if (draftDocument == null) return null;
+        if (draftDocument == null) return null;
 
-		ru.skbkontur.sdk.extern.service.transport.swagger.model.DraftDocument dto
-			= new ru.skbkontur.sdk.extern.service.transport.swagger.model.DraftDocument();
+        ru.skbkontur.sdk.extern.service.transport.swagger.model.DraftDocument dto
+                = new ru.skbkontur.sdk.extern.service.transport.swagger.model.DraftDocument();
 
-		LinkDto linkDto = new LinkDto();
+        LinkDto linkDto = new LinkDto();
 
-		if (draftDocument.getDecryptedContentLink() != null) {
-			dto.setDecryptedContentLink(linkDto.toDto(draftDocument.getDecryptedContentLink()));
-		}
+        if (draftDocument.getDecryptedContentLink() != null) {
+            dto.setDecryptedContentLink(linkDto.toDto(draftDocument.getDecryptedContentLink()));
+        }
 
-		if (draftDocument.getEncryptedContentLink() != null) {
-			dto.setEncryptedContentLink(linkDto.toDto(draftDocument.getEncryptedContentLink()));
-		}
+        if (draftDocument.getEncryptedContentLink() != null) {
+            dto.setEncryptedContentLink(linkDto.toDto(draftDocument.getEncryptedContentLink()));
+        }
 
-		dto.setId(draftDocument.getId());
+        dto.setId(draftDocument.getId());
 
-		DocumentDescriptionDto documentDescriptionDto = new DocumentDescriptionDto();
+        DocumentDescriptionDto documentDescriptionDto = new DocumentDescriptionDto();
 
-		dto.setDescription(documentDescriptionDto.toDto(draftDocument.getDocumentDescription()));
+        dto.setDescription(documentDescriptionDto.toDto(draftDocument.getDocumentDescription()));
 
-		dto.setSignatureContentLink(linkDto.toDto(draftDocument.getSignatureContentLink()));
+        dto.setSignatureContentLink(linkDto.toDto(draftDocument.getSignatureContentLink()));
 
-		return dto;
-	}
+        return dto;
+    }
 }

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/dto/DraftDocumentDto.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/dto/DraftDocumentDto.java
@@ -1,8 +1,27 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * MIT License
+ *
+ * Copyright (c) 2018 SKB Kontur
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  */
+
 package ru.skbkontur.sdk.extern.service.transport.adaptors.dto;
 
 /**

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/dto/DraftDto.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/dto/DraftDto.java
@@ -1,8 +1,27 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * MIT License
+ *
+ * Copyright (c) 2018 SKB Kontur
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  */
+
 package ru.skbkontur.sdk.extern.service.transport.adaptors.dto;
 
 /**

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/dto/DraftDto.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/dto/DraftDto.java
@@ -6,33 +6,32 @@
 package ru.skbkontur.sdk.extern.service.transport.adaptors.dto;
 
 /**
- *
  * @author AlexS
  */
 public class DraftDto {
 
-	public ru.skbkontur.sdk.extern.model.Draft fromDto(ru.skbkontur.sdk.extern.service.transport.swagger.model.Draft dto) {
+    public ru.skbkontur.sdk.extern.model.Draft fromDto(ru.skbkontur.sdk.extern.service.transport.swagger.model.Draft dto) {
 
-		if (dto == null) return null;
+        if (dto == null) return null;
 
-		ru.skbkontur.sdk.extern.model.Draft draft = new ru.skbkontur.sdk.extern.model.Draft();
-		draft.setId(dto.getId());
-		draft.setStatus(dto.getStatus().getValue());
+        ru.skbkontur.sdk.extern.model.Draft draft = new ru.skbkontur.sdk.extern.model.Draft();
+        draft.setId(dto.getId());
+        draft.setStatus(dto.getStatus().getValue());
 
-		return draft;
-	}
+        return draft;
+    }
 
-	public ru.skbkontur.sdk.extern.service.transport.swagger.model.Draft toDto(ru.skbkontur.sdk.extern.model.Draft draft) {
+    public ru.skbkontur.sdk.extern.service.transport.swagger.model.Draft toDto(ru.skbkontur.sdk.extern.model.Draft draft) {
 
-		if (draft == null) return null;
+        if (draft == null) return null;
 
-		ru.skbkontur.sdk.extern.service.transport.swagger.model.Draft dto
-			= new ru.skbkontur.sdk.extern.service.transport.swagger.model.Draft();
-		dto.setId(draft.getId());
-		ru.skbkontur.sdk.extern.service.transport.swagger.model.Draft.StatusEnum status
-			= ru.skbkontur.sdk.extern.service.transport.swagger.model.Draft.StatusEnum.fromValue(draft.getStatus().getValue());
-		dto.setStatus(status);
+        ru.skbkontur.sdk.extern.service.transport.swagger.model.Draft dto
+                = new ru.skbkontur.sdk.extern.service.transport.swagger.model.Draft();
+        dto.setId(draft.getId());
+        ru.skbkontur.sdk.extern.service.transport.swagger.model.Draft.StatusEnum status
+                = ru.skbkontur.sdk.extern.service.transport.swagger.model.Draft.StatusEnum.fromValue(draft.getStatus().getValue());
+        dto.setStatus(status);
 
-		return dto;
-	}
+        return dto;
+    }
 }

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/dto/DraftMetaDto.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/dto/DraftMetaDto.java
@@ -9,87 +9,87 @@ import ru.skbkontur.sdk.extern.model.FnsRecipient;
 import ru.skbkontur.sdk.extern.model.Organization;
 import ru.skbkontur.sdk.extern.model.Recipient;
 
+
 /**
- *
  * @author AlexS
  */
 public class DraftMetaDto {
 
-	public ru.skbkontur.sdk.extern.model.DraftMeta fromDto(ru.skbkontur.sdk.extern.service.transport.swagger.model.DraftMeta dto) {
+    public ru.skbkontur.sdk.extern.model.DraftMeta fromDto(ru.skbkontur.sdk.extern.service.transport.swagger.model.DraftMeta dto) {
 
-		if (dto == null) return null;
+        if (dto == null) return null;
 
-		ru.skbkontur.sdk.extern.model.DraftMeta draftMeta = new ru.skbkontur.sdk.extern.model.DraftMeta();
+        ru.skbkontur.sdk.extern.model.DraftMeta draftMeta = new ru.skbkontur.sdk.extern.model.DraftMeta();
 
-		ru.skbkontur.sdk.extern.service.transport.swagger.model.Sender dtoSender = dto.getSender();
+        ru.skbkontur.sdk.extern.service.transport.swagger.model.Sender dtoSender = dto.getSender();
 
-		ru.skbkontur.sdk.extern.model.Sender sender = new ru.skbkontur.sdk.extern.model.Sender();
-		sender.setInn(dtoSender.getInn());
-		sender.setKpp(dtoSender.getKpp());
-		sender.setCertificate(dtoSender.getCertificate() == null ? null : dtoSender.getCertificate().getContent());
-		sender.setIpaddress(dto.getSender().getIpaddress());
+        ru.skbkontur.sdk.extern.model.Sender sender = new ru.skbkontur.sdk.extern.model.Sender();
+        sender.setInn(dtoSender.getInn());
+        sender.setKpp(dtoSender.getKpp());
+        sender.setCertificate(dtoSender.getCertificate() == null ? null : dtoSender.getCertificate().getContent());
+        sender.setIpaddress(dto.getSender().getIpaddress());
 
-		draftMeta.setSender(sender);
+        draftMeta.setSender(sender);
 
-		draftMeta.setRecipient(createRecipient(dto.getRecipient()));
+        draftMeta.setRecipient(createRecipient(dto.getRecipient()));
 
-		draftMeta.setPayer(
-			new Organization(dto.getPayer().getInn(), dto.getPayer().getOrganization() == null ? null : dto.getPayer().getOrganization().getKpp())
-		);
+        draftMeta.setPayer(
+                new Organization(dto.getPayer().getInn(), dto.getPayer().getOrganization() == null ? null : dto.getPayer().getOrganization().getKpp())
+        );
 
-		return draftMeta;
-	}
+        return draftMeta;
+    }
 
-	public ru.skbkontur.sdk.extern.service.transport.swagger.model.DraftMeta toDto(ru.skbkontur.sdk.extern.model.DraftMeta draftMeta) {
+    public ru.skbkontur.sdk.extern.service.transport.swagger.model.DraftMeta toDto(ru.skbkontur.sdk.extern.model.DraftMeta draftMeta) {
 
-		if (draftMeta == null) return null;
+        if (draftMeta == null) return null;
 
-		ru.skbkontur.sdk.extern.service.transport.swagger.model.DraftMeta dtoDraftMeta
-			= new ru.skbkontur.sdk.extern.service.transport.swagger.model.DraftMeta();
+        ru.skbkontur.sdk.extern.service.transport.swagger.model.DraftMeta dtoDraftMeta
+                = new ru.skbkontur.sdk.extern.service.transport.swagger.model.DraftMeta();
 
-		ru.skbkontur.sdk.extern.service.transport.swagger.model.Sender dtoSender = new ru.skbkontur.sdk.extern.service.transport.swagger.model.Sender();
-		dtoSender.setInn(draftMeta.getSender().getInn());
-		if (draftMeta.getSender().getKpp() != null && !draftMeta.getSender().getKpp().isEmpty()) {
-			dtoSender.setKpp(draftMeta.getSender().getKpp());
-		}
+        ru.skbkontur.sdk.extern.service.transport.swagger.model.Sender dtoSender = new ru.skbkontur.sdk.extern.service.transport.swagger.model.Sender();
+        dtoSender.setInn(draftMeta.getSender().getInn());
+        if (draftMeta.getSender().getKpp() != null && !draftMeta.getSender().getKpp().isEmpty()) {
+            dtoSender.setKpp(draftMeta.getSender().getKpp());
+        }
 
-		ru.skbkontur.sdk.extern.service.transport.swagger.model.Certificate dtoCertificate = new ru.skbkontur.sdk.extern.service.transport.swagger.model.Certificate();
+        ru.skbkontur.sdk.extern.service.transport.swagger.model.Certificate dtoCertificate = new ru.skbkontur.sdk.extern.service.transport.swagger.model.Certificate();
 
-		dtoSender.setCertificate(dtoCertificate.content(draftMeta.getSender().getCertificate()));
+        dtoSender.setCertificate(dtoCertificate.content(draftMeta.getSender().getCertificate()));
 
-		dtoSender.setIpaddress(draftMeta.getSender().getIpaddress());
+        dtoSender.setIpaddress(draftMeta.getSender().getIpaddress());
 
-		dtoDraftMeta.setSender(dtoSender);
+        dtoDraftMeta.setSender(dtoSender);
 
-		dtoDraftMeta.setRecipient(createRecipentInfo(draftMeta.getRecipient()));
+        dtoDraftMeta.setRecipient(createRecipentInfo(draftMeta.getRecipient()));
 
-		ru.skbkontur.sdk.extern.service.transport.swagger.model.AccountInfo dtoAccountInfo = new ru.skbkontur.sdk.extern.service.transport.swagger.model.AccountInfo();
-		dtoAccountInfo.setInn(draftMeta.getPayer().getInn());
+        ru.skbkontur.sdk.extern.service.transport.swagger.model.AccountInfo dtoAccountInfo = new ru.skbkontur.sdk.extern.service.transport.swagger.model.AccountInfo();
+        dtoAccountInfo.setInn(draftMeta.getPayer().getInn());
 
-		ru.skbkontur.sdk.extern.service.transport.swagger.model.OrganizationInfo dtoOrganizationInfo = new ru.skbkontur.sdk.extern.service.transport.swagger.model.OrganizationInfo();
-		dtoOrganizationInfo.setKpp(draftMeta.getPayer().getKpp());
-		dtoAccountInfo.setOrganization(dtoOrganizationInfo);
+        ru.skbkontur.sdk.extern.service.transport.swagger.model.OrganizationInfo dtoOrganizationInfo = new ru.skbkontur.sdk.extern.service.transport.swagger.model.OrganizationInfo();
+        dtoOrganizationInfo.setKpp(draftMeta.getPayer().getKpp());
+        dtoAccountInfo.setOrganization(dtoOrganizationInfo);
 
-		dtoDraftMeta.setPayer(dtoAccountInfo);
+        dtoDraftMeta.setPayer(dtoAccountInfo);
 
-		return dtoDraftMeta;
-	}
+        return dtoDraftMeta;
+    }
 
-	private ru.skbkontur.sdk.extern.service.transport.swagger.model.RecipientInfo createRecipentInfo(Recipient recipient) {
-		ru.skbkontur.sdk.extern.service.transport.swagger.model.RecipientInfo recipientInfo = new ru.skbkontur.sdk.extern.service.transport.swagger.model.RecipientInfo();
-		if (recipient instanceof FnsRecipient) {
-			String fnsCode = ((FnsRecipient) recipient).getIfnsCode();
-			recipientInfo.setIfnsCode(fnsCode);
-			return recipientInfo;
-		}
-		return null;
-	}
+    private ru.skbkontur.sdk.extern.service.transport.swagger.model.RecipientInfo createRecipentInfo(Recipient recipient) {
+        ru.skbkontur.sdk.extern.service.transport.swagger.model.RecipientInfo recipientInfo = new ru.skbkontur.sdk.extern.service.transport.swagger.model.RecipientInfo();
+        if (recipient instanceof FnsRecipient) {
+            String fnsCode = ((FnsRecipient) recipient).getIfnsCode();
+            recipientInfo.setIfnsCode(fnsCode);
+            return recipientInfo;
+        }
+        return null;
+    }
 
-	private ru.skbkontur.sdk.extern.model.Recipient createRecipient(ru.skbkontur.sdk.extern.service.transport.swagger.model.RecipientInfo recipientDto) {
-		ru.skbkontur.sdk.extern.model.Recipient recipient = null;
-		if (recipientDto.getIfnsCode() != null && !recipientDto.getIfnsCode().isEmpty()) {
-			recipient = new ru.skbkontur.sdk.extern.model.FnsRecipient(recipientDto.getIfnsCode());
-		}
-		return recipient;
-	}
+    private ru.skbkontur.sdk.extern.model.Recipient createRecipient(ru.skbkontur.sdk.extern.service.transport.swagger.model.RecipientInfo recipientDto) {
+        ru.skbkontur.sdk.extern.model.Recipient recipient = null;
+        if (recipientDto.getIfnsCode() != null && !recipientDto.getIfnsCode().isEmpty()) {
+            recipient = new ru.skbkontur.sdk.extern.model.FnsRecipient(recipientDto.getIfnsCode());
+        }
+        return recipient;
+    }
 }

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/dto/DraftMetaDto.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/dto/DraftMetaDto.java
@@ -1,8 +1,27 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * MIT License
+ *
+ * Copyright (c) 2018 SKB Kontur
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  */
+
 package ru.skbkontur.sdk.extern.service.transport.adaptors.dto;
 
 import ru.skbkontur.sdk.extern.model.FnsRecipient;

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/dto/LinkDto.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/dto/LinkDto.java
@@ -1,8 +1,27 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * MIT License
+ *
+ * Copyright (c) 2018 SKB Kontur
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  */
+
 package ru.skbkontur.sdk.extern.service.transport.adaptors.dto;
 
 import java.lang.reflect.Field;

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/dto/LinkDto.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/dto/LinkDto.java
@@ -8,61 +8,60 @@ package ru.skbkontur.sdk.extern.service.transport.adaptors.dto;
 import java.lang.reflect.Field;
 import java.util.Map;
 
+
 /**
- *
  * @author AlexS
  */
 public class LinkDto {
 
-	public ru.skbkontur.sdk.extern.model.Link fromDto(ru.skbkontur.sdk.extern.service.transport.swagger.model.Link dto) {
+    public ru.skbkontur.sdk.extern.model.Link fromDto(ru.skbkontur.sdk.extern.service.transport.swagger.model.Link dto) {
 
-		if (dto == null) return null;
+        if (dto == null) return null;
 
-		ru.skbkontur.sdk.extern.model.Link link = new ru.skbkontur.sdk.extern.model.Link();
-		link.setHref(dto.getHref());
-		link.setName(dto.getName());
-		link.setProfile(dto.getProfile());
-		link.setRel(dto.getRel());
-		link.setTemplated(dto.getTemplated());
-		link.setTitle(dto.getTitle());
+        ru.skbkontur.sdk.extern.model.Link link = new ru.skbkontur.sdk.extern.model.Link();
+        link.setHref(dto.getHref());
+        link.setName(dto.getName());
+        link.setProfile(dto.getProfile());
+        link.setRel(dto.getRel());
+        link.setTemplated(dto.getTemplated());
+        link.setTitle(dto.getTitle());
 
-		return link;
-	}
+        return link;
+    }
 
-	public ru.skbkontur.sdk.extern.model.Link fromDto(Map<String, Object> dto) {
+    public ru.skbkontur.sdk.extern.model.Link fromDto(Map<String, Object> dto) {
 
-		if (dto == null) return null;
+        if (dto == null) return null;
 
-		ru.skbkontur.sdk.extern.model.Link link = new ru.skbkontur.sdk.extern.model.Link();
-		link.setHref((String) dto.get("href"));
-		link.setName((String) dto.get("name"));
-		link.setProfile((String) dto.get("profile"));
-		link.setRel((String) dto.get("rel"));
-		link.setTemplated((Boolean) dto.get("templated"));
-		link.setTitle((String) dto.get("title"));
+        ru.skbkontur.sdk.extern.model.Link link = new ru.skbkontur.sdk.extern.model.Link();
+        link.setHref((String) dto.get("href"));
+        link.setName((String) dto.get("name"));
+        link.setProfile((String) dto.get("profile"));
+        link.setRel((String) dto.get("rel"));
+        link.setTemplated((Boolean) dto.get("templated"));
+        link.setTitle((String) dto.get("title"));
 
-		return link;
-	}
+        return link;
+    }
 
-	public ru.skbkontur.sdk.extern.service.transport.swagger.model.Link toDto(ru.skbkontur.sdk.extern.model.Link link) {
+    public ru.skbkontur.sdk.extern.service.transport.swagger.model.Link toDto(ru.skbkontur.sdk.extern.model.Link link) {
 
-		if (link == null) return null;
+        if (link == null) return null;
 
-		ru.skbkontur.sdk.extern.service.transport.swagger.model.Link dto
-			= new ru.skbkontur.sdk.extern.service.transport.swagger.model.Link();
-		setPrivateFieldValue(dto, "href", link.getHref());
-		setPrivateFieldValue(dto, "rel", link.getRel());
+        ru.skbkontur.sdk.extern.service.transport.swagger.model.Link dto
+                = new ru.skbkontur.sdk.extern.service.transport.swagger.model.Link();
+        setPrivateFieldValue(dto, "href", link.getHref());
+        setPrivateFieldValue(dto, "rel", link.getRel());
 
-		return dto;
-	}
+        return dto;
+    }
 
-	private void setPrivateFieldValue(Object obj, String fieldName, Object value) {
-		try {
-			Field field = obj.getClass().getDeclaredField(fieldName);
-			field.setAccessible(true);
-			field.set(obj, value);
-		}
-		catch (NoSuchFieldException | SecurityException | IllegalAccessException ignore) {
-		}
-	}
+    private void setPrivateFieldValue(Object obj, String fieldName, Object value) {
+        try {
+            Field field = obj.getClass().getDeclaredField(fieldName);
+            field.setAccessible(true);
+            field.set(obj, value);
+        } catch (NoSuchFieldException | SecurityException | IllegalAccessException ignore) {
+        }
+    }
 }

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/dto/MerchantTaxDto.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/dto/MerchantTaxDto.java
@@ -1,8 +1,27 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * MIT License
+ *
+ * Copyright (c) 2018 SKB Kontur
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  */
+
 package ru.skbkontur.sdk.extern.service.transport.adaptors.dto;
 
 import ru.skbkontur.sdk.extern.model.MerchantTax;

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/dto/MerchantTaxDto.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/dto/MerchantTaxDto.java
@@ -7,38 +7,38 @@ package ru.skbkontur.sdk.extern.service.transport.adaptors.dto;
 
 import ru.skbkontur.sdk.extern.model.MerchantTax;
 
+
 /**
- *
  * @author alexs
  */
 public class MerchantTaxDto {
 
-	public MerchantTax fromDto(ru.skbkontur.sdk.extern.service.transport.swagger.model.MerchantTax dto) {
-		
-		if (dto == null) return null;
-		
-		MerchantTax t = new MerchantTax();
+    public MerchantTax fromDto(ru.skbkontur.sdk.extern.service.transport.swagger.model.MerchantTax dto) {
 
-		t.setDohod(dto.getDohod());
-		t.setIschisl(dto.getIschisl());
-		t.setTorgSborFact(dto.getTorgSborFact());
-		t.setTorgSborUmen(dto.getTorgSborUmen());
-		
-		return t;
-	}
-	
-	public ru.skbkontur.sdk.extern.service.transport.swagger.model.MerchantTax toDto(MerchantTax t) {
-		
-		if (t == null) return null;
-		
-		ru.skbkontur.sdk.extern.service.transport.swagger.model.MerchantTax dto 
-			= new ru.skbkontur.sdk.extern.service.transport.swagger.model.MerchantTax();
+        if (dto == null) return null;
 
-		dto.setDohod(t.getDohod());
-		dto.setIschisl(t.getIschisl());
-		dto.setTorgSborFact(t.getTorgSborFact());
-		dto.setTorgSborUmen(t.getTorgSborUmen());
-		
-		return dto;
-	}
+        MerchantTax t = new MerchantTax();
+
+        t.setDohod(dto.getDohod());
+        t.setIschisl(dto.getIschisl());
+        t.setTorgSborFact(dto.getTorgSborFact());
+        t.setTorgSborUmen(dto.getTorgSborUmen());
+
+        return t;
+    }
+
+    public ru.skbkontur.sdk.extern.service.transport.swagger.model.MerchantTax toDto(MerchantTax t) {
+
+        if (t == null) return null;
+
+        ru.skbkontur.sdk.extern.service.transport.swagger.model.MerchantTax dto
+                = new ru.skbkontur.sdk.extern.service.transport.swagger.model.MerchantTax();
+
+        dto.setDohod(t.getDohod());
+        dto.setIschisl(t.getIschisl());
+        dto.setTorgSborFact(t.getTorgSborFact());
+        dto.setTorgSborUmen(t.getTorgSborUmen());
+
+        return dto;
+    }
 }

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/dto/PassportInfoDto.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/dto/PassportInfoDto.java
@@ -1,8 +1,27 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * MIT License
+ *
+ * Copyright (c) 2018 SKB Kontur
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  */
+
 package ru.skbkontur.sdk.extern.service.transport.adaptors.dto;
 
 import ru.skbkontur.sdk.extern.model.PassportInfo;

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/dto/PassportInfoDto.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/dto/PassportInfoDto.java
@@ -7,38 +7,38 @@ package ru.skbkontur.sdk.extern.service.transport.adaptors.dto;
 
 import ru.skbkontur.sdk.extern.model.PassportInfo;
 
+
 /**
- *
  * @author alexs
  */
 class PassportInfoDto {
-	
-	public PassportInfo fromDto(ru.skbkontur.sdk.extern.service.transport.swagger.model.PassportInfo dto) {
-		
-		if (dto == null) return null;
-		
-		PassportInfo passportInfo = new PassportInfo();
-		
-		passportInfo.setCode(dto.getCode());
-		passportInfo.setIssuedBy(dto.getIssuedBy());
-		passportInfo.setIssuedDate(dto.getIssuedDate());
-		passportInfo.setSeriesNumber(dto.getSeriesNumber());
-			
-		return passportInfo;
-	}
-	
-	public ru.skbkontur.sdk.extern.service.transport.swagger.model.PassportInfo toDto(PassportInfo passportInfo) {
-		
-		if (passportInfo == null) return null;
-		
-		ru.skbkontur.sdk.extern.service.transport.swagger.model.PassportInfo dto 
-			= new ru.skbkontur.sdk.extern.service.transport.swagger.model.PassportInfo();
-		
-		dto.setCode(passportInfo.getCode());
-		dto.setIssuedBy(passportInfo.getIssuedBy());
-		dto.setIssuedDate(passportInfo.getIssuedDate());
-		dto.setSeriesNumber(passportInfo.getSeriesNumber());
-			
-		return dto;
-	}
+
+    public PassportInfo fromDto(ru.skbkontur.sdk.extern.service.transport.swagger.model.PassportInfo dto) {
+
+        if (dto == null) return null;
+
+        PassportInfo passportInfo = new PassportInfo();
+
+        passportInfo.setCode(dto.getCode());
+        passportInfo.setIssuedBy(dto.getIssuedBy());
+        passportInfo.setIssuedDate(dto.getIssuedDate());
+        passportInfo.setSeriesNumber(dto.getSeriesNumber());
+
+        return passportInfo;
+    }
+
+    public ru.skbkontur.sdk.extern.service.transport.swagger.model.PassportInfo toDto(PassportInfo passportInfo) {
+
+        if (passportInfo == null) return null;
+
+        ru.skbkontur.sdk.extern.service.transport.swagger.model.PassportInfo dto
+                = new ru.skbkontur.sdk.extern.service.transport.swagger.model.PassportInfo();
+
+        dto.setCode(passportInfo.getCode());
+        dto.setIssuedBy(passportInfo.getIssuedBy());
+        dto.setIssuedDate(passportInfo.getIssuedDate());
+        dto.setSeriesNumber(passportInfo.getSeriesNumber());
+
+        return dto;
+    }
 }

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/dto/PeriodIndicatorsDto.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/dto/PeriodIndicatorsDto.java
@@ -7,48 +7,48 @@ package ru.skbkontur.sdk.extern.service.transport.adaptors.dto;
 
 import ru.skbkontur.sdk.extern.model.PeriodIndicators;
 
+
 /**
- *
  * @author alexs
  */
 public class PeriodIndicatorsDto {
 
-	public PeriodIndicators fromDto(ru.skbkontur.sdk.extern.service.transport.swagger.model.PeriodIndicators dto) {
-	
-		if (dto == null) return null;
-		
-		PeriodIndicators i = new PeriodIndicators();
-		
-		i.setAvPu(dto.getAvPu());
-		i.setDohod(dto.getDohod());
-		i.setIschisl(dto.getIschisl());
-		i.setNalBazaUbyt(dto.getNalBazaUbyt());
-		i.setOktmo(dto.getOktmo());
-		i.setRaschTorgSbor(new MerchantTaxDto().fromDto(dto.getRaschTorgSbor()));
-		i.setRashod(dto.getRashod());
-		i.setStavka(dto.getStavka());
-		i.setUmenNal(dto.getUmenNal());
-		
-		return i;
-	}
-	
-	public ru.skbkontur.sdk.extern.service.transport.swagger.model.PeriodIndicators toDto(PeriodIndicators i) {
-	
-		if (i == null) return null;
-		
-		ru.skbkontur.sdk.extern.service.transport.swagger.model.PeriodIndicators dto 
-			= new ru.skbkontur.sdk.extern.service.transport.swagger.model.PeriodIndicators();
-		
-		dto.setAvPu(i.getAvPu());
-		dto.setDohod(i.getDohod());
-		dto.setIschisl(i.getIschisl());
-		dto.setNalBazaUbyt(i.getNalBazaUbyt());
-		dto.setOktmo(i.getOktmo());
-		dto.setRaschTorgSbor(new MerchantTaxDto().toDto(i.getRaschTorgSbor()));
-		dto.setRashod(i.getRashod());
-		dto.setStavka(i.getStavka());
-		dto.setUmenNal(i.getUmenNal());
-		
-		return dto;
-	}
+    public PeriodIndicators fromDto(ru.skbkontur.sdk.extern.service.transport.swagger.model.PeriodIndicators dto) {
+
+        if (dto == null) return null;
+
+        PeriodIndicators i = new PeriodIndicators();
+
+        i.setAvPu(dto.getAvPu());
+        i.setDohod(dto.getDohod());
+        i.setIschisl(dto.getIschisl());
+        i.setNalBazaUbyt(dto.getNalBazaUbyt());
+        i.setOktmo(dto.getOktmo());
+        i.setRaschTorgSbor(new MerchantTaxDto().fromDto(dto.getRaschTorgSbor()));
+        i.setRashod(dto.getRashod());
+        i.setStavka(dto.getStavka());
+        i.setUmenNal(dto.getUmenNal());
+
+        return i;
+    }
+
+    public ru.skbkontur.sdk.extern.service.transport.swagger.model.PeriodIndicators toDto(PeriodIndicators i) {
+
+        if (i == null) return null;
+
+        ru.skbkontur.sdk.extern.service.transport.swagger.model.PeriodIndicators dto
+                = new ru.skbkontur.sdk.extern.service.transport.swagger.model.PeriodIndicators();
+
+        dto.setAvPu(i.getAvPu());
+        dto.setDohod(i.getDohod());
+        dto.setIschisl(i.getIschisl());
+        dto.setNalBazaUbyt(i.getNalBazaUbyt());
+        dto.setOktmo(i.getOktmo());
+        dto.setRaschTorgSbor(new MerchantTaxDto().toDto(i.getRaschTorgSbor()));
+        dto.setRashod(i.getRashod());
+        dto.setStavka(i.getStavka());
+        dto.setUmenNal(i.getUmenNal());
+
+        return dto;
+    }
 }

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/dto/PeriodIndicatorsDto.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/dto/PeriodIndicatorsDto.java
@@ -1,8 +1,27 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * MIT License
+ *
+ * Copyright (c) 2018 SKB Kontur
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  */
+
 package ru.skbkontur.sdk.extern.service.transport.adaptors.dto;
 
 import ru.skbkontur.sdk.extern.model.PeriodIndicators;

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/dto/PrepareResultDto.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/dto/PrepareResultDto.java
@@ -7,38 +7,38 @@ package ru.skbkontur.sdk.extern.service.transport.adaptors.dto;
 
 import java.util.stream.Collectors;
 
+
 /**
- *
  * @author AlexS
  */
 public class PrepareResultDto {
 
-	public ru.skbkontur.sdk.extern.model.PrepareResult fromDto(ru.skbkontur.sdk.extern.service.transport.swagger.model.PrepareResult dto) {
+    public ru.skbkontur.sdk.extern.model.PrepareResult fromDto(ru.skbkontur.sdk.extern.service.transport.swagger.model.PrepareResult dto) {
 
-		if (dto == null) return null;
+        if (dto == null) return null;
 
-		CheckResultDataDto checkResultDataDto = new CheckResultDataDto();
-		LinkDto linkDto = new LinkDto();
-		ru.skbkontur.sdk.extern.model.PrepareResult prepareResult = new ru.skbkontur.sdk.extern.model.PrepareResult();
-		prepareResult.setCheckResult(checkResultDataDto.fromDto(dto.getCheckResult()));
-		prepareResult.setLinks(dto.getLinks().stream().map(l -> linkDto.fromDto(l)).collect(Collectors.toList()));
-		prepareResult.setStatus(ru.skbkontur.sdk.extern.model.PrepareResult.Status.fromValue(dto.getStatus().getValue()));
+        CheckResultDataDto checkResultDataDto = new CheckResultDataDto();
+        LinkDto linkDto = new LinkDto();
+        ru.skbkontur.sdk.extern.model.PrepareResult prepareResult = new ru.skbkontur.sdk.extern.model.PrepareResult();
+        prepareResult.setCheckResult(checkResultDataDto.fromDto(dto.getCheckResult()));
+        prepareResult.setLinks(dto.getLinks().stream().map(l -> linkDto.fromDto(l)).collect(Collectors.toList()));
+        prepareResult.setStatus(ru.skbkontur.sdk.extern.model.PrepareResult.Status.fromValue(dto.getStatus().getValue()));
 
-		return prepareResult;
-	}
+        return prepareResult;
+    }
 
-	public ru.skbkontur.sdk.extern.service.transport.swagger.model.PrepareResult toDto(ru.skbkontur.sdk.extern.model.PrepareResult prepareResult) {
+    public ru.skbkontur.sdk.extern.service.transport.swagger.model.PrepareResult toDto(ru.skbkontur.sdk.extern.model.PrepareResult prepareResult) {
 
-		if (prepareResult == null) return null;
+        if (prepareResult == null) return null;
 
-		CheckResultDataDto checkResultDataDto = new CheckResultDataDto();
-		LinkDto linkDto = new LinkDto();
-		ru.skbkontur.sdk.extern.service.transport.swagger.model.PrepareResult dto
-			= new ru.skbkontur.sdk.extern.service.transport.swagger.model.PrepareResult();
-		dto.setCheckResult(checkResultDataDto.toDto(prepareResult.getCheckResult()));
-		dto.setLinks(prepareResult.getLinks().stream().map(l -> linkDto.toDto(l)).collect(Collectors.toList()));
-		dto.setStatus(ru.skbkontur.sdk.extern.service.transport.swagger.model.PrepareResult.StatusEnum.fromValue(prepareResult.getStatus().getValue()));
+        CheckResultDataDto checkResultDataDto = new CheckResultDataDto();
+        LinkDto linkDto = new LinkDto();
+        ru.skbkontur.sdk.extern.service.transport.swagger.model.PrepareResult dto
+                = new ru.skbkontur.sdk.extern.service.transport.swagger.model.PrepareResult();
+        dto.setCheckResult(checkResultDataDto.toDto(prepareResult.getCheckResult()));
+        dto.setLinks(prepareResult.getLinks().stream().map(l -> linkDto.toDto(l)).collect(Collectors.toList()));
+        dto.setStatus(ru.skbkontur.sdk.extern.service.transport.swagger.model.PrepareResult.StatusEnum.fromValue(prepareResult.getStatus().getValue()));
 
-		return dto;
-	}
+        return dto;
+    }
 }

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/dto/PrepareResultDto.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/dto/PrepareResultDto.java
@@ -1,8 +1,27 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * MIT License
+ *
+ * Copyright (c) 2018 SKB Kontur
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  */
+
 package ru.skbkontur.sdk.extern.service.transport.adaptors.dto;
 
 import java.util.stream.Collectors;

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/dto/RepresentativeDto.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/dto/RepresentativeDto.java
@@ -7,39 +7,39 @@ package ru.skbkontur.sdk.extern.service.transport.adaptors.dto;
 
 import ru.skbkontur.sdk.extern.model.Representative;
 
+
 /**
- *
  * @author alexs
  */
 public class RepresentativeDto {
 
-	public Representative fromDto(ru.skbkontur.sdk.extern.service.transport.swagger.model.Representative dto) {
-		
-		if (dto == null) return null;
-		
-		Representative representative = new Representative();
-		
-		PassportInfoDto pasportInfoDto = new PassportInfoDto();
-		
-		representative.setPassport(pasportInfoDto.fromDto(dto.getPassport()));
-		representative.setRepresentativeDocument(dto.getRepresentativeDocument());
-		
-		return representative;
-	}
-	
-	public ru.skbkontur.sdk.extern.service.transport.swagger.model.Representative toDto(Representative representative) {
-		
-		if (representative == null) return null;
-		
-		ru.skbkontur.sdk.extern.service.transport.swagger.model.Representative dto 
-			= new ru.skbkontur.sdk.extern.service.transport.swagger.model.Representative();
-		
-		PassportInfoDto pasportInfoDto = new PassportInfoDto();
-		
-		dto.setPassport(pasportInfoDto.toDto(representative.getPassport()));
-		dto.setRepresentativeDocument(representative.getRepresentativeDocument());
-		
-		return dto;
-	}
-	
+    public Representative fromDto(ru.skbkontur.sdk.extern.service.transport.swagger.model.Representative dto) {
+
+        if (dto == null) return null;
+
+        Representative representative = new Representative();
+
+        PassportInfoDto pasportInfoDto = new PassportInfoDto();
+
+        representative.setPassport(pasportInfoDto.fromDto(dto.getPassport()));
+        representative.setRepresentativeDocument(dto.getRepresentativeDocument());
+
+        return representative;
+    }
+
+    public ru.skbkontur.sdk.extern.service.transport.swagger.model.Representative toDto(Representative representative) {
+
+        if (representative == null) return null;
+
+        ru.skbkontur.sdk.extern.service.transport.swagger.model.Representative dto
+                = new ru.skbkontur.sdk.extern.service.transport.swagger.model.Representative();
+
+        PassportInfoDto pasportInfoDto = new PassportInfoDto();
+
+        dto.setPassport(pasportInfoDto.toDto(representative.getPassport()));
+        dto.setRepresentativeDocument(representative.getRepresentativeDocument());
+
+        return dto;
+    }
+
 }

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/dto/RepresentativeDto.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/dto/RepresentativeDto.java
@@ -1,8 +1,27 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * MIT License
+ *
+ * Copyright (c) 2018 SKB Kontur
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  */
+
 package ru.skbkontur.sdk.extern.service.transport.adaptors.dto;
 
 import ru.skbkontur.sdk.extern.model.Representative;

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/dto/SignatureDto.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/dto/SignatureDto.java
@@ -1,8 +1,27 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * MIT License
+ *
+ * Copyright (c) 2018 SKB Kontur
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  */
+
 package ru.skbkontur.sdk.extern.service.transport.adaptors.dto;
 
 import java.util.stream.Collectors;

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/dto/SignatureDto.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/dto/SignatureDto.java
@@ -7,44 +7,44 @@ package ru.skbkontur.sdk.extern.service.transport.adaptors.dto;
 
 import java.util.stream.Collectors;
 
+
 /**
- *
  * @author AlexS
  */
 public class SignatureDto {
 
-	public SignatureDto() {
-	}
+    public SignatureDto() {
+    }
 
-	public ru.skbkontur.sdk.extern.model.Signature fromDto(ru.skbkontur.sdk.extern.service.transport.swagger.model.Signature dto) {
+    public ru.skbkontur.sdk.extern.model.Signature fromDto(ru.skbkontur.sdk.extern.service.transport.swagger.model.Signature dto) {
 
-		if (dto == null) return null;
+        if (dto == null) return null;
 
-		ru.skbkontur.sdk.extern.model.Signature signature
-			= new ru.skbkontur.sdk.extern.model.Signature();
+        ru.skbkontur.sdk.extern.model.Signature signature
+                = new ru.skbkontur.sdk.extern.model.Signature();
 
-		LinkDto linkDto = new LinkDto();
+        LinkDto linkDto = new LinkDto();
 
-		signature.setContentLink(linkDto.fromDto(dto.getContentLink()));
-		signature.setId(dto.getId());
-		signature.setLinks(dto.getLinks().stream().map(l -> linkDto.fromDto(l)).collect(Collectors.toList()));
+        signature.setContentLink(linkDto.fromDto(dto.getContentLink()));
+        signature.setId(dto.getId());
+        signature.setLinks(dto.getLinks().stream().map(l -> linkDto.fromDto(l)).collect(Collectors.toList()));
 
-		return signature;
-	}
+        return signature;
+    }
 
-	public ru.skbkontur.sdk.extern.service.transport.swagger.model.Signature toDto(ru.skbkontur.sdk.extern.model.Signature signature) {
+    public ru.skbkontur.sdk.extern.service.transport.swagger.model.Signature toDto(ru.skbkontur.sdk.extern.model.Signature signature) {
 
-		if (signature == null) return null;
+        if (signature == null) return null;
 
-		LinkDto linkDto = new LinkDto();
-		ru.skbkontur.sdk.extern.service.transport.swagger.model.Signature dto
-			= new ru.skbkontur.sdk.extern.service.transport.swagger.model.Signature();
-		dto.setContentLink(linkDto.toDto(signature.getContentLink()));
-		dto.setId(signature.getId());
-		if (signature.getLinks() != null) {
-			dto.setLinks(signature.getLinks().stream().map(l -> linkDto.toDto(l)).collect(Collectors.toList()));
-		}
+        LinkDto linkDto = new LinkDto();
+        ru.skbkontur.sdk.extern.service.transport.swagger.model.Signature dto
+                = new ru.skbkontur.sdk.extern.service.transport.swagger.model.Signature();
+        dto.setContentLink(linkDto.toDto(signature.getContentLink()));
+        dto.setId(signature.getId());
+        if (signature.getLinks() != null) {
+            dto.setLinks(signature.getLinks().stream().map(l -> linkDto.toDto(l)).collect(Collectors.toList()));
+        }
 
-		return dto;
-	}
+        return dto;
+    }
 }

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/dto/SignatureToSendDto.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/dto/SignatureToSendDto.java
@@ -1,8 +1,27 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * MIT License
+ *
+ * Copyright (c) 2018 SKB Kontur
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  */
+
 package ru.skbkontur.sdk.extern.service.transport.adaptors.dto;
 
 import java.util.Map;

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/dto/SignatureToSendDto.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/dto/SignatureToSendDto.java
@@ -7,48 +7,48 @@ package ru.skbkontur.sdk.extern.service.transport.adaptors.dto;
 
 import java.util.Map;
 
+
 /**
- *
  * @author AlexS
  */
 public class SignatureToSendDto {
 
-	public SignatureToSendDto() {
-	}
-	
-	public ru.skbkontur.sdk.extern.model.SignatureToSend fromDto(ru.skbkontur.sdk.extern.service.transport.swagger.model.SignatureToSend dto) {
-		
-		if (dto == null) return null;
-		
-		ru.skbkontur.sdk.extern.model.SignatureToSend signatureToSend = new ru.skbkontur.sdk.extern.model.SignatureToSend();
-		
-		signatureToSend.setContentData(dto.getContentData());
-		signatureToSend.setId(dto.getId());
-		
-		return signatureToSend;
-	}
+    public SignatureToSendDto() {
+    }
 
-	public ru.skbkontur.sdk.extern.model.SignatureToSend fromDto(Map<String,Object> dto) {
-		
-		if (dto == null) return null;
-		
-		ru.skbkontur.sdk.extern.model.SignatureToSend signatureToSend = new ru.skbkontur.sdk.extern.model.SignatureToSend();
-		
-		signatureToSend.setContentData((byte[])dto.get("content-data"));
-		signatureToSend.setId((String)dto.get("id"));
-		
-		return signatureToSend;
-	}
+    public ru.skbkontur.sdk.extern.model.SignatureToSend fromDto(ru.skbkontur.sdk.extern.service.transport.swagger.model.SignatureToSend dto) {
 
-	public ru.skbkontur.sdk.extern.service.transport.swagger.model.SignatureToSend toDto(ru.skbkontur.sdk.extern.model.SignatureToSend signatureToSend) {
-		
-		if (signatureToSend == null) return null;
-		
-		ru.skbkontur.sdk.extern.service.transport.swagger.model.SignatureToSend dto = new ru.skbkontur.sdk.extern.service.transport.swagger.model.SignatureToSend();
-		
-		dto.setContentData(signatureToSend.getContentData());
-		dto.setId(signatureToSend.getId());
-		
-		return dto;
-	}
+        if (dto == null) return null;
+
+        ru.skbkontur.sdk.extern.model.SignatureToSend signatureToSend = new ru.skbkontur.sdk.extern.model.SignatureToSend();
+
+        signatureToSend.setContentData(dto.getContentData());
+        signatureToSend.setId(dto.getId());
+
+        return signatureToSend;
+    }
+
+    public ru.skbkontur.sdk.extern.model.SignatureToSend fromDto(Map<String, Object> dto) {
+
+        if (dto == null) return null;
+
+        ru.skbkontur.sdk.extern.model.SignatureToSend signatureToSend = new ru.skbkontur.sdk.extern.model.SignatureToSend();
+
+        signatureToSend.setContentData((byte[]) dto.get("content-data"));
+        signatureToSend.setId((String) dto.get("id"));
+
+        return signatureToSend;
+    }
+
+    public ru.skbkontur.sdk.extern.service.transport.swagger.model.SignatureToSend toDto(ru.skbkontur.sdk.extern.model.SignatureToSend signatureToSend) {
+
+        if (signatureToSend == null) return null;
+
+        ru.skbkontur.sdk.extern.service.transport.swagger.model.SignatureToSend dto = new ru.skbkontur.sdk.extern.service.transport.swagger.model.SignatureToSend();
+
+        dto.setContentData(signatureToSend.getContentData());
+        dto.setId(signatureToSend.getId());
+
+        return dto;
+    }
 }

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/dto/TaxPeriodIndicatorsDto.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/dto/TaxPeriodIndicatorsDto.java
@@ -1,8 +1,27 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * MIT License
+ *
+ * Copyright (c) 2018 SKB Kontur
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  */
+
 package ru.skbkontur.sdk.extern.service.transport.adaptors.dto;
 
 import ru.skbkontur.sdk.extern.model.TaxPeriodIndicators;

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/dto/TaxPeriodIndicatorsDto.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/dto/TaxPeriodIndicatorsDto.java
@@ -7,50 +7,50 @@ package ru.skbkontur.sdk.extern.service.transport.adaptors.dto;
 
 import ru.skbkontur.sdk.extern.model.TaxPeriodIndicators;
 
+
 /**
- *
  * @author alexs
  */
 public class TaxPeriodIndicatorsDto {
 
-	public TaxPeriodIndicators fromDto(ru.skbkontur.sdk.extern.service.transport.swagger.model.TaxPeriodIndicators dto) {
-		
-		if (dto == null) return null;
-		
-		TaxPeriodIndicators i = new TaxPeriodIndicators();
+    public TaxPeriodIndicators fromDto(ru.skbkontur.sdk.extern.service.transport.swagger.model.TaxPeriodIndicators dto) {
 
-		i.setAvPu(dto.getAvPu());
-		i.setDohod(dto.getDohod());
-		i.setIschisl(dto.getIschisl());
-		i.setNalBazaUbyt(dto.getNalBazaUbyt());
-		i.setNalPumin(dto.getNalPumin());
-		i.setOktmo(dto.getOktmo());
-		i.setRaschTorgSbor(new MerchantTaxDto().fromDto(dto.getRaschTorgSbor()));
-		i.setRashod(dto.getRashod());
-		i.setStavka(dto.getStavka());
-		i.setUmenNal(dto.getUmenNal());
-		
-		return i;
-	}
-	
-	public ru.skbkontur.sdk.extern.service.transport.swagger.model.TaxPeriodIndicators toDto(TaxPeriodIndicators i) {
-		
-		if (i == null) return null;
-		
-		ru.skbkontur.sdk.extern.service.transport.swagger.model.TaxPeriodIndicators dto
-			= new ru.skbkontur.sdk.extern.service.transport.swagger.model.TaxPeriodIndicators();
+        if (dto == null) return null;
 
-		dto.setAvPu(i.getAvPu());
-		dto.setDohod(i.getDohod());
-		dto.setIschisl(i.getIschisl());
-		dto.setNalBazaUbyt(i.getNalBazaUbyt());
-		dto.setNalPumin(i.getNalPumin());
-		dto.setOktmo(i.getOktmo());
-		dto.setRaschTorgSbor(new MerchantTaxDto().toDto(i.getRaschTorgSbor()));
-		dto.setRashod(i.getRashod());
-		dto.setStavka(i.getStavka());
-		dto.setUmenNal(i.getUmenNal());
-		
-		return dto;
-	}
+        TaxPeriodIndicators i = new TaxPeriodIndicators();
+
+        i.setAvPu(dto.getAvPu());
+        i.setDohod(dto.getDohod());
+        i.setIschisl(dto.getIschisl());
+        i.setNalBazaUbyt(dto.getNalBazaUbyt());
+        i.setNalPumin(dto.getNalPumin());
+        i.setOktmo(dto.getOktmo());
+        i.setRaschTorgSbor(new MerchantTaxDto().fromDto(dto.getRaschTorgSbor()));
+        i.setRashod(dto.getRashod());
+        i.setStavka(dto.getStavka());
+        i.setUmenNal(dto.getUmenNal());
+
+        return i;
+    }
+
+    public ru.skbkontur.sdk.extern.service.transport.swagger.model.TaxPeriodIndicators toDto(TaxPeriodIndicators i) {
+
+        if (i == null) return null;
+
+        ru.skbkontur.sdk.extern.service.transport.swagger.model.TaxPeriodIndicators dto
+                = new ru.skbkontur.sdk.extern.service.transport.swagger.model.TaxPeriodIndicators();
+
+        dto.setAvPu(i.getAvPu());
+        dto.setDohod(i.getDohod());
+        dto.setIschisl(i.getIschisl());
+        dto.setNalBazaUbyt(i.getNalBazaUbyt());
+        dto.setNalPumin(i.getNalPumin());
+        dto.setOktmo(i.getOktmo());
+        dto.setRaschTorgSbor(new MerchantTaxDto().toDto(i.getRaschTorgSbor()));
+        dto.setRashod(i.getRashod());
+        dto.setStavka(i.getStavka());
+        dto.setUmenNal(i.getUmenNal());
+
+        return dto;
+    }
 }

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/dto/TaxpayerDto.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/dto/TaxpayerDto.java
@@ -1,8 +1,27 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * MIT License
+ *
+ * Copyright (c) 2018 SKB Kontur
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  */
+
 package ru.skbkontur.sdk.extern.service.transport.adaptors.dto;
 
 import ru.skbkontur.sdk.extern.model.Taxpayer;

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/dto/TaxpayerDto.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/dto/TaxpayerDto.java
@@ -7,44 +7,44 @@ package ru.skbkontur.sdk.extern.service.transport.adaptors.dto;
 
 import ru.skbkontur.sdk.extern.model.Taxpayer;
 
+
 /**
- *
  * @author alexs
  */
 public class TaxpayerDto {
-	
-	public Taxpayer fromDto(ru.skbkontur.sdk.extern.service.transport.swagger.model.Taxpayer dto) {
-		
-		if (dto == null) return null;
-		
-		Taxpayer taxpayer = new Taxpayer();
-		
-		RepresentativeDto representativeDto = new RepresentativeDto();
-		
-		taxpayer.setRepresentative(representativeDto.fromDto(dto.getRepresentative()));
-		taxpayer.setTaxpayerChiefFio(dto.getTaxpayerChiefFio());
-		taxpayer.setTaxpayerFullName(dto.getTaxpayerFullName());
-		taxpayer.setTaxpayerOkved(dto.getTaxpayerOkved());
-		taxpayer.setTaxpayerPhone(dto.getTaxpayerPhone());
-		
-		return taxpayer;
-	}
 
-	public ru.skbkontur.sdk.extern.service.transport.swagger.model.Taxpayer toDto(Taxpayer taxpayer) {
-		
-		if (taxpayer == null) return null;
-		
-		ru.skbkontur.sdk.extern.service.transport.swagger.model.Taxpayer dto 
-			= new ru.skbkontur.sdk.extern.service.transport.swagger.model.Taxpayer();
-		
-		RepresentativeDto representativeDto = new RepresentativeDto();
-		
-		dto.setRepresentative(representativeDto.toDto(taxpayer.getRepresentative()));
-		dto.setTaxpayerChiefFio(taxpayer.getTaxpayerChiefFio());
-		dto.setTaxpayerFullName(taxpayer.getTaxpayerFullName());
-		dto.setTaxpayerOkved(taxpayer.getTaxpayerOkved());
-		dto.setTaxpayerPhone(taxpayer.getTaxpayerPhone());
-		
-		return dto;
-	}
+    public Taxpayer fromDto(ru.skbkontur.sdk.extern.service.transport.swagger.model.Taxpayer dto) {
+
+        if (dto == null) return null;
+
+        Taxpayer taxpayer = new Taxpayer();
+
+        RepresentativeDto representativeDto = new RepresentativeDto();
+
+        taxpayer.setRepresentative(representativeDto.fromDto(dto.getRepresentative()));
+        taxpayer.setTaxpayerChiefFio(dto.getTaxpayerChiefFio());
+        taxpayer.setTaxpayerFullName(dto.getTaxpayerFullName());
+        taxpayer.setTaxpayerOkved(dto.getTaxpayerOkved());
+        taxpayer.setTaxpayerPhone(dto.getTaxpayerPhone());
+
+        return taxpayer;
+    }
+
+    public ru.skbkontur.sdk.extern.service.transport.swagger.model.Taxpayer toDto(Taxpayer taxpayer) {
+
+        if (taxpayer == null) return null;
+
+        ru.skbkontur.sdk.extern.service.transport.swagger.model.Taxpayer dto
+                = new ru.skbkontur.sdk.extern.service.transport.swagger.model.Taxpayer();
+
+        RepresentativeDto representativeDto = new RepresentativeDto();
+
+        dto.setRepresentative(representativeDto.toDto(taxpayer.getRepresentative()));
+        dto.setTaxpayerChiefFio(taxpayer.getTaxpayerChiefFio());
+        dto.setTaxpayerFullName(taxpayer.getTaxpayerFullName());
+        dto.setTaxpayerOkved(taxpayer.getTaxpayerOkved());
+        dto.setTaxpayerPhone(taxpayer.getTaxpayerPhone());
+
+        return dto;
+    }
 }

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/dto/UsnDataV2Dto.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/dto/UsnDataV2Dto.java
@@ -7,53 +7,53 @@ package ru.skbkontur.sdk.extern.service.transport.adaptors.dto;
 
 import ru.skbkontur.sdk.extern.model.UsnDataV2;
 
+
 /**
- *
  * @author alexs
  */
 public class UsnDataV2Dto {
 
 
-	public UsnDataV2 fromDto(ru.skbkontur.sdk.extern.service.transport.swagger.model.UsnDataV2 dto) {
-		
-		if (dto == null) return null;
-		
-		UsnDataV2 v2 = new UsnDataV2();
-		
-		PeriodIndicatorsDto periodIndicatorsDto = new PeriodIndicatorsDto();
-		
-		v2.setIschislMin(dto.getIschislMin());
-		v2.setNomKorr(dto.getNomKorr());
-		v2.setPoMestu(dto.getPoMestu());
-		v2.setPrizNp(dto.getPrizNp());
-		v2.setUbytPred(dto.getUbytPred());
-		v2.setZaKv(periodIndicatorsDto.fromDto(dto.getZaKv()));
-		v2.setZaNalPer(new TaxPeriodIndicatorsDto().fromDto(dto.getZaNalPer()));
-		v2.setZaPg(periodIndicatorsDto.fromDto(dto.getZaPg()));
-		v2.setZa9m(periodIndicatorsDto.fromDto(dto.getZa9m()));
-		
-		return v2;
-	}
-	
-	public ru.skbkontur.sdk.extern.service.transport.swagger.model.UsnDataV2 toDto(UsnDataV2 v2) {
-		
-		if (v2 == null) return null;
-		
-		ru.skbkontur.sdk.extern.service.transport.swagger.model.UsnDataV2 dto 
-			= new ru.skbkontur.sdk.extern.service.transport.swagger.model.UsnDataV2();
-		
-		PeriodIndicatorsDto periodIndicatorsDto = new PeriodIndicatorsDto();
-		
-		dto.setIschislMin(v2.getIschislMin());
-		dto.setNomKorr(v2.getNomKorr());
-		dto.setPoMestu(v2.getPoMestu());
-		dto.setPrizNp(dto.getPrizNp());
-		dto.setUbytPred(v2.getUbytPred());
-		dto.setZa9m(periodIndicatorsDto.toDto(v2.getZa9m()));
-		dto.setZaKv(periodIndicatorsDto.toDto(v2.getZaKv()));
-		dto.setZaNalPer(new TaxPeriodIndicatorsDto().toDto(v2.getZaNalPer()));
-		dto.setZaPg(periodIndicatorsDto.toDto(v2.getZaPg()));
-		
-		return dto;
-	}
+    public UsnDataV2 fromDto(ru.skbkontur.sdk.extern.service.transport.swagger.model.UsnDataV2 dto) {
+
+        if (dto == null) return null;
+
+        UsnDataV2 v2 = new UsnDataV2();
+
+        PeriodIndicatorsDto periodIndicatorsDto = new PeriodIndicatorsDto();
+
+        v2.setIschislMin(dto.getIschislMin());
+        v2.setNomKorr(dto.getNomKorr());
+        v2.setPoMestu(dto.getPoMestu());
+        v2.setPrizNp(dto.getPrizNp());
+        v2.setUbytPred(dto.getUbytPred());
+        v2.setZaKv(periodIndicatorsDto.fromDto(dto.getZaKv()));
+        v2.setZaNalPer(new TaxPeriodIndicatorsDto().fromDto(dto.getZaNalPer()));
+        v2.setZaPg(periodIndicatorsDto.fromDto(dto.getZaPg()));
+        v2.setZa9m(periodIndicatorsDto.fromDto(dto.getZa9m()));
+
+        return v2;
+    }
+
+    public ru.skbkontur.sdk.extern.service.transport.swagger.model.UsnDataV2 toDto(UsnDataV2 v2) {
+
+        if (v2 == null) return null;
+
+        ru.skbkontur.sdk.extern.service.transport.swagger.model.UsnDataV2 dto
+                = new ru.skbkontur.sdk.extern.service.transport.swagger.model.UsnDataV2();
+
+        PeriodIndicatorsDto periodIndicatorsDto = new PeriodIndicatorsDto();
+
+        dto.setIschislMin(v2.getIschislMin());
+        dto.setNomKorr(v2.getNomKorr());
+        dto.setPoMestu(v2.getPoMestu());
+        dto.setPrizNp(dto.getPrizNp());
+        dto.setUbytPred(v2.getUbytPred());
+        dto.setZa9m(periodIndicatorsDto.toDto(v2.getZa9m()));
+        dto.setZaKv(periodIndicatorsDto.toDto(v2.getZaKv()));
+        dto.setZaNalPer(new TaxPeriodIndicatorsDto().toDto(v2.getZaNalPer()));
+        dto.setZaPg(periodIndicatorsDto.toDto(v2.getZaPg()));
+
+        return dto;
+    }
 }

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/dto/UsnDataV2Dto.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/dto/UsnDataV2Dto.java
@@ -1,8 +1,27 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * MIT License
+ *
+ * Copyright (c) 2018 SKB Kontur
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  */
+
 package ru.skbkontur.sdk.extern.service.transport.adaptors.dto;
 
 import ru.skbkontur.sdk.extern.model.UsnDataV2;

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/dto/UsnFormatPeriodDto.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/dto/UsnFormatPeriodDto.java
@@ -1,8 +1,27 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * MIT License
+ *
+ * Copyright (c) 2018 SKB Kontur
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  */
+
 package ru.skbkontur.sdk.extern.service.transport.adaptors.dto;
 
 import ru.skbkontur.sdk.extern.model.UsnFormatPeriod;

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/dto/UsnFormatPeriodDto.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/dto/UsnFormatPeriodDto.java
@@ -8,34 +8,34 @@ package ru.skbkontur.sdk.extern.service.transport.adaptors.dto;
 import ru.skbkontur.sdk.extern.model.UsnFormatPeriod;
 import ru.skbkontur.sdk.extern.model.UsnFormatPeriod.PeriodModifiersEnum;
 
+
 /**
- *
  * @author alexs
  */
 public class UsnFormatPeriodDto {
-	
-	public UsnFormatPeriod fromDto(ru.skbkontur.sdk.extern.service.transport.swagger.model.UsnFormatPeriod dto) {
-		
-		if (dto == null) return null;
-		
-		UsnFormatPeriod period = new UsnFormatPeriod();
-		
-		period.setPeriodModifiers(PeriodModifiersEnum.fromValue(dto.getPeriodModifiers().getValue()));
-		period.setYear(dto.getYear());
-		
-		return period;
-	}
-	
-	public ru.skbkontur.sdk.extern.service.transport.swagger.model.UsnFormatPeriod toDto(UsnFormatPeriod period) {
-		
-		if (period == null) return null;
-		
-		ru.skbkontur.sdk.extern.service.transport.swagger.model.UsnFormatPeriod dto 
-			= new ru.skbkontur.sdk.extern.service.transport.swagger.model.UsnFormatPeriod();
-		
-		dto.setPeriodModifiers(ru.skbkontur.sdk.extern.service.transport.swagger.model.UsnFormatPeriod.PeriodModifiersEnum.fromValue(period.getPeriodModifiers().getValue()));
-		dto.setYear(period.getYear());
-		
-		return dto;
-	}
+
+    public UsnFormatPeriod fromDto(ru.skbkontur.sdk.extern.service.transport.swagger.model.UsnFormatPeriod dto) {
+
+        if (dto == null) return null;
+
+        UsnFormatPeriod period = new UsnFormatPeriod();
+
+        period.setPeriodModifiers(PeriodModifiersEnum.fromValue(dto.getPeriodModifiers().getValue()));
+        period.setYear(dto.getYear());
+
+        return period;
+    }
+
+    public ru.skbkontur.sdk.extern.service.transport.swagger.model.UsnFormatPeriod toDto(UsnFormatPeriod period) {
+
+        if (period == null) return null;
+
+        ru.skbkontur.sdk.extern.service.transport.swagger.model.UsnFormatPeriod dto
+                = new ru.skbkontur.sdk.extern.service.transport.swagger.model.UsnFormatPeriod();
+
+        dto.setPeriodModifiers(ru.skbkontur.sdk.extern.service.transport.swagger.model.UsnFormatPeriod.PeriodModifiersEnum.fromValue(period.getPeriodModifiers().getValue()));
+        dto.setYear(period.getYear());
+
+        return dto;
+    }
 }

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/dto/UsnServiceContractInfoDto.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/dto/UsnServiceContractInfoDto.java
@@ -7,42 +7,42 @@ package ru.skbkontur.sdk.extern.service.transport.adaptors.dto;
 
 import ru.skbkontur.sdk.extern.model.UsnServiceContractInfo;
 
+
 /**
- *
  * @author alexs
  */
 public class UsnServiceContractInfoDto {
-	
-	public UsnServiceContractInfo fromDto(ru.skbkontur.sdk.extern.service.transport.swagger.model.UsnServiceContractInfoObject dto) {
-		
-		if (dto == null) return null;
-		
-		UsnServiceContractInfo info = new UsnServiceContractInfo();
-		
-		AdditionalClientInfoDto additionalOrgInfoDto = new AdditionalClientInfoDto();
-		UsnFormatPeriodDto usnFormatPeriodDto = new UsnFormatPeriodDto();
-		
-		info.setAdditionalOrgInfo(additionalOrgInfoDto.fromDto(dto.getAdditionalOrgInfo()));
-		info.setData(dto.getData());
-		info.setPeriod(usnFormatPeriodDto.fromDto(dto.getPeriod()));
-		
-		return info;
-	}
-	
-	public ru.skbkontur.sdk.extern.service.transport.swagger.model.UsnServiceContractInfoObject toDto(UsnServiceContractInfo info) {
-		
-		if (info == null) return null;
-		
-		ru.skbkontur.sdk.extern.service.transport.swagger.model.UsnServiceContractInfoObject dto 
-			= new ru.skbkontur.sdk.extern.service.transport.swagger.model.UsnServiceContractInfoObject();
-		
-		AdditionalClientInfoDto additionalOrgInfoDto = new AdditionalClientInfoDto();
-		UsnFormatPeriodDto usnFormatPeriodDto = new UsnFormatPeriodDto();
-		
-		dto.setAdditionalOrgInfo(additionalOrgInfoDto.toDto(info.getAdditionalOrgInfo()));
-		dto.setData(info.getData());
-		dto.setPeriod(usnFormatPeriodDto.toDto(info.getPeriod()));
-		
-		return dto;
-	}
+
+    public UsnServiceContractInfo fromDto(ru.skbkontur.sdk.extern.service.transport.swagger.model.UsnServiceContractInfoObject dto) {
+
+        if (dto == null) return null;
+
+        UsnServiceContractInfo info = new UsnServiceContractInfo();
+
+        AdditionalClientInfoDto additionalOrgInfoDto = new AdditionalClientInfoDto();
+        UsnFormatPeriodDto usnFormatPeriodDto = new UsnFormatPeriodDto();
+
+        info.setAdditionalOrgInfo(additionalOrgInfoDto.fromDto(dto.getAdditionalOrgInfo()));
+        info.setData(dto.getData());
+        info.setPeriod(usnFormatPeriodDto.fromDto(dto.getPeriod()));
+
+        return info;
+    }
+
+    public ru.skbkontur.sdk.extern.service.transport.swagger.model.UsnServiceContractInfoObject toDto(UsnServiceContractInfo info) {
+
+        if (info == null) return null;
+
+        ru.skbkontur.sdk.extern.service.transport.swagger.model.UsnServiceContractInfoObject dto
+                = new ru.skbkontur.sdk.extern.service.transport.swagger.model.UsnServiceContractInfoObject();
+
+        AdditionalClientInfoDto additionalOrgInfoDto = new AdditionalClientInfoDto();
+        UsnFormatPeriodDto usnFormatPeriodDto = new UsnFormatPeriodDto();
+
+        dto.setAdditionalOrgInfo(additionalOrgInfoDto.toDto(info.getAdditionalOrgInfo()));
+        dto.setData(info.getData());
+        dto.setPeriod(usnFormatPeriodDto.toDto(info.getPeriod()));
+
+        return dto;
+    }
 }

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/dto/UsnServiceContractInfoDto.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/dto/UsnServiceContractInfoDto.java
@@ -1,8 +1,27 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * MIT License
+ *
+ * Copyright (c) 2018 SKB Kontur
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  */
+
 package ru.skbkontur.sdk.extern.service.transport.adaptors.dto;
 
 import ru.skbkontur.sdk.extern.model.UsnServiceContractInfo;

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/dto/UsnServiceContractInfoV2Dto.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/dto/UsnServiceContractInfoV2Dto.java
@@ -7,36 +7,36 @@ package ru.skbkontur.sdk.extern.service.transport.adaptors.dto;
 
 import ru.skbkontur.sdk.extern.model.UsnServiceContractInfoV2;
 
+
 /**
- *
  * @author alexs
  */
 public class UsnServiceContractInfoV2Dto {
-	
-	public UsnServiceContractInfoV2 fromDto(ru.skbkontur.sdk.extern.service.transport.swagger.model.UsnServiceContractInfoUsnDataV2 dto) {
-		
-		if (dto == null) return null;
-		
-		UsnServiceContractInfoV2 data = new UsnServiceContractInfoV2();
-		
-		data.setAdditionalOrgInfo(new AdditionalClientInfoDto().fromDto(dto.getAdditionalOrgInfo()));
-		data.setData(new UsnDataV2Dto().fromDto(dto.getData()));
-		data.setPeriod(new UsnFormatPeriodDto().fromDto(dto.getPeriod()));
-		
-		return data;
-	}
 
-	public ru.skbkontur.sdk.extern.service.transport.swagger.model.UsnServiceContractInfoUsnDataV2 toDto(UsnServiceContractInfoV2 data) {
-		
-		if (data == null) return null;
-		
-		ru.skbkontur.sdk.extern.service.transport.swagger.model.UsnServiceContractInfoUsnDataV2 dto 
-			= new ru.skbkontur.sdk.extern.service.transport.swagger.model.UsnServiceContractInfoUsnDataV2();
-		
-		dto.setAdditionalOrgInfo(new AdditionalClientInfoDto().toDto(data.getAdditionalOrgInfo()));
-		dto.setData(new UsnDataV2Dto().toDto(data.getData()));
-		dto.setPeriod(new UsnFormatPeriodDto().toDto(data.getPeriod()));
-		
-		return dto;
-	}
+    public UsnServiceContractInfoV2 fromDto(ru.skbkontur.sdk.extern.service.transport.swagger.model.UsnServiceContractInfoUsnDataV2 dto) {
+
+        if (dto == null) return null;
+
+        UsnServiceContractInfoV2 data = new UsnServiceContractInfoV2();
+
+        data.setAdditionalOrgInfo(new AdditionalClientInfoDto().fromDto(dto.getAdditionalOrgInfo()));
+        data.setData(new UsnDataV2Dto().fromDto(dto.getData()));
+        data.setPeriod(new UsnFormatPeriodDto().fromDto(dto.getPeriod()));
+
+        return data;
+    }
+
+    public ru.skbkontur.sdk.extern.service.transport.swagger.model.UsnServiceContractInfoUsnDataV2 toDto(UsnServiceContractInfoV2 data) {
+
+        if (data == null) return null;
+
+        ru.skbkontur.sdk.extern.service.transport.swagger.model.UsnServiceContractInfoUsnDataV2 dto
+                = new ru.skbkontur.sdk.extern.service.transport.swagger.model.UsnServiceContractInfoUsnDataV2();
+
+        dto.setAdditionalOrgInfo(new AdditionalClientInfoDto().toDto(data.getAdditionalOrgInfo()));
+        dto.setData(new UsnDataV2Dto().toDto(data.getData()));
+        dto.setPeriod(new UsnFormatPeriodDto().toDto(data.getPeriod()));
+
+        return dto;
+    }
 }

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/dto/UsnServiceContractInfoV2Dto.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/adaptors/dto/UsnServiceContractInfoV2Dto.java
@@ -1,8 +1,27 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * MIT License
+ *
+ * Copyright (c) 2018 SKB Kontur
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  */
+
 package ru.skbkontur.sdk.extern.service.transport.adaptors.dto;
 
 import ru.skbkontur.sdk.extern.model.UsnServiceContractInfoV2;

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/invoker/ApiClient.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/invoker/ApiClient.java
@@ -1,8 +1,27 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * MIT License
+ *
+ * Copyright (c) 2018 SKB Kontur
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  */
+
 package ru.skbkontur.sdk.extern.service.transport.invoker;
 
 import com.squareup.okhttp.Call;

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/invoker/ApiClient.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/invoker/ApiClient.java
@@ -8,84 +8,79 @@ package ru.skbkontur.sdk.extern.service.transport.invoker;
 import com.squareup.okhttp.Call;
 import com.squareup.okhttp.MediaType;
 import com.squareup.okhttp.RequestBody;
+import ru.skbkontur.sdk.extern.service.transport.swagger.invoker.Pair;
+
 import java.io.File;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
-import ru.skbkontur.sdk.extern.service.transport.swagger.invoker.Pair;
+
 
 /**
- *
  * @author AlexS
  */
 public class ApiClient extends ru.skbkontur.sdk.extern.service.transport.swagger.invoker.ApiClient {
 
-	public ApiClient() {
-		super();
-		setUserAgent(UserAgentService.USER_AGENT_STRING);
-	}
+    public ApiClient() {
+        super();
+        setUserAgent(UserAgentService.USER_AGENT_STRING);
+    }
 
-	/**
-	 * Serialize the given Java object into request body according to the object's class and the request Content-Type.
-	 *
-	 * @param obj The Java object
-	 * @param contentType The request Content-Type
-	 * @return The serialized request body
-	 * @throws ru.skbkontur.sdk.extern.service.transport.swagger.invoker.ApiException a swagger Exception
-	 */
-	@Override
-	public RequestBody serialize(Object obj, String contentType) throws ru.skbkontur.sdk.extern.service.transport.swagger.invoker.ApiException {
-		if (obj instanceof byte[]) {
-			// Binary (byte array) body parameter support.
-			return RequestBody.create(MediaType.parse(contentType), (byte[]) obj);
-		}
-		else if (obj instanceof String) {
-			// File body parameter support.
-			return RequestBody.create(MediaType.parse(contentType), (String) obj);
-		}
-		else if (obj instanceof File) {
-			// File body parameter support.
-			return RequestBody.create(MediaType.parse(contentType), (File) obj);
-		}
-		else if (isJsonMime(contentType)) {
-			String content;
-			if (obj != null) {
-				content = getJSON().serialize(obj);
-			}
-			else {
-				content = null;
-			}
-			return RequestBody.create(MediaType.parse(contentType), content);
-		}
-		else {
-			throw new ru.skbkontur.sdk.extern.service.transport.swagger.invoker.ApiException("Content type \"" + contentType + "\" is not supported");
-		}
-	}
-	
-	public <T> ApiResponse<T> submitHttpRequest(String httpRequestUri, String httpMetod, Map<String, String> queryParams, Object body, Map<String, String> headerParams, Map<String, Object> formParams, Class<T> dtoClass) throws ApiException {
-		try {
-			String[] localVarAuthNames = new String[]{"apiKey", "auth.sid"};
-			
-			List<Pair> params
-				= queryParams
-					.entrySet()
-					.stream()
-					.map(e -> new Pair(e.getKey(), e.getValue()))
-					.collect(Collectors.toList());
-			
-			Call call = buildCall(httpRequestUri, httpMetod, params, body, headerParams, formParams, localVarAuthNames, null);
-			
-			ru.skbkontur.sdk.extern.service.transport.swagger.invoker.ApiResponse<T> resp = this.execute(call, dtoClass);
-			
-			return new ApiResponse<>(resp.getStatusCode(), resp.getHeaders(), resp.getData());
-		}
-		catch (ru.skbkontur.sdk.extern.service.transport.swagger.invoker.ApiException x) {
-			throw new ApiException(x.getMessage(), x.getCause(), x.getCode(), x.getResponseHeaders(), x.getResponseBody());
-		}
-	}
-	
-	public void setReadTimeout(int milliseconds) {
-		getHttpClient().setReadTimeout(milliseconds, TimeUnit.MILLISECONDS);
-	}
+    /**
+     * Serialize the given Java object into request body according to the object's class and the request Content-Type.
+     *
+     * @param obj         The Java object
+     * @param contentType The request Content-Type
+     * @return The serialized request body
+     * @throws ru.skbkontur.sdk.extern.service.transport.swagger.invoker.ApiException a swagger Exception
+     */
+    @Override
+    public RequestBody serialize(Object obj, String contentType) throws ru.skbkontur.sdk.extern.service.transport.swagger.invoker.ApiException {
+        if (obj instanceof byte[]) {
+            // Binary (byte array) body parameter support.
+            return RequestBody.create(MediaType.parse(contentType), (byte[]) obj);
+        } else if (obj instanceof String) {
+            // File body parameter support.
+            return RequestBody.create(MediaType.parse(contentType), (String) obj);
+        } else if (obj instanceof File) {
+            // File body parameter support.
+            return RequestBody.create(MediaType.parse(contentType), (File) obj);
+        } else if (isJsonMime(contentType)) {
+            String content;
+            if (obj != null) {
+                content = getJSON().serialize(obj);
+            } else {
+                content = null;
+            }
+            return RequestBody.create(MediaType.parse(contentType), content);
+        } else {
+            throw new ru.skbkontur.sdk.extern.service.transport.swagger.invoker.ApiException("Content type \"" + contentType + "\" is not supported");
+        }
+    }
+
+    public <T> ApiResponse<T> submitHttpRequest(String httpRequestUri, String httpMetod, Map<String, String> queryParams, Object body, Map<String, String> headerParams, Map<String, Object> formParams, Class<T> dtoClass) throws ApiException {
+        try {
+            String[] localVarAuthNames = new String[]{"apiKey", "auth.sid"};
+
+            List<Pair> params
+                    = queryParams
+                    .entrySet()
+                    .stream()
+                    .map(e -> new Pair(e.getKey(), e.getValue()))
+                    .collect(Collectors.toList());
+
+            Call call = buildCall(httpRequestUri, httpMetod, params, body, headerParams, formParams, localVarAuthNames, null);
+
+            ru.skbkontur.sdk.extern.service.transport.swagger.invoker.ApiResponse<T> resp = this.execute(call, dtoClass);
+
+            return new ApiResponse<>(resp.getStatusCode(), resp.getHeaders(), resp.getData());
+        } catch (ru.skbkontur.sdk.extern.service.transport.swagger.invoker.ApiException x) {
+            throw new ApiException(x.getMessage(), x.getCause(), x.getCode(), x.getResponseHeaders(), x.getResponseBody());
+        }
+    }
+
+    public void setReadTimeout(int milliseconds) {
+        getHttpClient().setReadTimeout(milliseconds, TimeUnit.MILLISECONDS);
+    }
 }

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/invoker/ApiException.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/invoker/ApiException.java
@@ -1,8 +1,27 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * MIT License
+ *
+ * Copyright (c) 2018 SKB Kontur
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  */
+
 package ru.skbkontur.sdk.extern.service.transport.invoker;
 
 import java.util.List;

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/invoker/ApiException.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/invoker/ApiException.java
@@ -8,81 +8,81 @@ package ru.skbkontur.sdk.extern.service.transport.invoker;
 import java.util.List;
 import java.util.Map;
 
+
 /**
- *
  * @author alexs
  */
 public class ApiException extends Exception {
 
-	private int code = 0;
-	private Map<String, List<String>> responseHeaders = null;
-	private String responseBody = null;
+    private int code = 0;
+    private Map<String, List<String>> responseHeaders = null;
+    private String responseBody = null;
 
-	public ApiException() {
-	}
+    public ApiException() {
+    }
 
-	public ApiException(Throwable throwable) {
-		super(throwable);
-	}
+    public ApiException(Throwable throwable) {
+        super(throwable);
+    }
 
-	public ApiException(String message) {
-		super(message);
-	}
+    public ApiException(String message) {
+        super(message);
+    }
 
-	public ApiException(String message, Throwable throwable, int code, Map<String, List<String>> responseHeaders, String responseBody) {
-		super(message, throwable);
-		this.code = code;
-		this.responseHeaders = responseHeaders;
-		this.responseBody = responseBody;
-	}
+    public ApiException(String message, Throwable throwable, int code, Map<String, List<String>> responseHeaders, String responseBody) {
+        super(message, throwable);
+        this.code = code;
+        this.responseHeaders = responseHeaders;
+        this.responseBody = responseBody;
+    }
 
-	public ApiException(String message, int code, Map<String, List<String>> responseHeaders, String responseBody) {
-		this(message, (Throwable) null, code, responseHeaders, responseBody);
-	}
+    public ApiException(String message, int code, Map<String, List<String>> responseHeaders, String responseBody) {
+        this(message, null, code, responseHeaders, responseBody);
+    }
 
-	public ApiException(String message, Throwable throwable, int code, Map<String, List<String>> responseHeaders) {
-		this(message, throwable, code, responseHeaders, null);
-	}
+    public ApiException(String message, Throwable throwable, int code, Map<String, List<String>> responseHeaders) {
+        this(message, throwable, code, responseHeaders, null);
+    }
 
-	public ApiException(int code, Map<String, List<String>> responseHeaders, String responseBody) {
-		this((String) null, (Throwable) null, code, responseHeaders, responseBody);
-	}
+    public ApiException(int code, Map<String, List<String>> responseHeaders, String responseBody) {
+        this(null, null, code, responseHeaders, responseBody);
+    }
 
-	public ApiException(int code, String message) {
-		super(message);
-		this.code = code;
-	}
+    public ApiException(int code, String message) {
+        super(message);
+        this.code = code;
+    }
 
-	public ApiException(int code, String message, Map<String, List<String>> responseHeaders, String responseBody) {
-		this(code, message);
-		this.responseHeaders = responseHeaders;
-		this.responseBody = responseBody;
-	}
+    public ApiException(int code, String message, Map<String, List<String>> responseHeaders, String responseBody) {
+        this(code, message);
+        this.responseHeaders = responseHeaders;
+        this.responseBody = responseBody;
+    }
 
-	/**
-	 * Get the HTTP status code.
-	 *
-	 * @return HTTP status code
-	 */
-	public int getCode() {
-		return code;
-	}
+    /**
+     * Get the HTTP status code.
+     *
+     * @return HTTP status code
+     */
+    public int getCode() {
+        return code;
+    }
 
-	/**
-	 * Get the HTTP response headers.
-	 *
-	 * @return A map of list of string
-	 */
-	public Map<String, List<String>> getResponseHeaders() {
-		return responseHeaders;
-	}
+    /**
+     * Get the HTTP response headers.
+     *
+     * @return A map of list of string
+     */
+    public Map<String, List<String>> getResponseHeaders() {
+        return responseHeaders;
+    }
 
-	/**
-	 * Get the HTTP response body.
-	 *
-	 * @return Response body in the form of string
-	 */
-	public String getResponseBody() {
-		return responseBody;
-	}
+    /**
+     * Get the HTTP response body.
+     *
+     * @return Response body in the form of string
+     */
+    public String getResponseBody() {
+        return responseBody;
+    }
 }

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/invoker/ApiResponse.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/invoker/ApiResponse.java
@@ -1,8 +1,27 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * MIT License
+ *
+ * Copyright (c) 2018 SKB Kontur
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  */
+
 package ru.skbkontur.sdk.extern.service.transport.invoker;
 
 import java.util.List;

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/invoker/ApiResponse.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/invoker/ApiResponse.java
@@ -8,44 +8,44 @@ package ru.skbkontur.sdk.extern.service.transport.invoker;
 import java.util.List;
 import java.util.Map;
 
+
 /**
- *
  * @author AlexS
  */
 public class ApiResponse<T> {
 
-	final private int statusCode;
-	final private Map<String, List<String>> headers;
-	final private T data;
+    final private int statusCode;
+    final private Map<String, List<String>> headers;
+    final private T data;
 
-	/**
-	 * @param statusCode The status code of HTTP response
-	 * @param headers The headers of HTTP response
-	 */
-	public ApiResponse(int statusCode, Map<String, List<String>> headers) {
-		this(statusCode, headers, null);
-	}
+    /**
+     * @param statusCode The status code of HTTP response
+     * @param headers    The headers of HTTP response
+     */
+    public ApiResponse(int statusCode, Map<String, List<String>> headers) {
+        this(statusCode, headers, null);
+    }
 
-	/**
-	 * @param statusCode The status code of HTTP response
-	 * @param headers The headers of HTTP response
-	 * @param data The object deserialized from response bod
-	 */
-	public ApiResponse(int statusCode, Map<String, List<String>> headers, T data) {
-		this.statusCode = statusCode;
-		this.headers = headers;
-		this.data = data;
-	}
+    /**
+     * @param statusCode The status code of HTTP response
+     * @param headers    The headers of HTTP response
+     * @param data       The object deserialized from response bod
+     */
+    public ApiResponse(int statusCode, Map<String, List<String>> headers, T data) {
+        this.statusCode = statusCode;
+        this.headers = headers;
+        this.data = data;
+    }
 
-	public int getStatusCode() {
-		return statusCode;
-	}
+    public int getStatusCode() {
+        return statusCode;
+    }
 
-	public Map<String, List<String>> getHeaders() {
-		return headers;
-	}
+    public Map<String, List<String>> getHeaders() {
+        return headers;
+    }
 
-	public T getData() {
-		return data;
-	}
+    public T getData() {
+        return data;
+    }
 }

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/invoker/DateAdapter.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/invoker/DateAdapter.java
@@ -1,8 +1,27 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * MIT License
+ *
+ * Copyright (c) 2018 SKB Kontur
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  */
+
 package ru.skbkontur.sdk.extern.service.transport.invoker;
 
 import com.google.gson.JsonDeserializationContext;

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/invoker/DateAdapter.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/invoker/DateAdapter.java
@@ -13,14 +13,16 @@ import com.google.gson.JsonParseException;
 import com.google.gson.JsonPrimitive;
 import com.google.gson.JsonSerializationContext;
 import com.google.gson.JsonSerializer;
+
 import java.lang.reflect.Type;
 import java.util.Date;
 
+
 /**
- *
  * @author AlexS
  */
 public class DateAdapter implements JsonSerializer<Date>, JsonDeserializer<Date> {
+
     private final ru.skbkontur.sdk.extern.service.transport.swagger.invoker.ApiClient apiClient;
 
     /**
@@ -36,9 +38,9 @@ public class DateAdapter implements JsonSerializer<Date>, JsonDeserializer<Date>
     /**
      * Serialize
      *
-     * @param src Date
+     * @param src       Date
      * @param typeOfSrc Type
-     * @param context Json Serialization Context
+     * @param context   Json Serialization Context
      * @return Json Element
      */
     @Override
@@ -53,8 +55,8 @@ public class DateAdapter implements JsonSerializer<Date>, JsonDeserializer<Date>
     /**
      * Deserialize
      *
-     * @param json Json element
-     * @param date Type
+     * @param json    Json element
+     * @param date    Type
      * @param context Json Serialization Context
      * @return Date
      * @throws JsonParseException if fail to parse

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/invoker/DateTimeTypeAdapter.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/invoker/DateTimeTypeAdapter.java
@@ -8,10 +8,12 @@ package ru.skbkontur.sdk.extern.service.transport.invoker;
 import com.google.gson.TypeAdapter;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
-import java.io.IOException;
 import org.joda.time.DateTime;
 import org.joda.time.format.DateTimeFormatter;
 import org.joda.time.format.ISODateTimeFormat;
+
+import java.io.IOException;
+
 
 /**
  * Gson TypeAdapter for Joda DateTime type

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/invoker/DateTimeTypeAdapter.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/invoker/DateTimeTypeAdapter.java
@@ -1,8 +1,27 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * MIT License
+ *
+ * Copyright (c) 2018 SKB Kontur
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  */
+
 package ru.skbkontur.sdk.extern.service.transport.invoker;
 
 import com.google.gson.TypeAdapter;

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/invoker/DocumentToSendAdapter.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/invoker/DocumentToSendAdapter.java
@@ -1,8 +1,27 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * MIT License
+ *
+ * Copyright (c) 2018 SKB Kontur
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  */
+
 package ru.skbkontur.sdk.extern.service.transport.invoker;
 
 import com.google.gson.TypeAdapter;

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/invoker/DocumentToSendAdapter.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/invoker/DocumentToSendAdapter.java
@@ -9,64 +9,64 @@ import com.google.gson.TypeAdapter;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonToken;
 import com.google.gson.stream.JsonWriter;
-import java.io.IOException;
-import java.util.UUID;
 import ru.skbkontur.sdk.extern.service.transport.swagger.model.DocumentToSend;
 
+import java.io.IOException;
+import java.util.UUID;
+
+
 /**
- *
  * @author AlexS
  */
 public class DocumentToSendAdapter extends TypeAdapter<DocumentToSend> {
 
-	private static final java.util.Base64.Encoder ENCODER = java.util.Base64.getEncoder();
-	private static final java.util.Base64.Decoder DECODER = java.util.Base64.getDecoder();
+    private static final java.util.Base64.Encoder ENCODER = java.util.Base64.getEncoder();
+    private static final java.util.Base64.Decoder DECODER = java.util.Base64.getDecoder();
 
-	private final SignatureToSendAdapter signatureToSendAdapter = new SignatureToSendAdapter();
-	
-	@Override
-	public void write(JsonWriter out, DocumentToSend d) throws IOException {
-		if (d == null) {
-			out.nullValue();
-		}
-		else {
-			out.beginObject();
-			out.name("id").value(d.getId().toString());
-			out.name("content").value(ENCODER.encodeToString(d.getContent()));
-			out.name("filename").value(d.getFilename());
-			out.name("signature").jsonValue(signatureToSendAdapter.toJson(d.getSignature()));
-			out.name("sender-ip").value(d.getSenderIp());
-			out.endObject();
-		}
-	}
+    private final SignatureToSendAdapter signatureToSendAdapter = new SignatureToSendAdapter();
 
-	@Override
-	public DocumentToSend read(JsonReader in) throws IOException {
-		if (in.peek() != JsonToken.BEGIN_OBJECT) {
-			return null;
-		}
+    @Override
+    public void write(JsonWriter out, DocumentToSend d) throws IOException {
+        if (d == null) {
+            out.nullValue();
+        } else {
+            out.beginObject();
+            out.name("id").value(d.getId().toString());
+            out.name("content").value(ENCODER.encodeToString(d.getContent()));
+            out.name("filename").value(d.getFilename());
+            out.name("signature").jsonValue(signatureToSendAdapter.toJson(d.getSignature()));
+            out.name("sender-ip").value(d.getSenderIp());
+            out.endObject();
+        }
+    }
 
-		DocumentToSend d = new DocumentToSend();
+    @Override
+    public DocumentToSend read(JsonReader in) throws IOException {
+        if (in.peek() != JsonToken.BEGIN_OBJECT) {
+            return null;
+        }
 
-		while (in.hasNext()) {
-			String name = in.nextName();
-			switch (name) {
-				case "id":
-					d.setId(UUID.fromString(in.nextString()));
-					break;
-				case "content":
-					d.setContent(DECODER.decode(in.nextString()));
-					break;
-				case "filename":
-					d.setFilename(in.nextString());
-					break;
-				case "signature":
-					d.setSignature(signatureToSendAdapter.read(in));
-					break;
-			}
-		}
+        DocumentToSend d = new DocumentToSend();
 
-		return d;
-	}
+        while (in.hasNext()) {
+            String name = in.nextName();
+            switch (name) {
+                case "id":
+                    d.setId(UUID.fromString(in.nextString()));
+                    break;
+                case "content":
+                    d.setContent(DECODER.decode(in.nextString()));
+                    break;
+                case "filename":
+                    d.setFilename(in.nextString());
+                    break;
+                case "signature":
+                    d.setSignature(signatureToSendAdapter.read(in));
+                    break;
+            }
+        }
+
+        return d;
+    }
 
 }

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/invoker/LocalDateTypeAdapter.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/invoker/LocalDateTypeAdapter.java
@@ -1,8 +1,27 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * MIT License
+ *
+ * Copyright (c) 2018 SKB Kontur
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  */
+
 package ru.skbkontur.sdk.extern.service.transport.invoker;
 
 import com.google.gson.TypeAdapter;

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/invoker/LocalDateTypeAdapter.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/invoker/LocalDateTypeAdapter.java
@@ -8,10 +8,12 @@ package ru.skbkontur.sdk.extern.service.transport.invoker;
 import com.google.gson.TypeAdapter;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
-import java.io.IOException;
 import org.joda.time.LocalDate;
 import org.joda.time.format.DateTimeFormatter;
 import org.joda.time.format.ISODateTimeFormat;
+
+import java.io.IOException;
+
 
 /**
  * Gson TypeAdapter for Joda LocalDate type

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/invoker/SignatureToSendAdapter.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/invoker/SignatureToSendAdapter.java
@@ -9,57 +9,57 @@ import com.google.gson.TypeAdapter;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonToken;
 import com.google.gson.stream.JsonWriter;
-import java.io.IOException;
-import java.util.UUID;
 import ru.skbkontur.sdk.extern.service.transport.swagger.model.SignatureToSend;
 
+import java.io.IOException;
+import java.util.UUID;
+
+
 /**
- *
  * @author AlexS
  */
 public class SignatureToSendAdapter extends TypeAdapter<SignatureToSend> {
 
-	private static final java.util.Base64.Encoder ENCODER = java.util.Base64.getEncoder();
-	private static final java.util.Base64.Decoder DECODER = java.util.Base64.getDecoder();
+    private static final java.util.Base64.Encoder ENCODER = java.util.Base64.getEncoder();
+    private static final java.util.Base64.Decoder DECODER = java.util.Base64.getDecoder();
 
-	@Override
-	public void write(JsonWriter out, SignatureToSend s) throws IOException {
-		if (s == null) {
-			out.nullValue();
-		}
-		else {
-			out.beginObject();
-			if (s.getId() != null) {
-				out.name("id").value(s.getId().toString());
-			}
-			if (s.getContentData() != null) {
-				out.name("content-data").value(ENCODER.encodeToString(s.getContentData()));
-			}
-			out.endObject();
-		}
-	}
+    @Override
+    public void write(JsonWriter out, SignatureToSend s) throws IOException {
+        if (s == null) {
+            out.nullValue();
+        } else {
+            out.beginObject();
+            if (s.getId() != null) {
+                out.name("id").value(s.getId().toString());
+            }
+            if (s.getContentData() != null) {
+                out.name("content-data").value(ENCODER.encodeToString(s.getContentData()));
+            }
+            out.endObject();
+        }
+    }
 
-	@Override
-	public SignatureToSend read(JsonReader in) throws IOException {
-		if (in.peek() != JsonToken.BEGIN_OBJECT) {
-			return null;
-		}
+    @Override
+    public SignatureToSend read(JsonReader in) throws IOException {
+        if (in.peek() != JsonToken.BEGIN_OBJECT) {
+            return null;
+        }
 
-		SignatureToSend s = new SignatureToSend();
+        SignatureToSend s = new SignatureToSend();
 
-		while (in.hasNext()) {
-			String name = in.nextName();
-			switch (name) {
-				case "id":
-					s.setId(UUID.fromString(in.nextString()));
-					break;
-				case "content-data":
-					s.setContentData(DECODER.decode(in.nextString()));
-					break;
-			}
-		}
+        while (in.hasNext()) {
+            String name = in.nextName();
+            switch (name) {
+                case "id":
+                    s.setId(UUID.fromString(in.nextString()));
+                    break;
+                case "content-data":
+                    s.setContentData(DECODER.decode(in.nextString()));
+                    break;
+            }
+        }
 
-		return s;
-	}
+        return s;
+    }
 
 }

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/invoker/SignatureToSendAdapter.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/invoker/SignatureToSendAdapter.java
@@ -1,8 +1,27 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * MIT License
+ *
+ * Copyright (c) 2018 SKB Kontur
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  */
+
 package ru.skbkontur.sdk.extern.service.transport.invoker;
 
 import com.google.gson.TypeAdapter;

--- a/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/invoker/UserAgentService.java
+++ b/extern-sdk/src/main/java/ru/skbkontur/sdk/extern/service/transport/invoker/UserAgentService.java
@@ -1,3 +1,27 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2018 SKB Kontur
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 package ru.skbkontur.sdk.extern.service.transport.invoker;
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>ru.skbkontur.sdk</groupId>
     <artifactId>extern</artifactId>
-    <version>1.1-SNAPSHOT</version>
+    <version>1.2-SNAPSHOT</version>
 
     <packaging>pom</packaging>
 
@@ -19,13 +19,60 @@
         <gson-version>2.8.1</gson-version>
         <jodatime-version>2.9.9</jodatime-version>
         <maven-plugin-version>1.0.0</maven-plugin-version>
-        <junit-version>4.12</junit-version>
+        <junit.version>5.1.0</junit.version>
         <cryptoservice.version>5.0.19</cryptoservice.version>
+        <maven-jar-plugin.version>2.2</maven-jar-plugin.version>
+        <findbugs-maven-plugin.version>3.0.1</findbugs-maven-plugin.version>
+        <maven-javadoc-plugin.version>2.10.4</maven-javadoc-plugin.version>
+        <annotations.version>15.0</annotations.version>
+        <hamcrest-core.version>1.3</hamcrest-core.version>
+        <maven-project-info-reports-plugin.version>2.9</maven-project-info-reports-plugin.version>
     </properties>
 
     <modules>
         <module>extern-sdk</module>
         <module>extern-sdk-examples</module>
     </modules>
+
+    <build>
+        <plugins>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-project-info-reports-plugin</artifactId>
+                <version>${maven-project-info-reports-plugin.version}</version>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>${maven-jar-plugin.version}</version>
+            </plugin>
+
+        </plugins>
+    </build>
+
+    <profiles>
+        <profile>
+            <id>javadoc</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <version>${maven-javadoc-plugin.version}</version>
+                        <executions>
+                            <execution>
+                                <id>attach-javadocs</id>
+                                <goals>
+                                    <goal>jar</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>ru.skbkontur.sdk</groupId>
@@ -8,23 +9,23 @@
 
     <packaging>pom</packaging>
 
-	<properties>
-		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<java.version>1.8</java.version>
-		<maven.compiler.source>${java.version}</maven.compiler.source>
-		<maven.compiler.target>${java.version}</maven.compiler.target>
-		<swagger-core-version>1.5.15</swagger-core-version>
-		<okhttp-version>2.7.5</okhttp-version>
-		<gson-version>2.8.1</gson-version>
-		<jodatime-version>2.9.9</jodatime-version>
-		<maven-plugin-version>1.0.0</maven-plugin-version>
-		<junit-version>4.12</junit-version>
-	        <cryptoservice.version>5.0.19</cryptoservice.version>
-	</properties>
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <java.version>1.8</java.version>
+        <maven.compiler.source>${java.version}</maven.compiler.source>
+        <maven.compiler.target>${java.version}</maven.compiler.target>
+        <swagger-core-version>1.5.15</swagger-core-version>
+        <okhttp-version>2.7.5</okhttp-version>
+        <gson-version>2.8.1</gson-version>
+        <jodatime-version>2.9.9</jodatime-version>
+        <maven-plugin-version>1.0.0</maven-plugin-version>
+        <junit-version>4.12</junit-version>
+        <cryptoservice.version>5.0.19</cryptoservice.version>
+    </properties>
 
     <modules>
-      <module>extern-sdk</module>
-      <module>extern-sdk-examples</module>
+        <module>extern-sdk</module>
+        <module>extern-sdk-examples</module>
     </modules>
 
 </project>


### PR DESCRIPTION
- intelijIdea cleanup && reformat tools were applied
- license headers included to all files
- pom file simplified
    - now you can just run `mvn clean install`
    - and if we need javadocs then enable profile `-Pjavadoc`
    - build time redused to couple seconds

Since many files have been changed it is easier to understand changes by inspecting [`pom.xml` changing commit](https://github.com/skbkontur/extern-java-sdk/pull/4/commits/dde06e27eb515bcddbdf9714e204ca91b3cafc20) first

ps: none of swagger generated classes were changed.