### PR TITLE
Ka 4333

### DIFF
--- a/extern-api-java-sdk-integrational-tests/src/test/java/ru/kontur/extern_api/sdk/DocflowServiceIT.java
+++ b/extern-api-java-sdk-integrational-tests/src/test/java/ru/kontur/extern_api/sdk/DocflowServiceIT.java
@@ -316,7 +316,7 @@ class DocflowServiceIT {
 
             Boolean needDecompress = d.getDescription().getCompressed()
                     && docflow.getType() != DocflowType.PFR_REPORT
-                    && !d.hasEncryptedContent();
+                    && !d.hasEncryptedContent(); //расшифрованный контент для зашифрованных документов всегда расжат
             if (needDecompress) {
                 decrypted = Zip.unzip(decrypted);
             }

--- a/extern-api-java-sdk-integrational-tests/src/test/java/ru/kontur/extern_api/sdk/DocflowServiceIT.java
+++ b/extern-api-java-sdk-integrational-tests/src/test/java/ru/kontur/extern_api/sdk/DocflowServiceIT.java
@@ -315,7 +315,8 @@ class DocflowServiceIT {
                     .getOrThrow();
 
             Boolean needDecompress = d.getDescription().getCompressed()
-                    && docflow.getType() != DocflowType.PFR_REPORT;
+                    && docflow.getType() != DocflowType.PFR_REPORT
+                    && !d.hasEncryptedContent();
             if (needDecompress) {
                 decrypted = Zip.unzip(decrypted);
             }


### PR DESCRIPTION
Тест использует GetDecryptedContent и опирается на флаг Compressed. Это справедливо только для незашифрованных документов.
Для зашифрованных, полученный через GetDecryptedContent контент, всегда будет разжат.